### PR TITLE
Remove mutexes that are not needed when using callbacks

### DIFF
--- a/source/packages/modulo_core/include/modulo_core/Communication/CommunicationHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/CommunicationHandler.hpp
@@ -23,72 +23,59 @@ enum class CommunicationType {
  */
 class CommunicationHandler {
 private:
-  const CommunicationType type_;     ///< type of the handler from the CommunicationType enumeration
-  std::chrono::nanoseconds timeout_; ///< period before considered time out
-  std::shared_ptr<std::mutex> mutex_;///< reference to the Cell mutex
+  const CommunicationType type_;    ///< type of the handler from the CommunicationType enumeration
+  std::chrono::nanoseconds timeout_;///< period before considered time out
 
 public:
   /**
- * @brief Constructor for a CommunicationHandler
- * @param  type      the type of CommunicationHandler from the CommunicationType enumeration
- * @param  clock     reference to the Cell clock
- * @param  mutex     reference to the Cell mutex
- */
-  explicit CommunicationHandler(const CommunicationType& type,
-                                const std::shared_ptr<std::mutex>& mutex);
+   * @brief Constructor for a CommunicationHandler
+   * @param  type      the type of CommunicationHandler from the CommunicationType enumeration
+   * @param  clock     reference to the Cell clock
+   */
+  explicit CommunicationHandler(const CommunicationType& type);
 
   /**
-				 * @brief Constructor for a CommunicationHandler  with a timeout
-				 * @param  type      the type of CommunicationHandler from the CommunicationType enumeration
-				 * @param  timeout   period before considered time out
-				 * @param  clock     reference to the Cell clock
-				 * @param  mutex     reference to the Cell mutex
-				 */
+	 * @brief Constructor for a CommunicationHandler  with a timeout
+	 * @param  type      the type of CommunicationHandler from the CommunicationType enumeration
+	 * @param  timeout   period before considered time out
+	 * @param  clock     reference to the Cell clock
+	 */
   template <typename DurationT>
   explicit CommunicationHandler(const CommunicationType& type,
-                                const std::chrono::duration<int64_t, DurationT>& timeout,
-                                const std::shared_ptr<std::mutex>& mutex);
+                                const std::chrono::duration<int64_t, DurationT>& timeout);
 
   /**
- * @brief Getter of the CommunicationType
- * @return the type of the handler
- */
+   * @brief Getter of the CommunicationType
+   * @return the type of the handler
+   */
   const CommunicationType& get_type();
 
   /**
- * @brief Getter of the timeout period
- * @return the timeout period
- */
+   * @brief Getter of the timeout period
+   * @return the timeout period
+   */
   const std::chrono::nanoseconds& get_timeout() const;
 
   /**
- * @brief Getter of the mutex reference
- * @return the mutex reference
- */
-  std::mutex& get_mutex();
-
-  /**
- * @brief Virtual function to activate a handler
- */
+   * @brief Virtual function to activate a handler
+   */
   virtual void activate();
 
   /**
- * @brief Virtual function to deactivate a handler
- */
+   * @brief Virtual function to deactivate a handler
+   */
   virtual void deactivate();
 
   /**
- * @brief Virtual function to check if the handler is timed out
- */
+   * @brief Virtual function to check if the handler is timed out
+   */
   virtual void check_timeout();
 };
 
 template <typename DurationT>
 CommunicationHandler::CommunicationHandler(const CommunicationType& type,
-                                           const std::chrono::duration<int64_t, DurationT>& timeout,
-                                           const std::shared_ptr<std::mutex>& mutex) : type_(type),
-                                                                                       timeout_(timeout),
-                                                                                       mutex_(mutex) {}
+                                           const std::chrono::duration<int64_t, DurationT>& timeout) : type_(type),
+                                                                                                       timeout_(timeout) {}
 
 inline const CommunicationType& CommunicationHandler::get_type() {
   return this->type_;
@@ -96,10 +83,6 @@ inline const CommunicationType& CommunicationHandler::get_type() {
 
 inline const std::chrono::nanoseconds& CommunicationHandler::get_timeout() const {
   return this->timeout_;
-}
-
-inline std::mutex& CommunicationHandler::get_mutex() {
-  return *this->mutex_;
 }
 
 inline void CommunicationHandler::activate() {}

--- a/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/MessagePassingHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/MessagePassingHandler.hpp
@@ -22,33 +22,27 @@ public:
   /**
    * @brief Constructor for a MessagePassingHandler without timeout nor recipient
    * @param  type      the type of MessagePassingHandler from the CommunicationType enumeration
-   * @param  mutex     reference to the Cell mutex
    */
-  explicit MessagePassingHandler(const CommunicationType& type,
-                                 const std::shared_ptr<std::mutex>& mutex);
+  explicit MessagePassingHandler(const CommunicationType& type);
 
   /**
    * @brief Constructor for a MessagePassingHandler without timeout
    * @param  type      the type of MessagePassingHandler from the CommunicationType enumeration
    * @param  recipient recipient associated to the handler
-   * @param  mutex     reference to the Cell mutex
    */
   explicit MessagePassingHandler(const CommunicationType& type,
-                                 const std::shared_ptr<state_representation::State>& recipient,
-                                 const std::shared_ptr<std::mutex>& mutex);
+                                 const std::shared_ptr<state_representation::State>& recipient);
 
   /**
    * @brief Constructor for a MessagePassingHandler
    * @param  type      the type of CommunicationHandler from the CommunicationType enumeration
    * @param  recipient recipient associated to the handler
    * @param  timeout   period before considered time out
-   * @param  mutex     reference to the Cell mutex
    */
   template <typename DurationT>
   explicit MessagePassingHandler(const CommunicationType& type,
                                  const std::shared_ptr<state_representation::State>& recipient,
-                                 const std::chrono::duration<int64_t, DurationT>& timeout,
-                                 const std::shared_ptr<std::mutex>& mutex);
+                                 const std::chrono::duration<int64_t, DurationT>& timeout);
 
   /**
    * @brief Getter of the recipient
@@ -72,10 +66,9 @@ public:
 template <typename DurationT>
 MessagePassingHandler::MessagePassingHandler(const CommunicationType& type,
                                              const std::shared_ptr<state_representation::State>& recipient,
-                                             const std::chrono::duration<int64_t, DurationT>& timeout,
-                                             const std::shared_ptr<std::mutex>& mutex) : CommunicationHandler(type, timeout, mutex),
-                                                                                         recipient_(recipient),
-                                                                                         asynchronous_(true) {}
+                                             const std::chrono::duration<int64_t, DurationT>& timeout) : CommunicationHandler(type, timeout),
+                                                                                                         recipient_(recipient),
+                                                                                                         asynchronous_(true) {}
 
 inline const state_representation::State& MessagePassingHandler::get_recipient() const {
   return *this->recipient_;

--- a/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/PublisherHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/PublisherHandler.hpp
@@ -33,19 +33,15 @@ public:
    * @brief Constructor of a PublisherHandler
    * @param  recipient the recipent associated to the publisher
    * @param  clock     reference to the Cell clock
-   * @param  mutex     reference to the Cell mutex
    */
   explicit PublisherHandler(const std::shared_ptr<state_representation::State>& recipient,
-                            const std::shared_ptr<rclcpp::Clock>& clock,
-                            const std::shared_ptr<std::mutex>& mutex);
+                            const std::shared_ptr<rclcpp::Clock>& clock);
 
   /**
    * @brief Constructor of a PublisherHandler without a recipient for one-shot publishing
    * @param  clock     reference to the Cell clock
-   * @param  mutex     reference to the Cell mutex
    */
-  explicit PublisherHandler(const std::shared_ptr<rclcpp::Clock>& clock,
-                            const std::shared_ptr<std::mutex>& mutex);
+  explicit PublisherHandler(const std::shared_ptr<rclcpp::Clock>& clock);
 
   /**
    * @brief Function to publish periodically 
@@ -89,19 +85,15 @@ public:
 
 template <class RecT, typename MsgT>
 PublisherHandler<RecT, MsgT>::PublisherHandler(const std::shared_ptr<state_representation::State>& recipient,
-                                               const std::shared_ptr<rclcpp::Clock>& clock,
-                                               const std::shared_ptr<std::mutex>& mutex) : MessagePassingHandler(CommunicationType::PUBLISHER,
-                                                                                                                 recipient,
-                                                                                                                 mutex),
-                                                                                           clock_(clock),
-                                                                                           activated_(false) {}
+                                               const std::shared_ptr<rclcpp::Clock>& clock) : MessagePassingHandler(CommunicationType::PUBLISHER,
+                                                                                                                    recipient),
+                                                                                              clock_(clock),
+                                                                                              activated_(false) {}
 
 template <class RecT, typename MsgT>
-PublisherHandler<RecT, MsgT>::PublisherHandler(const std::shared_ptr<rclcpp::Clock>& clock,
-                                               const std::shared_ptr<std::mutex>& mutex) : MessagePassingHandler(CommunicationType::PUBLISHER,
-                                                                                                                 mutex),
-                                                                                           clock_(clock),
-                                                                                           activated_(false) {}
+PublisherHandler<RecT, MsgT>::PublisherHandler(const std::shared_ptr<rclcpp::Clock>& clock) : MessagePassingHandler(CommunicationType::PUBLISHER),
+                                                                                              clock_(clock),
+                                                                                              activated_(false) {}
 
 template <class RecT, typename MsgT>
 void PublisherHandler<RecT, MsgT>::publish(const RecT& recipient) {
@@ -112,7 +104,6 @@ void PublisherHandler<RecT, MsgT>::publish(const RecT& recipient) {
 
 template <class RecT, typename MsgT>
 void PublisherHandler<RecT, MsgT>::publish_callback() {
-  std::lock_guard<std::mutex> guard(this->get_mutex());
   if (this->is_asynchronous() && this->activated_ && !this->get_recipient().is_empty()) {
     this->publish(static_cast<RecT&>(this->get_recipient()));
   }

--- a/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/SubscriptionHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/SubscriptionHandler.hpp
@@ -20,12 +20,10 @@ public:
    * @brief Constructor of a SubscriptionHandler
    * @param  recipient the recipient associated to the subscription
    * @param  timeout   the period before timeout
-   * @param  mutex     reference to the Cell mutex
    */
   template <typename DurationT>
   explicit SubscriptionHandler(const std::shared_ptr<state_representation::State>& recipient,
-                               const std::chrono::duration<int64_t, DurationT>& timeout,
-                               const std::shared_ptr<std::mutex>& mutex);
+                               const std::chrono::duration<int64_t, DurationT>& timeout);
 
   /**
    * @brief Callback function to receive the message from the network
@@ -58,15 +56,12 @@ public:
 template <class RecT, typename MsgT>
 template <typename DurationT>
 SubscriptionHandler<RecT, MsgT>::SubscriptionHandler(const std::shared_ptr<state_representation::State>& recipient,
-                                                     const std::chrono::duration<int64_t, DurationT>& timeout,
-                                                     const std::shared_ptr<std::mutex>& mutex) : MessagePassingHandler(CommunicationType::SUBSCRIPTION,
-                                                                                                                       recipient,
-                                                                                                                       timeout,
-                                                                                                                       mutex) {}
+                                                     const std::chrono::duration<int64_t, DurationT>& timeout) : MessagePassingHandler(CommunicationType::SUBSCRIPTION,
+                                                                                                                                       recipient,
+                                                                                                                                       timeout) {}
 
 template <class RecT, typename MsgT>
 void SubscriptionHandler<RecT, MsgT>::subscription_callback(const std::shared_ptr<MsgT> msg) {
-  std::lock_guard<std::mutex> guard(this->get_mutex());
   state_conversion::read_msg(static_cast<RecT&>(this->get_recipient()), *msg);
 }
 

--- a/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/TransformBroadcasterHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/TransformBroadcasterHandler.hpp
@@ -15,18 +15,15 @@ public:
    * @brief Constructor for and asychronous TransformBroadcaster handler
    * @param  recipient the associated recipient to publish
    * @param  clock     reference to the Cell clock
-   * @param  mutex     reference to the Cell mutex
    */
   explicit TransformBroadcasterHandler(const std::shared_ptr<state_representation::CartesianState>& recipient,
-                                       const std::shared_ptr<rclcpp::Clock>& clock,
-                                       const std::shared_ptr<std::mutex>& mutex);
+                                       const std::shared_ptr<rclcpp::Clock>& clock);
 
   /**
    * @brief Constructor for TransformBroadcaster handler without an associated recipient
    * @param  clock     reference to the Cell clock
-   * @param  mutex     reference to the Cell mutex
    */
-  explicit TransformBroadcasterHandler(const std::shared_ptr<rclcpp::Clock>& clock, const std::shared_ptr<std::mutex>& mutex);
+  explicit TransformBroadcasterHandler(const std::shared_ptr<rclcpp::Clock>& clock);
 
   /**
    * @brief Function to send a transform over the network

--- a/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/TransformListenerHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/MessagePassing/TransformListenerHandler.hpp
@@ -5,7 +5,6 @@
 
 #include "modulo_core/Communication/MessagePassing/MessagePassingHandler.hpp"
 
-
 namespace modulo::core::communication {
 /**
  * @class TransformListenerHandler
@@ -18,35 +17,31 @@ private:
 
 public:
   /**
- * @brief Constructor for an asychronous TransformListener
- * @param  recipient the associated recipient to store received transforms
- * @param  timeout   period before timeout
- * @param  clock     reference to the Cell clock
- * @param  mutex     reference to the Cell mutex
- */
+   * @brief Constructor for an asychronous TransformListener
+   * @param  recipient the associated recipient to store received transforms
+   * @param  timeout   period before timeout
+   * @param  clock     reference to the Cell clock
+   */
   template <typename DurationT>
   explicit TransformListenerHandler(const std::shared_ptr<state_representation::CartesianPose>& recipient,
                                     const std::chrono::duration<int64_t, DurationT>& timeout,
-                                    const std::shared_ptr<rclcpp::Clock>& clock,
-                                    const std::shared_ptr<std::mutex>& mutex);
+                                    const std::shared_ptr<rclcpp::Clock>& clock);
 
   /**
- * @brief Constructor for a TransformListener without a recipient
- * @param  timeout   period before timeout
- * @param  clock     reference to the Cell clock
- * @param  mutex     reference to the Cell mutex
- */
+   * @brief Constructor for a TransformListener without a recipient
+   * @param  timeout   period before timeout
+   * @param  clock     reference to the Cell clock
+   */
   template <typename DurationT>
   explicit TransformListenerHandler(const std::chrono::duration<int64_t, DurationT>& timeout,
-                                    const std::shared_ptr<rclcpp::Clock>& clock,
-                                    const std::shared_ptr<std::mutex>& mutex);
+                                    const std::shared_ptr<rclcpp::Clock>& clock);
 
   /**
- * @brief Function to look up a transform over the network
- * @param  frame_name      name of the frame associated to the transform
- * @param  reference_frame name of its desired reference frame
- * @return                 the transform as a CartesianPose
- */
+   * @brief Function to look up a transform over the network
+   * @param  frame_name      name of the frame associated to the transform
+   * @param  reference_frame name of its desired reference frame
+   * @return                 the transform as a CartesianPose
+   */
   const state_representation::CartesianPose lookup_transform(const std::string& frame_name,
                                                              const std::string& reference_frame) const;
 };
@@ -54,23 +49,19 @@ public:
 template <typename DurationT>
 TransformListenerHandler::TransformListenerHandler(const std::shared_ptr<state_representation::CartesianPose>& recipient,
                                                    const std::chrono::duration<int64_t, DurationT>& timeout,
-                                                   const std::shared_ptr<rclcpp::Clock>& clock,
-                                                   const std::shared_ptr<std::mutex>& mutex) : MessagePassingHandler(CommunicationType::TRANSFORMLISTENER,
-                                                                                                                     recipient,
-                                                                                                                     timeout,
-                                                                                                                     mutex),
-                                                                                               buffer_(clock) {
+                                                   const std::shared_ptr<rclcpp::Clock>& clock) : MessagePassingHandler(CommunicationType::TRANSFORMLISTENER,
+                                                                                                                        recipient,
+                                                                                                                        timeout),
+                                                                                                  buffer_(clock) {
   this->tf_listener_ = std::make_unique<tf2_ros::TransformListener>(buffer_);
 }
 
 template <typename DurationT>
 TransformListenerHandler::TransformListenerHandler(const std::chrono::duration<int64_t, DurationT>& timeout,
-                                                   const std::shared_ptr<rclcpp::Clock>& clock,
-                                                   const std::shared_ptr<std::mutex>& mutex) : MessagePassingHandler(CommunicationType::TRANSFORMLISTENER,
-                                                                                                                     std::make_shared<state_representation::CartesianPose>(),
-                                                                                                                     timeout,
-                                                                                                                     mutex),
-                                                                                               buffer_(clock) {
+                                                   const std::shared_ptr<rclcpp::Clock>& clock) : MessagePassingHandler(CommunicationType::TRANSFORMLISTENER,
+                                                                                                                        std::make_shared<state_representation::CartesianPose>(),
+                                                                                                                        timeout),
+                                                                                                  buffer_(clock) {
   this->tf_listener_ = std::make_unique<tf2_ros::TransformListener>(buffer_);
 }
 }// namespace modulo::core::communication

--- a/source/packages/modulo_core/include/modulo_core/Communication/ServiceClient/ClientHandler.hpp
+++ b/source/packages/modulo_core/include/modulo_core/Communication/ServiceClient/ClientHandler.hpp
@@ -19,11 +19,9 @@ public:
   /**
    * @brief Constructor of a ClientHandler
    * @param timeout period before timeout
-   * @param mutex reference to the Cell mutex
    */
   template <typename DurationT>
-  explicit ClientHandler(const std::chrono::duration<int64_t, DurationT>& timeout,
-                         const std::shared_ptr<std::mutex>& mutex);
+  explicit ClientHandler(const std::chrono::duration<int64_t, DurationT>& timeout);
 
   /**
    * @brief Setter of the publisher reference
@@ -43,26 +41,24 @@ public:
                                             const std::chrono::duration<int64_t, DurationT>& time_to_wait);
 
   /**
- * @brief Send a request to the server asymchronously withtout waiting for the answer
- * @param request the request
- * @return the response as a future pointer
- */
+   * @brief Send a request to the server asymchronously withtout waiting for the answer
+   * @param request the request
+   * @return the response as a future pointer
+   */
   std::shared_future<std::shared_ptr<typename SrvT::Response>> send_request(const std::shared_ptr<typename SrvT::Request>& request) const;
 
   /**
- * @brief Send a request to the server asymchronously and wait for the answer
- * @param request the request
- * @return the response as a shared pointer
- */
+   * @brief Send a request to the server asymchronously and wait for the answer
+   * @param request the request
+   * @return the response as a shared pointer
+   */
   std::shared_ptr<typename SrvT::Response> send_blocking_request(const std::shared_ptr<typename SrvT::Request>& request) const;
 };
 
 template <typename SrvT>
 template <typename DurationT>
-ClientHandler<SrvT>::ClientHandler(const std::chrono::duration<int64_t, DurationT>& timeout,
-                                   const std::shared_ptr<std::mutex>& mutex) : CommunicationHandler(CommunicationType::CLIENT,
-                                                                                                    timeout,
-                                                                                                    mutex) {}
+ClientHandler<SrvT>::ClientHandler(const std::chrono::duration<int64_t, DurationT>& timeout) : CommunicationHandler(CommunicationType::CLIENT,
+                                                                                                                    timeout) {}
 
 template <typename SrvT>
 inline void ClientHandler<SrvT>::set_client(const std::shared_ptr<rclcpp::Client<SrvT>>& client) {

--- a/source/packages/modulo_core/src/Cell.cpp
+++ b/source/packages/modulo_core/src/Cell.cpp
@@ -18,7 +18,6 @@ void Cell::reset() {
 
 template <typename T>
 void Cell::add_parameter(const std::shared_ptr<state_representation::Parameter<T>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -39,7 +38,6 @@ template void Cell::add_parameter<std::vector<std::string>>(const std::shared_pt
 
 template <>
 void Cell::add_parameter<state_representation::CartesianState>(const std::shared_ptr<state_representation::Parameter<state_representation::CartesianState>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -48,7 +46,6 @@ void Cell::add_parameter<state_representation::CartesianState>(const std::shared
 
 template <>
 void Cell::add_parameter<state_representation::CartesianPose>(const std::shared_ptr<state_representation::Parameter<state_representation::CartesianPose>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -58,7 +55,6 @@ void Cell::add_parameter<state_representation::CartesianPose>(const std::shared_
 
 template <>
 void Cell::add_parameter<state_representation::JointState>(const std::shared_ptr<state_representation::Parameter<state_representation::JointState>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -67,7 +63,6 @@ void Cell::add_parameter<state_representation::JointState>(const std::shared_ptr
 
 template <>
 void Cell::add_parameter<state_representation::JointPositions>(const std::shared_ptr<state_representation::Parameter<state_representation::JointPositions>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -77,7 +72,6 @@ void Cell::add_parameter<state_representation::JointPositions>(const std::shared
 
 template <>
 void Cell::add_parameter<state_representation::Ellipsoid>(const std::shared_ptr<state_representation::Parameter<state_representation::Ellipsoid>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -86,7 +80,6 @@ void Cell::add_parameter<state_representation::Ellipsoid>(const std::shared_ptr<
 
 template <>
 void Cell::add_parameter<Eigen::MatrixXd>(const std::shared_ptr<state_representation::Parameter<Eigen::MatrixXd>>& parameter, const std::string& prefix) {
-  std::lock_guard<std::mutex> lock(*this->mutex_);
   std::string tprefix = (prefix != "") ? prefix + "_" : "";
   parameter->set_name(tprefix + parameter->get_name());
   this->parameters_.insert(std::make_pair(parameter->get_name(), parameter));
@@ -423,24 +416,20 @@ bool Cell::on_shutdown() {
 }
 
 void Cell::run() {
-  std::unique_lock<std::mutex> lck(*this->mutex_);
   for (auto& h : this->handlers_) {
     h.second.first->check_timeout();
   }
   if (this->active_) {
     this->step();
   }
-  lck.unlock();
 }
 
 void Cell::step() {}
 
 void Cell::run_periodic_call(const std::function<void(void)>& callback_function) {
-  std::unique_lock<std::mutex> lck(*this->mutex_);
   if (this->active_) {
     callback_function();
   }
-  lck.unlock();
 }
 
 void Cell::add_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period) {
@@ -454,95 +443,72 @@ void Cell::update_parameters() {
     for (auto& [key, param] : this->parameters_) {
       switch (param->get_type()) {
         case StateType::PARAMETER_DOUBLE: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           double value = this->get_parameter(param->get_name()).as_double();
           std::static_pointer_cast<Parameter<double>>(param)->set_value(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_DOUBLE_ARRAY: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           std::static_pointer_cast<Parameter<std::vector<double>>>(param)->set_value(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_BOOL: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           bool value = this->get_parameter(param->get_name()).as_bool();
           std::static_pointer_cast<Parameter<bool>>(param)->set_value(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_BOOL_ARRAY: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<bool> value = this->get_parameter(param->get_name()).as_bool_array();
           std::static_pointer_cast<Parameter<std::vector<bool>>>(param)->set_value(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_STRING: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::string value = this->get_parameter(param->get_name()).as_string();
           std::static_pointer_cast<Parameter<std::string>>(param)->set_value(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_STRING_ARRAY: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<std::string> value = this->get_parameter(param->get_name()).as_string_array();
           std::static_pointer_cast<Parameter<std::vector<std::string>>>(param)->set_value(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_CARTESIANSTATE: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           std::static_pointer_cast<Parameter<CartesianState>>(param)->get_value().from_std_vector(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_CARTESIANPOSE: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           std::static_pointer_cast<Parameter<CartesianPose>>(param)->get_value().CartesianPose::from_std_vector(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_JOINTSTATE: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           std::static_pointer_cast<Parameter<JointState>>(param)->get_value().from_std_vector(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_JOINTPOSITIONS: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           std::static_pointer_cast<Parameter<JointPositions>>(param)->get_value().JointPositions::from_std_vector(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_ELLIPSOID: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           std::static_pointer_cast<Parameter<Ellipsoid>>(param)->get_value().from_std_vector(value);
-          lck.unlock();
           break;
         }
 
         case StateType::PARAMETER_MATRIX: {
-          std::unique_lock<std::mutex> lck(*this->mutex_);
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
           size_t rows = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().rows();
           size_t cols = std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->get_value().cols();
@@ -564,7 +530,6 @@ void Cell::update_parameters() {
             throw IncompatibleSizeException("The value set does not have the correct expected size of " + std::to_string(rows) + "x" + std::to_string(cols) + "elements");
           }
           std::static_pointer_cast<Parameter<Eigen::MatrixXd>>(param)->set_value(matrix_value);
-          lck.unlock();
           break;
         }
 

--- a/source/packages/modulo_core/src/Communication/CommunicationHandler.cpp
+++ b/source/packages/modulo_core/src/Communication/CommunicationHandler.cpp
@@ -1,7 +1,5 @@
 #include "modulo_core/Communication/CommunicationHandler.hpp"
 
 namespace modulo::core::communication {
-CommunicationHandler::CommunicationHandler(const CommunicationType& type,
-                                           const std::shared_ptr<std::mutex>& mutex) : type_(type),
-                                                                                       mutex_(mutex) {}
+CommunicationHandler::CommunicationHandler(const CommunicationType& type) : type_(type) {}
 }// namespace modulo::core::communication

--- a/source/packages/modulo_core/src/Communication/MessagePassing/MessagePassingHandler.cpp
+++ b/source/packages/modulo_core/src/Communication/MessagePassing/MessagePassingHandler.cpp
@@ -1,13 +1,11 @@
 #include "modulo_core/Communication/MessagePassing/MessagePassingHandler.hpp"
 
 namespace modulo::core::communication {
-MessagePassingHandler::MessagePassingHandler(const CommunicationType& type,
-                                             const std::shared_ptr<std::mutex>& mutex) : CommunicationHandler(type, mutex),
-                                                                                         asynchronous_(false) {}
+MessagePassingHandler::MessagePassingHandler(const CommunicationType& type) : CommunicationHandler(type),
+                                                                              asynchronous_(false) {}
 
 MessagePassingHandler::MessagePassingHandler(const CommunicationType& type,
-                                             const std::shared_ptr<state_representation::State>& recipient,
-                                             const std::shared_ptr<std::mutex>& mutex) : CommunicationHandler(type, mutex),
-                                                                                         recipient_(recipient),
-                                                                                         asynchronous_(true) {}
+                                             const std::shared_ptr<state_representation::State>& recipient) : CommunicationHandler(type),
+                                                                                                              recipient_(recipient),
+                                                                                                              asynchronous_(true) {}
 }// namespace modulo::core::communication

--- a/source/packages/modulo_core/src/Communication/MessagePassing/TransformBroadcasterHandler.cpp
+++ b/source/packages/modulo_core/src/Communication/MessagePassing/TransformBroadcasterHandler.cpp
@@ -2,13 +2,9 @@
 
 namespace modulo::core::communication {
 TransformBroadcasterHandler::TransformBroadcasterHandler(const std::shared_ptr<state_representation::CartesianState>& recipient,
-                                                         const std::shared_ptr<rclcpp::Clock>& clock,
-                                                         const std::shared_ptr<std::mutex>& mutex) : PublisherHandler<state_representation::CartesianState, tf2_msgs::msg::TFMessage>(recipient,
-                                                                                                                                                                                      clock,
-                                                                                                                                                                                      mutex) {}
+                                                         const std::shared_ptr<rclcpp::Clock>& clock) : PublisherHandler<state_representation::CartesianState, tf2_msgs::msg::TFMessage>(recipient,
+                                                                                                                                                                                         clock) {}
 
-TransformBroadcasterHandler::TransformBroadcasterHandler(const std::shared_ptr<rclcpp::Clock>& clock,
-                                                         const std::shared_ptr<std::mutex>& mutex) : PublisherHandler<state_representation::CartesianState, tf2_msgs::msg::TFMessage>(std::make_shared<state_representation::CartesianState>(),
-                                                                                                                                                                                      clock,
-                                                                                                                                                                                      mutex) {}
+TransformBroadcasterHandler::TransformBroadcasterHandler(const std::shared_ptr<rclcpp::Clock>& clock) : PublisherHandler<state_representation::CartesianState, tf2_msgs::msg::TFMessage>(std::make_shared<state_representation::CartesianState>(),
+                                                                                                                                                                                         clock) {}
 }// namespace modulo::core::communication


### PR DESCRIPTION
Nothing like a good old PR that removes lines of code. As the title says, callbacks from `wall_timer` are thread safe, even when using `MultiThreadedExecutor` (cf https://answers.ros.org/question/316539/are-callbacks-of-the-same-node-called-sequentally-in-multithreadexecutor/). Thanks to PR #14, all threads have been removed rendering the use of mutexes obsolete.