### PR TITLE
Add NodeOptions constructor to Cell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 **/*#*
 **/__pycache__/**
 **/.cache/**
+
+.idea
+cmake-build-*
+
 /source/lib/state_representation/build/*

--- a/source/packages/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Cell.hpp
@@ -26,14 +26,14 @@ using namespace std::chrono_literals;
 namespace modulo::core {
 /**
  * @class Cell
- * @brief Abstract class to define a Call
+ * @brief Abstract class to define a Cell
  * A Cell is the base class of the whole architecture.
  * It handles all the basic ROS communications such as
- * definitions of subrscriptions, publishers and service
+ * definitions of subscriptions, publishers and service
  * calls. It can then be derived into a MotionGenerator,
  * a Controller, a Sensor, or a RobotInterface. It is
- * derived from a lifecyle node which allows to use
- * ROS2 state machine functionnalities for nodes.
+ * derived from a lifecycle node which allows to use
+ * ROS2 state machine functionalities for nodes.
  */
 class Cell : public rclcpp_lifecycle::LifecycleNode {
 private:

--- a/source/packages/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Cell.hpp
@@ -107,6 +107,13 @@ public:
   explicit Cell(const std::string& node_name, const std::chrono::duration<int64_t, DurationT>& period, bool intra_process_comms = false);
 
   /**
+   * @brief Cell construction from ROS2 NodeOptions
+   * @param options NodeOptions containing a node name in the remapping arguments list and a "period" parameter
+   * with a value in seconds in the parameter override list
+   */
+  explicit Cell(const rclcpp::NodeOptions& options);
+
+  /**
    * @brief Destructor
    */
   ~Cell();

--- a/source/packages/modulo_core/include/modulo_core/Utilities/utilities.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Utilities/utilities.hpp
@@ -8,11 +8,11 @@
 namespace modulo::core::utilities {
 
 /**
- * @brief Parse a string argument value from an argument list given a pattern prefix
- * @param args A vector of string arguments
- * @param pattern The prefix pattern to find and strip
- * @param result The default argument value that is overwritten by reference if the given pattern is found
- * @return
+ * @brief Parse a string argument value from an argument list given a pattern prefix.
+ * @param args a vector of string arguments
+ * @param pattern the prefix pattern to find and strip
+ * @param result the default argument value that is overwritten by reference if the given pattern is found
+ * @return the value of the resultant string
  */
 static std::string parse_string_argument(const std::vector<std::string>& args, const std::string& pattern, std::string& result) {
   for (const auto& arg : args) {
@@ -27,10 +27,10 @@ static std::string parse_string_argument(const std::vector<std::string>& args, c
 }
 
 /**
- * Parse a string node name from NodeOptions arguments
- * @param options
- * @param fallback
- * @return
+ * @brief Parse a string node name from NodeOptions arguments.
+ * @param options the NodeOptions structure to parse
+ * @param fallback the default name if the NodeOptions structure cannot be parsed
+ * @return the parsed node name or the fallback name
  */
 std::string parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback="") {
   std::string node_name(fallback);
@@ -39,10 +39,10 @@ std::string parse_node_name(const rclcpp::NodeOptions& options, const std::strin
 }
 
 /**
- * Parse a string node namespace from NodeOptions arguments
- * @param options
- * @param fallback
- * @return
+ * @brief Parse a string node namespace from NodeOptions arguments.
+ * @param options the NodeOptions structure to parse
+ * @param fallback the default namespace if the NodeOptions structure cannot be parsed
+ * @return the parsed node namespace or the fallback namespace
  */
 std::string parse_node_namespace(const rclcpp::NodeOptions& options, const std::string& fallback="") {
   std::string node_namespace(fallback);
@@ -51,11 +51,12 @@ std::string parse_node_namespace(const rclcpp::NodeOptions& options, const std::
 }
 
 /**
- * Parse a period in seconds from NodeOptions parameters. The parameter must have the name "period"
+ * @brief Parse a period in seconds from NodeOptions parameters.
+ * @details The parameter must have the name "period"
  * and be interpretable as a value in seconds of type double
- * @param options
- * @param default_period
- * @return
+ * @param options the NodeOptions structure to parse
+ * @param default_period the default period in seconds
+ * @return the parsed period or the default period as a chrono duration
  */
 std::chrono::nanoseconds parse_period(const rclcpp::NodeOptions& options, double default_period = 0.001) {
   double period = default_period;

--- a/source/packages/modulo_core/include/modulo_core/Utilities/utilities.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Utilities/utilities.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+
+namespace modulo::core::utilities {
+
+/**
+ * @brief Parse a string argument value from an argument list given a pattern prefix
+ * @param args A vector of string arguments
+ * @param pattern The prefix pattern to find and strip
+ * @param result The default argument value that is overwritten by reference if the given pattern is found
+ * @return
+ */
+static std::string parse_string_argument(const std::vector<std::string>& args, const std::string& pattern, std::string& result) {
+  for (const auto& arg : args) {
+    std::string::size_type index = arg.find(pattern);
+    if (index != std::string::npos) {
+      result = arg;
+      result.erase(index, pattern.length());
+      break;
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse a string node name from NodeOptions arguments
+ * @param options
+ * @param fallback
+ * @return
+ */
+std::string parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback="") {
+  std::string node_name(fallback);
+  const std::string pattern("__node:=");
+  return parse_string_argument(options.arguments(), pattern, node_name);
+}
+
+/**
+ * Parse a string node namespace from NodeOptions arguments
+ * @param options
+ * @param fallback
+ * @return
+ */
+std::string parse_node_namespace(const rclcpp::NodeOptions& options, const std::string& fallback="") {
+  std::string node_namespace(fallback);
+  const std::string pattern("__ns:=");
+  return parse_string_argument(options.arguments(), pattern, node_namespace);
+}
+
+/**
+ * Parse a period in seconds from NodeOptions parameters. The parameter must have the name "period"
+ * and be interpretable as a value in seconds of type double
+ * @param options
+ * @param default_period
+ * @return
+ */
+std::chrono::nanoseconds parse_period(const rclcpp::NodeOptions& options, double default_period = 0.001) {
+  double period = default_period;
+  for (auto& param : options.parameter_overrides()) {
+    if (param.get_name() == "period") {
+      period = param.as_double();
+      break;
+    }
+  }
+  return std::chrono::nanoseconds(static_cast<int64_t>(period * 1e9));
+}
+
+}

--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -1,9 +1,15 @@
 #include "modulo_core/Cell.hpp"
+#include "modulo_core/Utilities/utilities.hpp"
 #include "modulo_core/Exceptions/UnconfiguredNodeException.hpp"
-#include <state_representation/exceptions/IncompatibleSizeException.hpp>
 #include <state_representation/exceptions/UnrecognizedParameterTypeException.hpp>
 
+
 namespace modulo::core {
+
+Cell::Cell(const rclcpp::NodeOptions& options) : Cell(utilities::parse_node_name(options, "Cell"),
+                                                      utilities::parse_period(options),
+                                                      options.use_intra_process_comms()) {}
+
 Cell::~Cell() {
   this->parameters_.clear();
   this->on_shutdown();

--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -6,9 +6,15 @@
 
 namespace modulo::core {
 
-Cell::Cell(const rclcpp::NodeOptions& options) : Cell(utilities::parse_node_name(options, "Cell"),
-                                                      utilities::parse_period(options),
-                                                      options.use_intra_process_comms()) {}
+Cell::Cell(const rclcpp::NodeOptions& options) :
+    rclcpp_lifecycle::LifecycleNode(utilities::parse_node_name(options, "Cell"), options),
+    configured_(false),
+    active_(false),
+    shutdown_(false),
+    period_(utilities::parse_period(options)) {
+  // add the update parameters call
+  this->update_parameters_timer_ = this->create_wall_timer(this->period_, [this] { this->update_parameters(); });
+}
 
 Cell::~Cell() {
   this->parameters_.clear();


### PR DESCRIPTION
* Add constructor declaration and
definition for Cell to take a
NodeOptions structure and parse
the name and period. This is
so that the Cell can be configured
as a component.

* Add utilities header to make parsing
NodeOptions more convenient. This utility
can be used by derived classes outside
of modulo core.