### PR TITLE
Fix Jacobian setters in ReadStateConversion

### DIFF
--- a/source/packages/modulo_core/src/Communication/MessagePassing/ReadStateConversion.cpp
+++ b/source/packages/modulo_core/src/Communication/MessagePassing/ReadStateConversion.cpp
@@ -92,8 +92,6 @@ void read_msg(state_representation::JointState& state, const sensor_msgs::msg::J
 }
 
 void read_msg(state_representation::Jacobian& state, const modulo_msgs::msg::Jacobian& msg) {
-  state.set_rows(msg.nb_dimensions);
-  state.set_cols(msg.nb_joints);
   state.set_joint_names(msg.joint_names);
   state.set_data(Eigen::MatrixXd::Map(msg.data.data(), msg.nb_dimensions, msg.nb_joints));
 }


### PR DESCRIPTION
* Recent removal of the Jacobian::set_rows and ::set_cols
methods from the control_libraries development stream means
that these lines have been removed. Now, if the passed
Jacobian does not have the right size, it will
throw an IncompatibleSizeException.

If it's undesirable to throw an exception within the read message, the alternative is to construct and swap a new Jacobian object with the corresponding robot name from the original state and everything else from the message state. I don't know what you prefer here - lightweight code that can raise exceptions, or slightly heavier code that is exception safe. I feel like the former is preferable in the message layer.