### PR TITLE
Correct installation of control_libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ ARG ROS_VERSION=foxy
 FROM ros2_ws:${ROS_VERSION}
 
 # import control library packages
-RUN git clone -b v1.0.0 --depth 1 https://github.com/epfl-lasa/control_libraries.git
+RUN git clone -b develop --depth 1 https://github.com/epfl-lasa/control_libraries.git
 WORKDIR ${HOME}/control_libraries/source
-RUN sudo ./install.sh
+RUN sudo ./install.sh -y
 
 # build ROS workspace
 WORKDIR ${HOME}/ros2_ws/


### PR DESCRIPTION
Due to the recent changes of `control_libraries`, the install script now requires the `-y` option. I am also changing for the develop branch as we are here tracking develop I guess. When doing release in here we should then track a released branch of `control_libraries`