### PR TITLE
Fix periodic call exiting before configure

### DIFF
--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -327,7 +327,6 @@ const state_representation::CartesianPose Cell::lookup_transform(const std::stri
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cell::on_configure(const rclcpp_lifecycle::State&) {
   RCUTILS_LOG_INFO_NAMED(get_name(), "on_configure() is called.");
-  this->active_ = false;
   this->configured_ = true;
   // call the proxy on_configure function
   if (!this->on_configure()) {

--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -327,15 +327,14 @@ const state_representation::CartesianPose Cell::lookup_transform(const std::stri
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cell::on_configure(const rclcpp_lifecycle::State&) {
   RCUTILS_LOG_INFO_NAMED(get_name(), "on_configure() is called.");
+  this->active_ = false;
+  this->configured_ = true;
   // call the proxy on_configure function
   if (!this->on_configure()) {
     RCLCPP_ERROR(get_logger(), "Configuration failed");
     this->reset();
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
   }
-  // start the parameters
-  this->active_ = false;
-  this->configured_ = true;
   // add the run thread
   std::function<void(void)> run_fnc = std::bind(&Cell::run, this);
   this->run_thread_ = std::thread(run_fnc);


### PR DESCRIPTION
The `periodic_call` functions are defined in the same way than the normal `step` function with a `run` function that loop while the node is `configured`. This effectively means that the `add_periodic_call` function needs be put in the `on_configure` function of the node. Problem was that the`on_configure` function of the derived nodes is called prior the setting of the `configured_` boolean. This means that the `run_periodic_call` function was exiting as soon as it was added. Simple solution is to set the `configured_` boolean prior the `on_configure` call. In case the node fails to configure anyway, the reset function is called which terminates all threads and reset all handlers of threads and publishers. So I think it is actually rather safe to do like this.