### PR TITLE
Fix docker COPY in CI

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,6 +9,7 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,7 +9,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-  pull_request:
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/aica-technology/ros2-ws:${ROS_VERSION}
 
 # install google dependencies
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/include/google /usr/local/include/google
-COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/lib/libproto* /usr/local/lib
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/lib/libproto* /usr/local/lib/
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/bin/protoc /usr/local/bin
 RUN sudo ldconfig
 


### PR DESCRIPTION
The CI was failing with the new libproto copy command:
> When using COPY with more than one source file, the destination must be a directory and end with a /

I added a temporary CI build on PR synchronise to test this. I will remove it once the image build.