### PR TITLE
Improve the script to build also the production image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
 ROS_VERSION=foxy
 
-TARGET=development
+BUILD_PROD=false
 IMAGE_NAME=aica-technology/modulo
 
-BUILD_FLAGS=()
+PARAM_BUILD_FLAGS=()
 
-while getopts 'r' opt; do
+while [[ $# -gt 0 ]]; do
+  opt="$1"
   case $opt in
-    r) BUILD_FLAGS+=(--no-cache) ;;
+    -p|--production) BUILD_PROD=true ; shift ;;
+    -r|--rebuild) PARAM_BUILD_FLAGS+=(--no-cache) ; shift ;;
     *) echo 'Error in command line parsing' >&2
        exit 1
   esac
 done
-shift "$(( OPTIND - 1 ))"
 
-
+BUILD_FLAGS=()
 BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}/${TARGET}":"${ROS_VERSION}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}/development":"${ROS_VERSION}")
+BUILD_FLAGS+=("${PARAM_BUILD_FLAGS[@]}")
 
-docker pull ghcr.io/aica-technology/ros2-ws:"${ROS_VERSION}"
-DOCKER_BUILDKIT=1 docker build --file ./Dockerfile.${TARGET} "${BUILD_FLAGS[@]}" .
+docker pull ghcr.io/aica-technology/ros2-control-libraries:"${ROS_VERSION}"
+DOCKER_BUILDKIT=1 docker build --file ./Dockerfile.development "${BUILD_FLAGS[@]}" .
+
+if [ $BUILD_PROD = true ]; then
+  BUILD_FLAGS=()
+  BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+  BUILD_FLAGS+=(-t "${IMAGE_NAME}/production":"${ROS_VERSION}")
+  BUILD_FLAGS+=("${PARAM_BUILD_FLAGS[@]}")
+  DOCKER_BUILDKIT=1 docker build --file ./Dockerfile.production "${BUILD_FLAGS[@]}" .
+fi

--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,25 @@ ROS_VERSION=foxy
 BUILD_PROD=false
 IMAGE_NAME=aica-technology/modulo
 
-PARAM_BUILD_FLAGS=()
+HELP_MESSAGE="Usage: build.sh [-p] [-r]
 
+Options:
+  -p, --production       Build the production ready image on top of
+                         of the development one.
+
+  -r, --rebuild          Rebuild the image(s) using the docker
+                         --no-cache option
+"
+
+PARAM_BUILD_FLAGS=()
 while [[ $# -gt 0 ]]; do
   opt="$1"
   case $opt in
     -p|--production) BUILD_PROD=true ; shift ;;
     -r|--rebuild) PARAM_BUILD_FLAGS+=(--no-cache) ; shift ;;
+    -h|--help) echo "${HELP_MESSAGE}" ; exit 0 ;;
     *) echo 'Error in command line parsing' >&2
+       echo -e "\n${HELP_MESSAGE}"
        exit 1
   esac
 done

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ DOCKER_BUILDKIT=1 docker build --file ./Dockerfile.development "${BUILD_FLAGS[@]
 if [ $BUILD_PROD = true ]; then
   BUILD_FLAGS=()
   BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
-  BUILD_FLAGS+=(-t "${IMAGE_NAME}/production":"${ROS_VERSION}")
+  BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${ROS_VERSION}")
   BUILD_FLAGS+=("${PARAM_BUILD_FLAGS[@]}")
   DOCKER_BUILDKIT=1 docker build --file ./Dockerfile.production "${BUILD_FLAGS[@]}" .
 fi


### PR DESCRIPTION
The current building process for the development and production image was not very convenient as it required to modify the script in case you wanted to build the production image. This PR introduces the `-p|--production` option to the script to build the production image. Note that it also build the development one first and uses the `-r` option if provided. This PR also correct the pulled image which was not changed to `ros2-contol-libraries`