### PR TITLE
Change the underlying message type to UInt8MultiArray

### DIFF
--- a/source/modulo_core/include/modulo_core/communication/EncodedState.hpp
+++ b/source/modulo_core/include/modulo_core/communication/EncodedState.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <std_msgs/msg/byte_multi_array.hpp>
+#include <std_msgs/msg/u_int8_multi_array.hpp>
 
 namespace modulo::core {
-	typedef std_msgs::msg::ByteMultiArray EncodedState;
+	typedef std_msgs::msg::UInt8MultiArray EncodedState;
 }


### PR DESCRIPTION
This PR is complementary to https://github.com/aica-technology/dynamic-components/pull/20. With this, both `python` and `c++` versions of the encode state transfer are consistent.

This has been tested on the examples. Note that the examples have trouble running at the moment due to the changes made on the `Parameters`. Thus, this need to be the next fix.