### PR TITLE
Use wall timer instead of threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG ROS_VERSION=foxy
 FROM aica-technology/ros2-ws:${ROS_VERSION}
 
 # install control library packages
+WORKDIR ${HOME}
 RUN git clone -b develop --depth 1 https://github.com/epfl-lasa/control_libraries.git
 WORKDIR ${HOME}/control_libraries/source
 RUN sudo ./install.sh -y

--- a/source/packages/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Cell.hpp
@@ -475,7 +475,7 @@ Cell::Cell(const std::string& node_name, const std::chrono::duration<int64_t, Du
                                                                                                                               mutex_(std::make_shared<std::mutex>()),
                                                                                                                               period_(period) {
   // add the update parameters call
-  auto update_parameters_fnc = std::bind(&Cell::update_parameters, this);
+  std::function<void(void)> update_parameters_fnc = std::bind(&Cell::update_parameters, this);
   this->update_parameters_timer_ = this->create_wall_timer(this->period_, update_parameters_fnc);
 }
 

--- a/source/packages/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Cell.hpp
@@ -20,7 +20,6 @@
 #include <state_representation/parameters/Parameter.hpp>
 #include <state_representation/parameters/ParameterInterface.hpp>
 #include <string>
-#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -41,11 +40,10 @@ private:
   bool configured_;                                                                                      ///< boolean that informs that the node has been configured, i.e passed by the on_configure state
   bool active_;                                                                                          ///< boolean that informs that the node has been activated, i.e passed by the on_activate state
   bool shutdown_;                                                                                        ///< boolean that informs that the node has been shutdown, i.e passed by the on_shutdown state
-  std::thread run_thread_;                                                                               ///< thread object to start the main loop, i.e. the run function, in parallel of the rest
-  std::thread parameter_update_thread_;                                                                  ///< thread object to start the parameter update loop
+  std::shared_ptr<rclcpp::TimerBase> update_parameters_timer_;                                           ///< reference to the timer for periodically that periodicall update the parameters
+  std::list<std::shared_ptr<rclcpp::TimerBase>> timers_;                                                 ///< reference to timers for periodically called functions
   std::shared_ptr<std::mutex> mutex_;                                                                    ///< a mutex to use when modifying messages between functions
   std::chrono::nanoseconds period_;                                                                      ///< rate of the publisher functions in nanoseconds
-  std::list<std::thread> active_threads_;                                                                ///< list of active threads for periodic calling
   std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>> parameters_;          ///< list for storing parameters
   std::map<std::string, std::pair<std::shared_ptr<communication::CommunicationHandler>, bool>> handlers_;///< map for storing publishers, subscriptions and tf
 
@@ -455,11 +453,11 @@ public:
   void run();
 
   /**
-   * @brief Function to periodically call the given callback_function at the given period
+   * @brief Function to periodically call the given callback_function with guard protection and only
+   * when the node is active
    * @param callback_function the function to call
-   * @param period the period between two calls
    */
-  void run_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period);
+  void run_periodic_call(const std::function<void(void)>& callback_function);
 
   /**
    * @brief Function to add a periodic call to the function given in input
@@ -477,8 +475,8 @@ Cell::Cell(const std::string& node_name, const std::chrono::duration<int64_t, Du
                                                                                                                               mutex_(std::make_shared<std::mutex>()),
                                                                                                                               period_(period) {
   // add the update parameters call
-  std::function<void(void)> update_parameters_fnc = std::bind(&Cell::update_parameters, this);
-  this->parameter_update_thread_ = std::thread(update_parameters_fnc);
+  auto update_parameters_fnc = std::bind(&Cell::update_parameters, this);
+  this->update_parameters_timer_ = this->create_wall_timer(this->period_, update_parameters_fnc);
 }
 
 inline const std::map<std::string, std::pair<std::shared_ptr<communication::CommunicationHandler>, bool>>& Cell::get_handlers() const {

--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -331,8 +331,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cell::
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
   }
   // add the run periodic call
-  std::function<void(void)> run_fnc = std::bind(&Cell::run, this);
-  this->timers_.push_back(this->create_wall_timer(this->period_, run_fnc));
+  this->timers_.push_back(this->create_wall_timer(this->period_, [this] { this->run(); }));
   // add default transform broadcaster and transform listener
   this->add_transform_broadcaster(this->period_, true);
   this->add_transform_listener(10 * this->period_);
@@ -445,8 +444,7 @@ void Cell::run_periodic_call(const std::function<void(void)>& callback_function)
 }
 
 void Cell::add_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period) {
-  std::function<void(void)> run_fnc = std::bind(&Cell::run_periodic_call, this, callback_function);
-  this->timers_.push_back(this->create_wall_timer(period, run_fnc));
+  this->timers_.push_back(this->create_wall_timer(period, [this, callback_function] { this->run_periodic_call(callback_function); }));
 }
 
 void Cell::update_parameters() {

--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -13,11 +13,7 @@ void Cell::reset() {
   this->active_ = false;
   this->configured_ = false;
   this->handlers_.clear();
-  for (auto& t : this->active_threads_) {
-    t.join();
-  }
-  this->active_threads_.clear();
-  this->run_thread_.join();
+  this->timers_.clear();
 }
 
 template <typename T>
@@ -334,9 +330,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cell::
     this->reset();
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
   }
-  // add the run thread
+  // add the run periodic call
   std::function<void(void)> run_fnc = std::bind(&Cell::run, this);
-  this->run_thread_ = std::thread(run_fnc);
+  this->timers_.push_back(this->create_wall_timer(this->period_, run_fnc));
   // add default transform broadcaster and transform listener
   this->add_transform_broadcaster(this->period_, true);
   this->add_transform_listener(10 * this->period_);
@@ -428,190 +424,163 @@ bool Cell::on_shutdown() {
 }
 
 void Cell::run() {
-  while (this->configured_) {
-    auto start = std::chrono::steady_clock::now();
-    std::unique_lock<std::mutex> lck(*this->mutex_);
-    for (auto& h : this->handlers_) {
-      h.second.first->check_timeout();
-    }
-    if (this->active_) {
-      this->step();
-    }
-    lck.unlock();
-    auto end = std::chrono::steady_clock::now();
-    auto elapsed = end - start;
-    auto timeToWait = this->period_ - elapsed;
-    if (timeToWait > std::chrono::nanoseconds::zero()) {
-      std::this_thread::sleep_for(timeToWait);
-    }
+  std::unique_lock<std::mutex> lck(*this->mutex_);
+  for (auto& h : this->handlers_) {
+    h.second.first->check_timeout();
   }
+  if (this->active_) {
+    this->step();
+  }
+  lck.unlock();
 }
 
 void Cell::step() {}
 
-void Cell::run_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period) {
-  while (this->configured_) {
-    auto start = std::chrono::steady_clock::now();
-    std::unique_lock<std::mutex> lck(*this->mutex_);
-    if (this->active_) {
-      callback_function();
-    }
-    lck.unlock();
-    auto end = std::chrono::steady_clock::now();
-    auto elapsed = end - start;
-    auto timeToWait = period - elapsed;
-    if (timeToWait > std::chrono::nanoseconds::zero()) {
-      std::this_thread::sleep_for(timeToWait);
-    }
+void Cell::run_periodic_call(const std::function<void(void)>& callback_function) {
+  std::unique_lock<std::mutex> lck(*this->mutex_);
+  if (this->active_) {
+    callback_function();
   }
+  lck.unlock();
 }
 
 void Cell::add_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period) {
-  std::function<void(const std::function<void(void)>&, const std::chrono::nanoseconds&)> fnc = std::bind(&Cell::run_periodic_call, this, callback_function, period);
-  this->active_threads_.push_back(std::thread(fnc, callback_function, period));
+  std::function<void(void)> run_fnc = std::bind(&Cell::run_periodic_call, this, callback_function);
+  this->timers_.push_back(this->create_wall_timer(period, run_fnc));
 }
 
 void Cell::update_parameters() {
   using namespace state_representation;
   using namespace state_representation::exceptions;
-  while (!this->shutdown_) {
-    auto start = std::chrono::steady_clock::now();
-    try {
-      for (auto& [key, param] : this->parameters_) {
-        switch (param->get_type()) {
-          case StateType::PARAMETER_DOUBLE: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            double value = this->get_parameter(param->get_name()).as_double();
-            std::static_pointer_cast<Parameter<double>>(param)->set_value(value);
-            lck.unlock();
-            break;
-          }
+  try {
+    for (auto& [key, param] : this->parameters_) {
+      switch (param->get_type()) {
+        case StateType::PARAMETER_DOUBLE: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          double value = this->get_parameter(param->get_name()).as_double();
+          std::static_pointer_cast<Parameter<double>>(param)->set_value(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_DOUBLE_ARRAY: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            std::static_pointer_cast<Parameter<std::vector<double>>>(param)->set_value(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_DOUBLE_ARRAY: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          std::static_pointer_cast<Parameter<std::vector<double>>>(param)->set_value(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_BOOL: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            bool value = this->get_parameter(param->get_name()).as_bool();
-            std::static_pointer_cast<Parameter<bool>>(param)->set_value(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_BOOL: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          bool value = this->get_parameter(param->get_name()).as_bool();
+          std::static_pointer_cast<Parameter<bool>>(param)->set_value(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_BOOL_ARRAY: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<bool> value = this->get_parameter(param->get_name()).as_bool_array();
-            std::static_pointer_cast<Parameter<std::vector<bool>>>(param)->set_value(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_BOOL_ARRAY: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<bool> value = this->get_parameter(param->get_name()).as_bool_array();
+          std::static_pointer_cast<Parameter<std::vector<bool>>>(param)->set_value(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_STRING: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::string value = this->get_parameter(param->get_name()).as_string();
-            std::static_pointer_cast<Parameter<std::string>>(param)->set_value(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_STRING: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::string value = this->get_parameter(param->get_name()).as_string();
+          std::static_pointer_cast<Parameter<std::string>>(param)->set_value(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_STRING_ARRAY: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<std::string> value = this->get_parameter(param->get_name()).as_string_array();
-            std::static_pointer_cast<Parameter<std::vector<std::string>>>(param)->set_value(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_STRING_ARRAY: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<std::string> value = this->get_parameter(param->get_name()).as_string_array();
+          std::static_pointer_cast<Parameter<std::vector<std::string>>>(param)->set_value(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_CARTESIANSTATE: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            std::static_pointer_cast<Parameter<CartesianState>>(param)->get_value().from_std_vector(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_CARTESIANSTATE: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          std::static_pointer_cast<Parameter<CartesianState>>(param)->get_value().from_std_vector(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_CARTESIANPOSE: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            std::static_pointer_cast<Parameter<CartesianPose>>(param)->get_value().CartesianPose::from_std_vector(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_CARTESIANPOSE: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          std::static_pointer_cast<Parameter<CartesianPose>>(param)->get_value().CartesianPose::from_std_vector(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_JOINTSTATE: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            std::static_pointer_cast<Parameter<JointState>>(param)->get_value().from_std_vector(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_JOINTSTATE: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          std::static_pointer_cast<Parameter<JointState>>(param)->get_value().from_std_vector(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_JOINTPOSITIONS: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            std::static_pointer_cast<Parameter<JointPositions>>(param)->get_value().JointPositions::from_std_vector(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_JOINTPOSITIONS: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          std::static_pointer_cast<Parameter<JointPositions>>(param)->get_value().JointPositions::from_std_vector(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_ELLIPSOID: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            std::static_pointer_cast<Parameter<Ellipsoid>>(param)->get_value().from_std_vector(value);
-            lck.unlock();
-            break;
-          }
+        case StateType::PARAMETER_ELLIPSOID: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          std::static_pointer_cast<Parameter<Ellipsoid>>(param)->get_value().from_std_vector(value);
+          lck.unlock();
+          break;
+        }
 
-          case StateType::PARAMETER_MATRIX: {
-            std::unique_lock<std::mutex> lck(*this->mutex_);
-            std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-            size_t rows = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().rows();
-            size_t cols = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().cols();
-            size_t size = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().size();
-            // depending on the size of the received parameter produce a different matrix
-            Eigen::MatrixXd matrix_value(rows, cols);
-            if (value.size() == size)// equal size direct copy
-            {
-              matrix_value = Eigen::MatrixXd::Map(value.data(), rows, cols);
-            } else if (value.size() == rows && value.size() == cols)// diagonal matrix with only diagonal values set
-            {
-              Eigen::VectorXd diagonal_coefficients = Eigen::VectorXd::Map(value.data(), value.size());
-              matrix_value = diagonal_coefficients.asDiagonal();
-            } else if (value.size() == 1)// single element means iso diagonal matrix
-            {
-              matrix_value = value[0] * Eigen::MatrixXd::Identity(rows, cols);
-            } else// any other sizes generates an error
-            {
-              throw IncompatibleSizeException("The value set does not have the correct expected size of " + std::to_string(rows) + "x" + std::to_string(cols) + "elements");
-            }
-            std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->set_value(matrix_value);
-            lck.unlock();
-            break;
+        case StateType::PARAMETER_MATRIX: {
+          std::unique_lock<std::mutex> lck(*this->mutex_);
+          std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
+          size_t rows = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().rows();
+          size_t cols = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().cols();
+          size_t size = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().size();
+          // depending on the size of the received parameter produce a different matrix
+          Eigen::MatrixXd matrix_value(rows, cols);
+          if (value.size() == size)// equal size direct copy
+          {
+            matrix_value = Eigen::MatrixXd::Map(value.data(), rows, cols);
+          } else if (value.size() == rows && value.size() == cols)// diagonal matrix with only diagonal values set
+          {
+            Eigen::VectorXd diagonal_coefficients = Eigen::VectorXd::Map(value.data(), value.size());
+            matrix_value = diagonal_coefficients.asDiagonal();
+          } else if (value.size() == 1)// single element means iso diagonal matrix
+          {
+            matrix_value = value[0] * Eigen::MatrixXd::Identity(rows, cols);
+          } else// any other sizes generates an error
+          {
+            throw IncompatibleSizeException("The value set does not have the correct expected size of " + std::to_string(rows) + "x" + std::to_string(cols) + "elements");
           }
+          std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->set_value(matrix_value);
+          lck.unlock();
+          break;
+        }
 
-          default: {
-            throw UnrecognizedParameterTypeException("The Parameter type is not available");
-          }
+        default: {
+          throw UnrecognizedParameterTypeException("The Parameter type is not available");
         }
       }
-    } catch (rclcpp::ParameterTypeException& e) {
-      RCLCPP_ERROR(this->get_logger(), e.what());
-    } catch (IncompatibleSizeException& e) {
-      RCLCPP_ERROR(this->get_logger(), e.what());
-    } catch (UnrecognizedParameterTypeException& e) {
-      RCLCPP_ERROR(this->get_logger(), e.what());
     }
-    auto end = std::chrono::steady_clock::now();
-    auto elapsed = end - start;
-    auto timeToWait = this->period_ - elapsed;
-    if (timeToWait > std::chrono::nanoseconds::zero()) {
-      std::this_thread::sleep_for(timeToWait);
-    }
+  } catch (rclcpp::ParameterTypeException& e) {
+    RCLCPP_ERROR(this->get_logger(), e.what());
+  } catch (IncompatibleSizeException& e) {
+    RCLCPP_ERROR(this->get_logger(), e.what());
+  } catch (UnrecognizedParameterTypeException& e) {
+    RCLCPP_ERROR(this->get_logger(), e.what());
   }
 }
 }// namespace modulo::core


### PR DESCRIPTION
When discussing with @eeberhard I realized that using thread in the `Cell` class was actually breaking ros2 design that rely on a specific pattern called wall timer. This is used to add periodic publishing functions, but in fact it is also made to add any type of periodic call and works fine to handle the `step` function.

I have therefore removed all threads to switch to this wall timer and everything behave smoothly. I initially thought that those timer functions would not be called when the node is `deactivated` but that is not the case. In a sense this is actually good for us we can encapsulate the callback functions in another function that checks for node activation and also handle the mutex guard. However, it also means that this will probably not solve the throttling issue when too many nodes are spawned.