### PR TITLE
Component NodeOptions constructor

### DIFF
--- a/source/modulo_core/include/modulo_core/Component.hpp
+++ b/source/modulo_core/include/modulo_core/Component.hpp
@@ -19,7 +19,7 @@ private:
   std::map<std::string, std::shared_ptr<state_representation::Predicate>> predicates_;///< map of predicates
   std::list<std::pair<std::string, std::function<bool(void)>>> predicate_functions_;  ///< list of predicate functions evaluated at each step
   std::map<std::string, std::string> external_predicate_channels_;                    ///< map storing the channels for the external predicates
-  
+
   /**
    * @brief Periodically called function that evaluates the predicates functions
    */
@@ -112,6 +112,13 @@ public:
   explicit Component(const std::string& node_name,
                      const std::chrono::duration<int64_t, DurationT>& period,
                      bool intra_process_comms = false);
+
+  /**
+   * @brief Component construction from ROS2 NodeOptions
+   * @param options NodeOptions containing a node name in the remapping arguments list and a "period" parameter
+   * with a value in seconds in the parameter override list
+   */
+  explicit Component(const rclcpp::NodeOptions& options);
 
   /**
    * @brief Destructor

--- a/source/modulo_core/include/modulo_core/Component.hpp
+++ b/source/modulo_core/include/modulo_core/Component.hpp
@@ -148,7 +148,7 @@ public:
   /**
    * @brief Function computing one step of calculation. It is called periodically in the run function.
    */
-  virtual void step() = 0;
+  virtual void step() override = 0;
 };
 
 template <typename DurationT>

--- a/source/modulo_core/src/Component.cpp
+++ b/source/modulo_core/src/Component.cpp
@@ -4,6 +4,13 @@
 #include "modulo_core/exceptions/PredicateNotFoundException.hpp"
 
 namespace modulo::core {
+
+Component::Component(const rclcpp::NodeOptions& options) : Cell(options) {
+  this->declare_parameter<int>("predicate_checking_period", 100);
+  this->add_predicate("is_configured", [this] { return this->is_configured(); });
+  this->add_predicate("is_active", [this] { return this->is_active(); });
+}
+
 Component::~Component() {
   this->on_shutdown();
 }


### PR DESCRIPTION
* Add NodeOptions constructor to Component
class to make components loadable through
the component manager. This uses the base
Cell constructor to parse the NodeOptions.