### PR TITLE
Fix the removed from_std_vector

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -28,5 +28,5 @@ COPY --chown=${USER} ./source/ ./src/
 # Clean image
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
-# add the key for robotpkg
+# Restore the key for robotpkg
 RUN sudo curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -21,12 +21,10 @@ RUN sudo ./install.sh
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/openrobots/lib/
 RUN sudo ldconfig
 
+WORKDIR ${HOME}/ros2_ws
 # copy sources and build ROS workspace with user permissions
 WORKDIR ${HOME}/ros2_ws/
 COPY --chown=${USER} ./source/ ./src/
-RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"
-
-WORKDIR ${HOME}
 
 # Clean image
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -5,21 +5,20 @@ FROM ghcr.io/aica-technology/ros2-ws:${ROS_VERSION}
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/include/google /usr/local/include/google
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/lib/libproto* /usr/local/lib/
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local/bin/protoc /usr/local/bin
-RUN sudo ldconfig
+RUN ldconfig
 
-USER ${USER}
 # install control library packages
 WORKDIR ${HOME}
 RUN git clone -b develop --depth 1 https://github.com/epfl-lasa/control_libraries.git
 WORKDIR ${HOME}/control_libraries/source
-RUN sudo ./install.sh -y
+RUN ./install.sh -y
 
 # generate protobuf bindings
 WORKDIR ${HOME}/control_libraries/protocol
-RUN sudo ./install.sh
+RUN ./install.sh
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/openrobots/lib/
-RUN sudo ldconfig
+RUN ldconfig
 
 WORKDIR ${HOME}/ros2_ws
 # copy sources and build ROS workspace with user permissions

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -27,3 +27,6 @@ COPY --chown=${USER} ./source/ ./src/
 
 # Clean image
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+
+# add the key for robotpkg
+RUN sudo curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,5 @@
+ARG ROS_VERSION=foxy
+FROM aica-technology/modulo/development:${ROS_VERSION} as remote-development
+
+# build modulo
+RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -2,4 +2,4 @@ ARG ROS_VERSION=foxy
 FROM aica-technology/modulo/development:${ROS_VERSION} as remote-development
 
 # build modulo
-RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"
+RUN su ${USER} -c /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 ROS_VERSION=foxy
 
+TARGET=development
 IMAGE_NAME=aica-technology/modulo
-IMAGE_TAG=latest
 
 BUILD_FLAGS=()
 
@@ -15,8 +15,9 @@ while getopts 'r' opt; do
 done
 shift "$(( OPTIND - 1 ))"
 
+
 BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${IMAGE_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}/${TARGET}":"${ROS_VERSION}")
 
 docker pull ghcr.io/aica-technology/ros2-ws:"${ROS_VERSION}"
-DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .
+DOCKER_BUILDKIT=1 docker build --file ./Dockerfile.${TARGET} "${BUILD_FLAGS[@]}" .

--- a/source/modulo_core/src/Cell.cpp
+++ b/source/modulo_core/src/Cell.cpp
@@ -507,31 +507,31 @@ void Cell::update_parameters() {
 
         case StateType::PARAMETER_CARTESIANSTATE: {
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-          std::static_pointer_cast<Parameter<CartesianState>>(param)->get_value().from_std_vector(value);
+          std::static_pointer_cast<Parameter<CartesianState>>(param)->get_value().set_data(value);
           break;
         }
 
         case StateType::PARAMETER_CARTESIANPOSE: {
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-          std::static_pointer_cast<Parameter<CartesianPose>>(param)->get_value().CartesianPose::from_std_vector(value);
+          std::static_pointer_cast<Parameter<CartesianPose>>(param)->get_value().CartesianPose::set_data(value);
           break;
         }
 
         case StateType::PARAMETER_JOINTSTATE: {
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-          std::static_pointer_cast<Parameter<JointState>>(param)->get_value().from_std_vector(value);
+          std::static_pointer_cast<Parameter<JointState>>(param)->get_value().set_data(value);
           break;
         }
 
         case StateType::PARAMETER_JOINTPOSITIONS: {
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-          std::static_pointer_cast<Parameter<JointPositions>>(param)->get_value().JointPositions::from_std_vector(value);
+          std::static_pointer_cast<Parameter<JointPositions>>(param)->get_value().JointPositions::set_data(value);
           break;
         }
 
         case StateType::PARAMETER_ELLIPSOID: {
           std::vector<double> value = this->get_parameter(param->get_name()).as_double_array();
-          std::static_pointer_cast<Parameter<Ellipsoid>>(param)->get_value().from_std_vector(value);
+          std::static_pointer_cast<Parameter<Ellipsoid>>(param)->get_value().set_data(value);
           break;
         }
 


### PR DESCRIPTION
Due to the latest push in `control_libraries` that removes `from_std_vector`, `modulo` was in a broken state. This PR fixes it by using `set_data`. It also introduces a new Dockerfile structure that allow to create a remote development server even if modulo is not compiling. This might need to change the CI handles the images.