### PR TITLE
Fix the predicate publishing that was only happening at activation

### DIFF
--- a/source/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/modulo_core/include/modulo_core/Cell.hpp
@@ -531,6 +531,11 @@ public:
 
   /**
    * @brief Function to add a periodic call to the function given in input
+   * @details This function is similar to the add_deamon one with
+   * the difference that the callback_function is only called when the node
+   * is active. The desired design is, therefore, that it should only be called
+   * in the on_configure function, as periodic_call will be cleaned when on_cleanup
+   * is called.
    * @param callback_function the function to call
    * @param period the period between two calls
    */
@@ -538,6 +543,10 @@ public:
 
   /**
    * @brief Function to daemonize the callback function given in input
+   * @details This function is similar to the add_periodic_call one with
+   * the difference that a daemon is always active, including when the node
+   * is not configured. The desired design is, therefore, that it should be
+   * called only in the constructor to avoid potential duplicates.
    * @param callback_function the function to call
    * @param period the period between two calls
    */

--- a/source/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/modulo_core/include/modulo_core/Cell.hpp
@@ -42,10 +42,11 @@ private:
   bool active_;                                                                                          ///< boolean that informs that the node has been activated, i.e passed by the on_activate state
   bool shutdown_;                                                                                        ///< boolean that informs that the node has been shutdown, i.e passed by the on_shutdown state
   std::shared_ptr<rclcpp::TimerBase> update_parameters_timer_;                                           ///< reference to the timer for periodically that periodicall update the parameters
-  std::list<std::shared_ptr<rclcpp::TimerBase>> timers_;                                                 ///< reference to timers for periodically called functions
   std::chrono::nanoseconds period_;                                                                      ///< rate of the publisher functions in nanoseconds
   std::map<std::string, std::shared_ptr<state_representation::ParameterInterface>> parameters_;          ///< list for storing parameters
   std::map<std::string, std::pair<std::shared_ptr<communication::CommunicationHandler>, bool>> handlers_;///< map for storing publishers, subscriptions and tf
+  std::list<std::shared_ptr<rclcpp::TimerBase>> timers_;                                                 ///< reference to timers for periodically called functions
+  std::list<std::shared_ptr<rclcpp::TimerBase>> daemons_;                                                ///< reference to timers for daemonized functions
 
   /**
    * @brief Function to clear all publishers, subscriptions and services
@@ -56,7 +57,7 @@ private:
    * @brief Function to add a default transform broadcaster to the map of handlers
    * @tparam DurationT template value for accepting any type of std::chrono duration values
    * @param period the period to wait between two publishing
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   template <typename DurationT>
   void add_transform_broadcaster(const std::chrono::duration<int64_t, DurationT>& period,
@@ -144,7 +145,7 @@ public:
    * @param channel unique name of the publish channel that is used as key to the map
    * @param recipient the state that contain the data to be published
    * @param period the period to wait between two publishing
-   * @param always_active if true, always publish the message as soon as the node is configured
+   * @param always_active if true, always publish even if the node is not configured
    * @param queue_size publisher parameters indicating the maximum size of the buffer
    */
   template <typename MsgT, class RecT, typename DurationT>
@@ -160,7 +161,7 @@ public:
    * @tparam RecT template value for accepting any type of recipient
    * @param channel unique name of the publish channel that is used as key to the map
    * @param recipient the state that contain the data to be published
-   * @param always_active if true, always publish the message as soon as the node is configured
+   * @param always_active if true, always publish even if the node is not configured
    * @param queue_size publisher parameters indicating the maximum size of the buffer
    */
   template <typename MsgT, class RecT>
@@ -177,7 +178,7 @@ public:
    * @param channel unique name of the publish channel that is used as key to the map
    * @param recipient the state that contain the data to be published
    * @param period the period to wait between two publishing
-   * @param always_active if true, always publish the message as soon as the node is configured
+   * @param always_active if true, always publish even if the node is not configured
    * @param queue_size publisher parameters indicating the maximum size of the buffer
    */
   template <class RecT, typename DurationT>
@@ -193,7 +194,7 @@ public:
    * @tparam RecT template value for accepting any State type recipient
    * @param channel unique name of the publish channel that is used as key to the map
    * @param recipient the state that contain the data to be published
-   * @param always_active if true, always publish the message as soon as the node is configured
+   * @param always_active if true, always publish even if the node is not configured
    * @param queue_size publisher parameters indicating the maximum size of the buffer
    */
   template <class RecT>
@@ -210,7 +211,7 @@ public:
    * @param channel unique name of the subscription channel that is used as key to the map
    * @param recipient the state that will contain the received data
    * @param timeout the period after wich to consider that the subscriber has timeout
-   * @param always_active if true, always receive messages from the topic as soon as the node is configured
+   * @param always_active if true, always receive messages from the topic even if the node is not configured
    * @param queue_size subscriber parameters indicating the maximum size of the buffer
    */
   template <typename MsgT, class RecT, typename DurationT>
@@ -224,7 +225,7 @@ public:
    * @brief Template function to add a generic subscription to the map of handlers
    * @param channel unique name of the subscription channel that is used as key to the map
    * @param recipient the state that will contain the received data
-   * @param always_active if true, always receive messages from the topic as soon as the node is configured
+   * @param always_active if true, always receive messages from the topic even if the node is not configured
    * @param nb_period_to_timeout the number of period before considering that the subscription has timeout
    * @param queue_size subscriber parameters indicating the maximum size of the buffer
    */
@@ -243,7 +244,7 @@ public:
    * @param channel unique name of the subscription channel that is used as key to the map
    * @param recipient the state that will contain the received data
    * @param timeout the period after wich to consider that the subscriber has timeout
-   * @param always_active if true, always receive messages from the topic as soon as the node is configured
+   * @param always_active if true, always receive messages from the topic even if the node is not configured
    * @param queue_size subscriber parameters indicating the maximum size of the buffer
    */
   template <class RecT, typename DurationT>
@@ -259,7 +260,7 @@ public:
    * @tparam RecT template value for accepting any State type recipient
    * @param channel unique name of the subscription channel that is used as key to the map
    * @param recipient the state that will contain the received data
-   * @param always_active if true, always receive messages from the topic as soon as the node is configured
+   * @param always_active if true, always receive messages from the topic even if the node is not configured
    * @param nb_period_to_timeout the number of period before considering that the subscription has timeout
    * @param queue_size subscriber parameters indicating the maximum size of the buffer
    */
@@ -284,7 +285,7 @@ public:
    * @brief Function to add a generic transform broadcaster to the map of handlers
    * @param recipient the state that contain the data to be published
    * @param period the period to wait between two publishing
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   template <typename DurationT>
   void add_transform_broadcaster(const std::shared_ptr<state_representation::CartesianState>& recipient,
@@ -296,7 +297,7 @@ public:
    * @brief Function to add a generic transform broadcaster to the map of handlers
    * @param recipient the state that contain the data to be published
    * @param period the period to wait between two publishing
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   template <typename DurationT>
   void add_transform_broadcaster(const state_representation::CartesianPose& recipient,
@@ -308,7 +309,7 @@ public:
    * @brief Function to add a generic transform broadcaster to the map of handlers
    * @param recipient the state that contain the data to be published
    * @param period the period to wait between two publishing
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   template <typename DurationT>
   void add_transform_broadcaster(const std::shared_ptr<state_representation::ParameterInterface>& recipient,
@@ -319,7 +320,7 @@ public:
   /**
    * @brief Function to add a generic transform broadcaster to the map of handlers
    * @param recipient the state that contain the data to be published
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   void add_transform_broadcaster(const std::shared_ptr<state_representation::CartesianState>& recipient,
                                  bool always_active = false,
@@ -328,7 +329,7 @@ public:
   /**
    * @brief Function to add a generic transform broadcaster to the map of handlers
    * @param recipient the state that contain the data to be published
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   void add_transform_broadcaster(const state_representation::CartesianPose& recipient,
                                  bool always_active = false,
@@ -337,7 +338,7 @@ public:
   /**
    * @brief Function to add a generic transform broadcaster to the map of handlers
    * @param recipient the state that contain the data to be published
-   * @param always_active if true, always publish the transform as soon as the node is configured
+   * @param always_active if true, always publish the transform even if the node is not configured
    */
   void add_transform_broadcaster(const std::shared_ptr<state_representation::ParameterInterface>& recipient,
                                  bool always_active = false,
@@ -534,6 +535,13 @@ public:
    * @param period the period between two calls
    */
   void add_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period);
+
+  /**
+   * @brief Function to daemonized the callback function given in input
+   * @param callback_function the function to call
+   * @param period the period between two calls
+   */
+  void add_daemon(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period);
 };
 
 template <typename DurationT>
@@ -585,6 +593,10 @@ void Cell::add_publisher(const std::string& channel,
   handler->set_publisher(this->create_publisher<MsgT>(channel, queue_size));
   handler->set_timer(this->create_wall_timer(period, [handler] { handler->publish_callback(); }));
   this->handlers_.insert(std::make_pair(channel, std::make_pair(handler, always_active)));
+  // if the handler is always active, activate it directly
+  if (always_active) {
+    handler->activate();
+  }
 }
 
 template <typename MsgT, class RecT>
@@ -621,6 +633,9 @@ void Cell::add_subscription(const std::string& channel,
   auto handler = std::make_shared<communication::SubscriptionHandler<RecT, MsgT>>(recipient, timeout);
   handler->set_subscription(this->create_subscription<MsgT>(channel, queue_size, [handler](const std::shared_ptr<MsgT> msg) { handler->subscription_callback(msg); }));
   this->handlers_.insert(std::make_pair(channel, std::make_pair(handler, always_active)));
+  if (always_active) {
+    handler->activate();
+  }
 }
 
 template <typename MsgT, class RecT>
@@ -658,6 +673,9 @@ void Cell::add_transform_broadcaster(const std::chrono::duration<int64_t, Durati
   handler->set_publisher(this->create_publisher<tf2_msgs::msg::TFMessage>("tf", queue_size));
   handler->set_timer(this->create_wall_timer(period, [handler] { handler->publish_callback(); }));
   this->handlers_.insert(std::make_pair("tf_broadcaster", std::make_pair(handler, always_active)));
+  if (always_active) {
+    handler->activate();
+  }
 }
 
 template <typename DurationT>
@@ -669,6 +687,9 @@ void Cell::add_transform_broadcaster(const std::shared_ptr<state_representation:
   handler->set_publisher(this->create_publisher<tf2_msgs::msg::TFMessage>("tf", queue_size));
   handler->set_timer(this->create_wall_timer(period, [handler] { handler->publish_callback(); }));
   this->handlers_.insert(std::make_pair(recipient->get_name() + "_in_" + recipient->get_reference_frame() + "_broadcaster", std::make_pair(handler, always_active)));
+  if (always_active) {
+    handler->activate();
+  }
 }
 
 template <typename DurationT>
@@ -691,6 +712,9 @@ void Cell::add_transform_broadcaster(const std::shared_ptr<state_representation:
   handler->set_publisher(this->create_publisher<tf2_msgs::msg::TFMessage>("tf", queue_size));
   handler->set_timer(this->create_wall_timer(period, [handler] { handler->publish_callback(); }));
   this->handlers_.insert(std::make_pair(parameter->get_value().get_name() + "_in_" + parameter->get_value().get_reference_frame() + "_broadcaster", std::make_pair(handler, always_active)));
+  if (always_active) {
+    handler->activate();
+  }
 }
 
 template <typename DurationT>

--- a/source/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/modulo_core/include/modulo_core/Cell.hpp
@@ -537,7 +537,7 @@ public:
   void add_periodic_call(const std::function<void(void)>& callback_function, const std::chrono::nanoseconds& period);
 
   /**
-   * @brief Function to daemonized the callback function given in input
+   * @brief Function to daemonize the callback function given in input
    * @param callback_function the function to call
    * @param period the period between two calls
    */

--- a/source/modulo_core/include/modulo_core/Component.hpp
+++ b/source/modulo_core/include/modulo_core/Component.hpp
@@ -24,6 +24,13 @@ private:
    */
   void evaluate_predicate_functions();
 
+  /**
+   * @brief Create a topic name from the predicate name
+   * @param predicate_name The predicate name
+   * @return A corresponding topic name
+   */
+  std::string generate_predicate_topic(const std::string& predicate_name) const;
+
 protected:
   /**
    * @brief Add a predicate to the map of predicates

--- a/source/modulo_core/include/modulo_core/Component.hpp
+++ b/source/modulo_core/include/modulo_core/Component.hpp
@@ -20,6 +20,11 @@ private:
   std::map<std::string, std::function<bool(void)>> predicate_functions_;              ///< map of predicate functions evaluated at each step
 
   /**
+   * @brief Initialize all the parameters needed in the constructors
+   */
+  void on_init();
+
+  /**
    * @brief Periodically called function that evaluates the predicates functions
    */
   void evaluate_predicate_functions();
@@ -147,10 +152,6 @@ template <typename DurationT>
 Component::Component(const std::string& node_name,
                      const std::chrono::duration<int64_t, DurationT>& period,
                      bool intra_process_comms) : Cell(node_name, period, intra_process_comms) {
-  this->declare_parameter<int>("predicate_checking_period", 100);
-  this->add_predicate("is_configured", [this] { return this->is_configured(); });
-  this->add_predicate("is_active", [this] { return this->is_active(); });
-  this->add_daemon([this] { this->evaluate_predicate_functions(); },
-                   std::chrono::milliseconds(this->get_parameter("predicate_checking_period").as_int()));
+  this->on_init();
 }
 }// namespace modulo::core

--- a/source/modulo_core/src/Component.cpp
+++ b/source/modulo_core/src/Component.cpp
@@ -5,10 +5,16 @@
 
 namespace modulo::core {
 
-Component::Component(const rclcpp::NodeOptions& options) : Cell(options) {
+void Component::on_init() {
   this->declare_parameter<int>("predicate_checking_period", 100);
   this->add_predicate("is_configured", [this] { return this->is_configured(); });
   this->add_predicate("is_active", [this] { return this->is_active(); });
+  this->add_daemon([this] { this->evaluate_predicate_functions(); },
+                   std::chrono::milliseconds(this->get_parameter("predicate_checking_period").as_int()));
+}
+
+Component::Component(const rclcpp::NodeOptions& options) : Cell(options) {
+  this->on_init();
 }
 
 Component::~Component() {

--- a/source/modulo_core/src/Component.cpp
+++ b/source/modulo_core/src/Component.cpp
@@ -43,11 +43,17 @@ void Component::add_predicate(const std::shared_ptr<state_representation::Predic
 }
 
 void Component::add_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function) {
+  // insert the predicate function in the list overwriting it if it already exists
+  this->predicate_functions_.insert_or_assign(predicate_name, predicate_function);
   // crate a predicate with named prefixed with the action name
   auto predicate = std::make_shared<state_representation::Predicate>(predicate_name);
-  this->add_predicate(predicate);
-  // insert the predicate function in the list
-  this->predicate_functions_.insert(std::make_pair(predicate_name, predicate_function));
+  // try to insert the predicate in the map. If it already exists, do nothing to just
+  // update the predicate_function
+  try {
+    this->add_predicate(predicate);
+  } catch (exceptions::PredicateAlreadyRegisteredException&) {
+    RCLCPP_DEBUG(this->get_logger(), "Predicate with same name already exists, overwriting predicate callback function");
+  }
 }
 
 void Component::add_received_predicate(const std::string& predicate_name, const std::string& channel) {

--- a/source/modulo_core/src/Component.cpp
+++ b/source/modulo_core/src/Component.cpp
@@ -16,8 +16,8 @@ Component::~Component() {
 }
 
 void Component::evaluate_predicate_functions() {
-  for (auto& predicate : this->predicate_functions_) {
-    this->set_predicate_value(predicate.first, (predicate.second)());
+  for (auto const& [key, val] : this->predicate_functions_) {
+    this->set_predicate_value(key, (val)());
   }
 }
 
@@ -28,6 +28,8 @@ void Component::add_predicate(const std::shared_ptr<state_representation::Predic
   }
   // add the predicate to the map
   this->predicates_.insert(std::make_pair(predicate_name, predicate));
+  // add the publisher predicate
+  this->add_publisher<std_msgs::msg::Bool>("/predicates/" + std::string(this->get_name()) + "/" + predicate_name, predicate, true);
 }
 
 void Component::add_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function) {
@@ -35,13 +37,14 @@ void Component::add_predicate(const std::string& predicate_name, const std::func
   auto predicate = std::make_shared<state_representation::Predicate>(predicate_name);
   this->add_predicate(predicate);
   // insert the predicate function in the list
-  this->predicate_functions_.push_back(std::make_pair(predicate_name, predicate_function));
+  this->predicate_functions_.insert(std::make_pair(predicate_name, predicate_function));
 }
 
 void Component::add_received_predicate(const std::string& predicate_name, const std::string& channel) {
   auto predicate = std::make_shared<state_representation::Predicate>(predicate_name);
   this->predicates_.insert(std::make_pair(predicate_name, predicate));
-  this->external_predicate_channels_.insert(std::make_pair(predicate_name, channel));
+  // add a subscription to the channel where the predicate is published
+  this->add_subscription<std_msgs::msg::Bool>(channel, predicate, true);
 }
 
 bool Component::get_predicate_value(const std::string& predicate_name) const {
@@ -88,21 +91,5 @@ const std::list<std::shared_ptr<state_representation::Predicate>> Component::get
   std::list<std::shared_ptr<state_representation::Predicate>> predicate_list;
   std::transform(this->predicates_.begin(), this->predicates_.end(), std::back_inserter(predicate_list), [](const std::map<std::string, std::shared_ptr<state_representation::Predicate>>::value_type& val) { return val.second; });
   return predicate_list;
-}
-
-rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-Component::on_configure(const rclcpp_lifecycle::State& state) {
-  this->add_periodic_call([this] { this->evaluate_predicate_functions(); },
-                          std::chrono::milliseconds(this->get_parameter("predicate_checking_period").as_int()));
-  for (auto& [key, val] : this->predicates_) {
-    // check if the predicate is external or local
-    auto external_predicate_iterator = this->external_predicate_channels_.find(key);
-    if (external_predicate_iterator == this->external_predicate_channels_.end()) {
-      this->add_publisher<std_msgs::msg::Bool>("/predicates/" + std::string(this->get_name()) + "/" + key, val, true);
-    } else {
-      this->add_subscription<std_msgs::msg::Bool>(external_predicate_iterator->second, val, true);
-    }
-  }
-  return this->Cell::on_configure(state);
 }
 }// namespace modulo::core

--- a/source/modulo_core/src/Component.cpp
+++ b/source/modulo_core/src/Component.cpp
@@ -21,6 +21,10 @@ void Component::evaluate_predicate_functions() {
   }
 }
 
+std::string Component::generate_predicate_topic(const std::string& predicate_name) const {
+  return "/predicates/" + std::string(this->get_name()) + "/" + predicate_name;
+}
+
 void Component::add_predicate(const std::shared_ptr<state_representation::Predicate>& predicate) {
   std::string predicate_name = predicate->get_name();
   if (this->predicates_.find(predicate_name) != this->predicates_.end()) {
@@ -29,7 +33,7 @@ void Component::add_predicate(const std::shared_ptr<state_representation::Predic
   // add the predicate to the map
   this->predicates_.insert(std::make_pair(predicate_name, predicate));
   // add the publisher predicate
-  this->add_publisher<std_msgs::msg::Bool>("/predicates/" + std::string(this->get_name()) + "/" + predicate_name, predicate, true);
+  this->add_publisher<std_msgs::msg::Bool>(this->generate_predicate_topic(predicate_name), predicate, true);
 }
 
 void Component::add_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function) {


### PR DESCRIPTION
The whole predicate publishing was only happening when the node was actually activated. This fixes this issues by changing the scope of `always_activated` communication handlers. It also introduces the concept of `daemons` function calls that are always happening in the background even if the node is not configured (e.g. `update_parameters` function call.