### PR TITLE
Remove the pure virtual step function

### DIFF
--- a/source/modulo_core/include/modulo_core/Component.hpp
+++ b/source/modulo_core/include/modulo_core/Component.hpp
@@ -136,11 +136,6 @@ public:
    * @return the list of predicates
    */
   const std::list<std::shared_ptr<state_representation::Predicate>> get_predicates() const;
-
-  /**
-   * @brief Function computing one step of calculation. It is called periodically in the run function.
-   */
-  virtual void step() override = 0;
 };
 
 template <typename DurationT>


### PR DESCRIPTION
In `Component`, the `step` function was overwritten to be declared as pure virtual which does not really make sense. This PR simply removes it from the header.