### PR TITLE
Modify build script for production by default

### DIFF
--- a/build-server.sh
+++ b/build-server.sh
@@ -37,7 +37,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 docker pull ghcr.io/aica-technology/ros2-control-libraries:"${ROS_VERSION}"
-DOCKER_BUILDKIT=1 docker build -t "${IMAGE_NAME}/${IMAGE_TAG}" "${BUILD_FLAGS[@]}" . || exit 1
+DOCKER_BUILDKIT=1 docker build -t "${IMAGE_NAME}:${IMAGE_TAG}" "${BUILD_FLAGS[@]}" . || exit 1
 
 if [ "${SERVE_REMOTE}" = true ]; then
   aica-docker server "${IMAGE_NAME}/${IMAGE_TAG}" -u ros2 -p "${REMOTE_SSH_PORT}"

--- a/build-server.sh
+++ b/build-server.sh
@@ -40,5 +40,5 @@ docker pull ghcr.io/aica-technology/ros2-control-libraries:"${ROS_VERSION}"
 DOCKER_BUILDKIT=1 docker build -t "${IMAGE_NAME}:${IMAGE_TAG}" "${BUILD_FLAGS[@]}" . || exit 1
 
 if [ "${SERVE_REMOTE}" = true ]; then
-  aica-docker server "${IMAGE_NAME}/${IMAGE_TAG}" -u ros2 -p "${REMOTE_SSH_PORT}"
+  aica-docker server "${IMAGE_NAME}:${IMAGE_TAG}" -u ros2 -p "${REMOTE_SSH_PORT}"
 fi


### PR DESCRIPTION
This PR adopts the paradigm where the default layer should be production not development. This way you can directly serve a production server or a development one.

One thing to note is that serving a development server, then a production one will generate an error as the two images do not have the same name. Thus, docker will complain that the port is already use.