### PR TITLE
Normal gain member for CircleDS

### DIFF
--- a/source/lib/dynamical_systems/include/dynamical_systems/Circular.hpp
+++ b/source/lib/dynamical_systems/include/dynamical_systems/Circular.hpp
@@ -14,197 +14,220 @@
 #include "state_representation/Space/Cartesian/CartesianTwist.hpp"
 #include "state_representation/Geometry/Ellipsoid.hpp"
 
-namespace DynamicalSystems
-{
-	/**
-	 * @class Circular
-	 * @brief Represent a Circular dynamical system to move around an center
-	 */
-	class Circular: public DynamicalSystem<StateRepresentation::CartesianState>
-	{
-	private:
-		std::shared_ptr<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>> limit_cycle_; ///< limit_cycle of the dynamical system
-		std::shared_ptr<StateRepresentation::Parameter<double>> gain_; ///< gain associate to the system
-		std::shared_ptr<StateRepresentation::Parameter<double>> circular_velocity_; ///< velocity at wich to navigate the limit cycle
+namespace DynamicalSystems {
+/**
+ * @class Circular
+ * @brief Represent a Circular dynamical system to move around an center
+ */
+class Circular : public DynamicalSystem<StateRepresentation::CartesianState> {
+private:
+  std::shared_ptr<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>
+      limit_cycle_; ///< limit_cycle of the dynamical system
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      planar_gain_; ///< gain associate to the system in the plane of the circle
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      normal_gain_; ///< gain associate to the system normal to the plane of the circle
+  std::shared_ptr<StateRepresentation::Parameter<double>>
+      circular_velocity_; ///< velocity at wich to navigate the limit cycle
 
-	protected:
-		/**
-		 * @brief Compute the dynamics of the input state.
-		 * Internal function, to be redefined based on the 
-		 * type of dynamical system, called by the evaluate
-		 * function
-		 * @param state the input state
-		 * @return the output state
-		 */
-		const StateRepresentation::CartesianState compute_dynamics(const StateRepresentation::CartesianState& state) const;
+protected:
+  /**
+   * @brief Compute the dynamics of the input state.
+   * Internal function, to be redefined based on the
+   * type of dynamical system, called by the evaluate
+   * function
+   * @param state the input state
+   * @return the output state
+   */
+  const StateRepresentation::CartesianState compute_dynamics(const StateRepresentation::CartesianState& state) const;
 
-	public:
-		/**
-		 * @brief Default constructor with center and fixed radius
-		 * @param center the center of the limit cycle
-		 * @param radius radius of the limit cycle (default=1.)
-		 * @param gain gain of the dynamical system (default=1.)
-		 * @param circular_velocity circular velocity to move around the limit cycle
-		 */
-		explicit Circular(const StateRepresentation::CartesianState& center, double radius=1.0, double gain=1.0, double circular_velocity=M_PI/2);
+public:
+  /**
+   * @brief Default constructor with center and fixed radius
+   * @param center the center of the limit cycle
+   * @param radius radius of the limit cycle (default=1.)
+   * @param gain gain of the dynamical system (default=1.)
+   * @param circular_velocity circular velocity to move around the limit cycle
+   */
+  explicit Circular(const StateRepresentation::CartesianState& center,
+                    double radius = 1.0,
+                    double gain = 1.0,
+                    double circular_velocity = M_PI / 2);
 
-		/**
-		 * @brief Cnstructor with an elliptic limit cycle
-		 * @param limit_cycle the limit cycle as an ellipsoid
-		 * @param gain gain of the dynamical system (default=1.)
-		 * @param circular_velocity circular velocity to move around the limit cycle
-		 */
-		explicit Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gain=1.0, double circular_velocity=M_PI/2);
+  /**
+   * @brief Cnstructor with an elliptic limit cycle
+   * @param limit_cycle the limit cycle as an ellipsoid
+   * @param gain gain of the dynamical system (default=1.)
+   * @param circular_velocity circular velocity to move around the limit cycle
+   */
+  explicit Circular(const StateRepresentation::Ellipsoid& limit_cycle,
+                    double gain = 1.0,
+                    double circular_velocity = M_PI / 2);
 
-		/**
-		 * @brief Getter of the center
-		 * @return the center as a const reference
-		 */
-		const StateRepresentation::CartesianPose& get_center() const;
+  /**
+   * @brief Getter of the center
+   * @return the center as a const reference
+   */
+  const StateRepresentation::CartesianPose& get_center() const;
 
-		/**
-		 * @brief Setter of the center as a new value
-		 * @param center the new center
-		 */
-		void set_center(const StateRepresentation::CartesianPose& center);
+  /**
+   * @brief Setter of the center as a new value
+   * @param center the new center
+   */
+  void set_center(const StateRepresentation::CartesianPose& center);
 
-		/**
-		 * @brief Getter of the gain attribute
-		 * @return The gain value 
-		 */
-		double get_gain() const;
+  /**
+   * @brief Getter of the planar gain attribute
+   * @return The gain value in the plane of the circle
+   */
+  double get_planar_gain() const;
 
-		/**
-		 * @brief Getter of the gain attribute
-		 * @return The gain value 
-		 */
-		void set_gain(double gain);
+  /**
+   * @brief Getter of the normal gain attribute
+   * @return The gain value normal to the plane of the circle
+   */
+  double get_normal_gain() const;
 
-		/**
-		 * @brief Getter of the radiuses of the limit cycle
-		 * @return the radius value
-		 */
+  /**
+   * @brief Setter of the gain attribute
+   */
+  void set_gain(double gain);
 
-		double get_rotation_angle() const;
+  /**
+   * @brief Setter of the planar gain attribute
+   */
+  void set_planar_gain(double gain);
 
-		/**
-		 * @brief Getter of the rotation angle attribute
-		 * @return The rotation agnle value 
-		 */
-		void set_rotation_angle(double angle);
+  /**
+   * @brief Setter of the normal gain attribute
+   */
+  void set_normal_gain(double gain);
 
-		/**
-		 * @brief Setterthe rotation angle attribute
-		 * @param The rotation agnle value 
-		 */
+  /**
+   * @brief Getter of the radiuses of the limit cycle
+   * @return the radius value
+   */
 
-		const std::vector<double>& get_radiuses() const;
+  double get_rotation_angle() const;
 
-		/**
-		 * @brief Setter of the radiuses of the limit cycle
-		 * @param radiuses the new radiuses values
-		 */
-		void set_radiuses(const std::vector<double>& radiuses);
+  /**
+   * @brief Setter of the rotation angle attribute
+   * @return The rotation angle value
+   */
+  void set_rotation_angle(double angle);
 
-		/**
-		 * @brief Setter of the radius of the limit cycle as a single value, i.e. perfect cycle
-		 * @param radiuses the new radiuses values
-		 */
-		void set_radius(double radius);
+  /**
+   * @brief Getter of the rotation angle attribute
+   * @param The rotation angle value
+   */
 
-		/**
-		 * @brief Getter of the circular velocity attribute
-		 * @return the cirular velocity value
-		 */
-		double get_circular_velocity() const;
+  const std::vector<double>& get_radiuses() const;
 
-		/**
-		 * @brief Setter of the circular_velocity attribute
-		 * @param circular_velocity the new circular_velocity value
-		 */
-		void set_circular_velocity(double circular_velocity);
+  /**
+   * @brief Setter of the radiuses of the limit cycle
+   * @param radiuses the new radiuses values
+   */
+  void set_radiuses(const std::vector<double>& radiuses);
 
-		/**
-		 * @brief Getter of the limit cycle attribute
-		 * @return the limit cycle
-		 */
-		const StateRepresentation::Ellipsoid& get_limit_cycle() const;
+  /**
+   * @brief Setter of the radius of the limit cycle as a single value, i.e. perfect cycle
+   * @param radiuses the new radiuses values
+   */
+  void set_radius(double radius);
 
-		/**
-		 * @brief Setter of the limit cycle attribute
-		 * @param the limit cycle value
-		 */
-		void set_limit_cycle(const StateRepresentation::Ellipsoid& limit_cycle);
+  /**
+   * @brief Getter of the circular velocity attribute
+   * @return the cirular velocity value
+   */
+  double get_circular_velocity() const;
 
-		/**
-		 * @brief Return a list of all the parameters of the dynamical system
-		 * @return the list of parameters
-		 */
-		const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const override;
-	};
+  /**
+   * @brief Setter of the circular_velocity attribute
+   * @param circular_velocity the new circular_velocity value
+   */
+  void set_circular_velocity(double circular_velocity);
 
-	inline const StateRepresentation::CartesianPose& Circular::get_center() const
-	{
-		return this->limit_cycle_->get_value().get_center_pose();
-	}
+  /**
+   * @brief Getter of the limit cycle attribute
+   * @return the limit cycle
+   */
+  const StateRepresentation::Ellipsoid& get_limit_cycle() const;
 
-	inline void Circular::set_center(const StateRepresentation::CartesianPose& center)
-	{
-		this->limit_cycle_->get_value().set_center_pose(center);
-	}
+  /**
+   * @brief Setter of the limit cycle attribute
+   * @param the limit cycle value
+   */
+  void set_limit_cycle(const StateRepresentation::Ellipsoid& limit_cycle);
 
-	inline double Circular::get_gain() const
-	{
-		return this->gain_->get_value();
-	}
+  /**
+   * @brief Return a list of all the parameters of the dynamical system
+   * @return the list of parameters
+   */
+  const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> get_parameters() const override;
+};
 
-	inline void Circular::set_gain(double gain)
-	{
-		this->gain_->set_value(gain);
-	}
+inline const StateRepresentation::CartesianPose& Circular::get_center() const {
+  return this->limit_cycle_->get_value().get_center_pose();
+}
 
-	inline double Circular::get_rotation_angle() const
-	{
-		return this->limit_cycle_->get_value().get_rotation_angle();
-	}
+inline void Circular::set_center(const StateRepresentation::CartesianPose& center) {
+  this->limit_cycle_->get_value().set_center_pose(center);
+}
 
-	inline void Circular::set_rotation_angle(double angle)
-	{
-		 this->limit_cycle_->get_value().set_rotation_angle(angle);
-	}
+inline double Circular::get_planar_gain() const {
+  return this->planar_gain_->get_value();
+}
 
-	inline const std::vector<double>& Circular::get_radiuses() const
-	{
-		return this->limit_cycle_->get_value().get_axis_lengths();
-	}
+inline double Circular::get_normal_gain() const {
+  return this->normal_gain_->get_value();
+}
 
-	inline void Circular::set_radiuses(const std::vector<double>& radiuses)
-	{
-		this->limit_cycle_->get_value().set_axis_lengths(radiuses);
-	}
+inline void Circular::set_gain(double gain) {
+  this->planar_gain_->set_value(gain);
+  this->normal_gain_->set_value(gain);
+}
 
-	inline void Circular::set_radius(double radius)
-	{
-		this->limit_cycle_->get_value().set_axis_lengths({radius, radius});
-	}
+inline void Circular::set_planar_gain(double gain) {
+  this->planar_gain_->set_value(gain);
+}
 
-	inline double Circular::get_circular_velocity() const
-	{
-		return this->circular_velocity_->get_value();
-	}
+inline void Circular::set_normal_gain(double gain) {
+  this->normal_gain_->set_value(gain);
+}
 
-	inline void Circular::set_circular_velocity(double circular_velocity)
-	{
-		this->circular_velocity_->set_value(circular_velocity);
-	}
+inline double Circular::get_rotation_angle() const {
+  return this->limit_cycle_->get_value().get_rotation_angle();
+}
 
-	inline const StateRepresentation::Ellipsoid& Circular::get_limit_cycle() const
-	{
-		return this->limit_cycle_->get_value();
-	}
+inline void Circular::set_rotation_angle(double angle) {
+  this->limit_cycle_->get_value().set_rotation_angle(angle);
+}
 
-	inline void Circular::set_limit_cycle(const StateRepresentation::Ellipsoid& limit_cycle)
-	{
-		this->limit_cycle_->set_value(limit_cycle);
-	}
+inline const std::vector<double>& Circular::get_radiuses() const {
+  return this->limit_cycle_->get_value().get_axis_lengths();
+}
+
+inline void Circular::set_radiuses(const std::vector<double>& radiuses) {
+  this->limit_cycle_->get_value().set_axis_lengths(radiuses);
+}
+
+inline void Circular::set_radius(double radius) {
+  this->limit_cycle_->get_value().set_axis_lengths({radius, radius});
+}
+
+inline double Circular::get_circular_velocity() const {
+  return this->circular_velocity_->get_value();
+}
+
+inline void Circular::set_circular_velocity(double circular_velocity) {
+  this->circular_velocity_->set_value(circular_velocity);
+}
+
+inline const StateRepresentation::Ellipsoid& Circular::get_limit_cycle() const {
+  return this->limit_cycle_->get_value();
+}
+
+inline void Circular::set_limit_cycle(const StateRepresentation::Ellipsoid& limit_cycle) {
+  this->limit_cycle_->set_value(limit_cycle);
+}
 }

--- a/source/lib/dynamical_systems/src/Circular.cpp
+++ b/source/lib/dynamical_systems/src/Circular.cpp
@@ -1,59 +1,65 @@
 #include "dynamical_systems/Circular.hpp"
 
-namespace DynamicalSystems
-{
-	Circular::Circular(const StateRepresentation::CartesianState& center, double radius, double gain, double circular_velocity):
-	DynamicalSystem(StateRepresentation::CartesianPose::Identity(center.get_reference_frame())),
-	limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>("limit_cycle", StateRepresentation::Ellipsoid(center.get_name(), center.get_reference_frame()))),
-	gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
-	circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity", circular_velocity))
-	{
-		this->limit_cycle_->get_value().set_center_state(center);
-		this->limit_cycle_->get_value().set_axis_lengths({radius, radius});
-	}
+namespace DynamicalSystems {
+Circular::Circular(const StateRepresentation::CartesianState& center,
+                   double radius,
+                   double gain,
+                   double circular_velocity) :
+    DynamicalSystem(StateRepresentation::CartesianPose::Identity(center.get_reference_frame())),
+    limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>("limit_cycle",
+                                                                                                  StateRepresentation::Ellipsoid(
+                                                                                                      center.get_name(),
+                                                                                                      center.get_reference_frame()))),
+    planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
+    circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
+                                                                                circular_velocity)) {
+  this->limit_cycle_->get_value().set_center_state(center);
+  this->limit_cycle_->get_value().set_axis_lengths({radius, radius});
+}
 
-	Circular::Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gain, double circular_velocity):
-	DynamicalSystem(StateRepresentation::CartesianPose::Identity(limit_cycle.get_center_pose().get_reference_frame())),
-	limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>(" limit_cycle", limit_cycle)),
-	gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
-	circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity", circular_velocity))
-	{}
+Circular::Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gain, double circular_velocity) :
+    DynamicalSystem(StateRepresentation::CartesianPose::Identity(limit_cycle.get_center_pose().get_reference_frame())),
+    limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>(" limit_cycle",
+                                                                                                  limit_cycle)),
+    planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
+    circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
+                                                                                circular_velocity)) {}
 
-	const StateRepresentation::CartesianState Circular::compute_dynamics(const StateRepresentation::CartesianState& state) const
-	{
-		// put the point in the reference of the center
-		StateRepresentation::CartesianPose pose = static_cast<const StateRepresentation::CartesianPose&>(state);
-		pose = this->get_limit_cycle().get_rotation().inverse() * this->get_center().inverse() * pose;
+const StateRepresentation::CartesianState Circular::compute_dynamics(const StateRepresentation::CartesianState& state) const {
+  // put the point in the reference of the center
+  StateRepresentation::CartesianPose pose = static_cast<const StateRepresentation::CartesianPose&>(state);
+  pose = this->get_limit_cycle().get_rotation().inverse() * this->get_center().inverse() * pose;
 
-		StateRepresentation::CartesianTwist velocity(pose.get_name(), pose.get_reference_frame());
-		Eigen::Vector3d linear_velocity;
-		linear_velocity(2) = -this->get_gain() * pose.get_position()(2);
+  StateRepresentation::CartesianTwist velocity(pose.get_name(), pose.get_reference_frame());
+  Eigen::Vector3d linear_velocity;
+  linear_velocity(2) = -this->get_normal_gain() * pose.get_position()(2);
 
-		std::vector<double> radiuses = this->get_radiuses();
+  std::vector<double> radiuses = this->get_radiuses();
 
-		double a2 = radiuses[0]*radiuses[0];
-		double b2 = radiuses[1]*radiuses[1];
-		double dradius = -this->get_gain() * radiuses[0] * radiuses[1] * (pose.get_position()[0]*pose.get_position()[0] / a2 + pose.get_position()[1]*pose.get_position()[1] / b2 - 1);
-		double tangeant_velocity_x = - radiuses[0] / radiuses[1] * pose.get_position()[1];
-		double tangeant_velocity_y = radiuses[1] / radiuses[0] * pose.get_position()[0];
+  double a2 = radiuses[0] * radiuses[0];
+  double b2 = radiuses[1] * radiuses[1];
+  double dradius = -this->get_planar_gain() * radiuses[0] * radiuses[1]
+      * (pose.get_position()[0] * pose.get_position()[0] / a2 + pose.get_position()[1] * pose.get_position()[1] / b2
+          - 1);
+  double tangeant_velocity_x = -radiuses[0] / radiuses[1] * pose.get_position()[1];
+  double tangeant_velocity_y = radiuses[1] / radiuses[0] * pose.get_position()[0];
 
-		linear_velocity(0) = this->get_circular_velocity() * tangeant_velocity_x + dradius * tangeant_velocity_y;
-		linear_velocity(1) = this->get_circular_velocity() * tangeant_velocity_y - dradius * tangeant_velocity_x;
+  linear_velocity(0) = this->get_circular_velocity() * tangeant_velocity_x + dradius * tangeant_velocity_y;
+  linear_velocity(1) = this->get_circular_velocity() * tangeant_velocity_y - dradius * tangeant_velocity_x;
 
-		velocity.set_linear_velocity(linear_velocity);
-		velocity.set_angular_velocity(Eigen::Vector3d::Zero());
+  velocity.set_linear_velocity(linear_velocity);
+  velocity.set_angular_velocity(Eigen::Vector3d::Zero());
 
-		//compute back the linear velocity in the desired frame
-		velocity = this->get_center() * this->get_limit_cycle().get_rotation() * velocity;
-		return velocity;
-	}
+  //compute back the linear velocity in the desired frame
+  velocity = this->get_center() * this->get_limit_cycle().get_rotation() * velocity;
+  return velocity;
+}
 
-	const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Circular::get_parameters() const
-	{
-		std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
-		param_list.push_back(this->limit_cycle_);
-		param_list.push_back(this->gain_);
-		param_list.push_back(this->circular_velocity_);
-		return param_list;
-	}
+const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Circular::get_parameters() const {
+  std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
+  param_list.push_back(this->limit_cycle_);
+  param_list.push_back(this->planar_gain_);
+  param_list.push_back(this->circular_velocity_);
+  return param_list;
+}
 }

--- a/source/lib/dynamical_systems/src/Circular.cpp
+++ b/source/lib/dynamical_systems/src/Circular.cpp
@@ -11,6 +11,7 @@ Circular::Circular(const StateRepresentation::CartesianState& center,
                                                                                                       center.get_name(),
                                                                                                       center.get_reference_frame()))),
     planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
+    normal_gain_(std::make_shared<StateRepresentation::Parameter<double>>("normal_gain", gain)),
     circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
                                                                                 circular_velocity)) {
   this->limit_cycle_->get_value().set_center_state(center);
@@ -22,6 +23,7 @@ Circular::Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gai
     limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>(" limit_cycle",
                                                                                                   limit_cycle)),
     planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
+    normal_gain_(std::make_shared<StateRepresentation::Parameter<double>>("normal_gain", gain)),
     circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
                                                                                 circular_velocity)) {}
 
@@ -59,6 +61,7 @@ const std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> Circul
   std::list<std::shared_ptr<StateRepresentation::ParameterInterface>> param_list;
   param_list.push_back(this->limit_cycle_);
   param_list.push_back(this->planar_gain_);
+  param_list.push_back(this->normal_gain_);
   param_list.push_back(this->circular_velocity_);
   return param_list;
 }

--- a/source/lib/dynamical_systems/src/Circular.cpp
+++ b/source/lib/dynamical_systems/src/Circular.cpp
@@ -7,10 +7,8 @@ Circular::Circular(const StateRepresentation::CartesianState& center,
                    double circular_velocity) :
     DynamicalSystem(StateRepresentation::CartesianPose::Identity(center.get_reference_frame())),
     limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>("limit_cycle",
-                                                                                                  StateRepresentation::Ellipsoid(
-                                                                                                      center.get_name(),
-                                                                                                      center.get_reference_frame()))),
-    planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
+        StateRepresentation::Ellipsoid(center.get_name(), center.get_reference_frame()))),
+    planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("planar_gain", gain)),
     normal_gain_(std::make_shared<StateRepresentation::Parameter<double>>("normal_gain", gain)),
     circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
                                                                                 circular_velocity)) {
@@ -20,9 +18,9 @@ Circular::Circular(const StateRepresentation::CartesianState& center,
 
 Circular::Circular(const StateRepresentation::Ellipsoid& limit_cycle, double gain, double circular_velocity) :
     DynamicalSystem(StateRepresentation::CartesianPose::Identity(limit_cycle.get_center_pose().get_reference_frame())),
-    limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>(" limit_cycle",
+    limit_cycle_(std::make_shared<StateRepresentation::Parameter<StateRepresentation::Ellipsoid>>("limit_cycle",
                                                                                                   limit_cycle)),
-    planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("gain", gain)),
+    planar_gain_(std::make_shared<StateRepresentation::Parameter<double>>("planar_gain", gain)),
     normal_gain_(std::make_shared<StateRepresentation::Parameter<double>>("normal_gain", gain)),
     circular_velocity_(std::make_shared<StateRepresentation::Parameter<double>>("circular_velocity",
                                                                                 circular_velocity)) {}
@@ -38,11 +36,9 @@ const StateRepresentation::CartesianState Circular::compute_dynamics(const State
 
   std::vector<double> radiuses = this->get_radiuses();
 
-  double a2 = radiuses[0] * radiuses[0];
-  double b2 = radiuses[1] * radiuses[1];
-  double dradius = -this->get_planar_gain() * radiuses[0] * radiuses[1]
-      * (pose.get_position()[0] * pose.get_position()[0] / a2 + pose.get_position()[1] * pose.get_position()[1] / b2
-          - 1);
+  double a2ratio = (pose.get_position()[0] * pose.get_position()[0]) / (radiuses[0] * radiuses[0]);
+  double b2ratio = (pose.get_position()[1] * pose.get_position()[1]) / (radiuses[1] * radiuses[1]);
+  double dradius = -this->get_planar_gain() * radiuses[0] * radiuses[1] * (a2ratio + b2ratio - 1);
   double tangeant_velocity_x = -radiuses[0] / radiuses[1] * pose.get_position()[1];
   double tangeant_velocity_y = radiuses[1] / radiuses[0] * pose.get_position()[0];
 


### PR DESCRIPTION
* Add member normal_gain_ to Circular DS class

* Rename member gain_ to planar_gain_

* Distinguish between planar and normal gain in the main
evaluation: normal gain applies to the difference in local
Z axis, while planar gain is in the local XY.

* Update setters and getters (set_gain function sets both
gain members to the same value, so default  behaviour is unaffected)

* Reformat and fix some typos in docstrings


-- I would like this feature because I might want to treat normal gain differently than planar gain, for example to have a kind of "cylinder" response. In particular I want to control vertical gain externally (for adapting contact force), while tracking the planar gain much more closely.

Tip: hide whitespace changes when reviewing the changes 