### PR TITLE
Fix CI with two Dockerfiles

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -21,7 +21,8 @@ jobs:
 
       - name: Build image
         run: |
-          docker build . --file ./Dockerfile  --tag modulo
+          docker build . --file ./Dockerfile.development  --tag dev-image
+          docker build . --file ./Dockerfile.production --build-arg BASE_IMAGE=dev-image --tag modulo
       - name: Login to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,5 +1,6 @@
 ARG ROS_VERSION=foxy
-FROM aica-technology/modulo/development:${ROS_VERSION} as remote-development
+ARG BASE_IMAGE=aica-technology/modulo/development:${ROS_VERSION}
+FROM ${BASE_IMAGE} as remote-development
 
 # build modulo
 RUN su ${USER} -c /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"


### PR DESCRIPTION
Due to the new Dockerfiles, the CI is broken. I needed to introduce an argument BASE_IMAGE for the production image such that the it can be based on a random name in the CI (the name there is `dev-image`)