### PR TITLE
Use translators in MessagePair

### DIFF
--- a/source/modulo_core/include/modulo_core/Cell.hpp
+++ b/source/modulo_core/include/modulo_core/Cell.hpp
@@ -12,6 +12,7 @@
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <rclcpp_lifecycle/lifecycle_publisher.hpp>
 #include <rcutils/logging_macros.h>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
 #include <state_representation/parameters/Parameter.hpp>
 #include <state_representation/parameters/ParameterInterface.hpp>
 #include <string>

--- a/source/modulo_core/include/modulo_core/communication/message_passing/TransformListenerHandler.hpp
+++ b/source/modulo_core/include/modulo_core/communication/message_passing/TransformListenerHandler.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <state_representation/space/cartesian/CartesianPose.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
@@ -3,10 +3,11 @@
 #include "modulo_new_core/communication/MessagePairInterface.hpp"
 #include "modulo_new_core/translators/WriteStateConversion.hpp"
 
+#include <rclcpp/clock.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
-#include <std_msgs/msg/int64.hpp>
+#include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
 
 namespace modulo_new_core::communication {
@@ -15,9 +16,10 @@ template<typename MsgT, typename DataT>
 class MessagePair : public MessagePairInterface {
 private:
   std::shared_ptr<DataT> data_;
+  std::shared_ptr<rclcpp::Clock> clock_;
 
 public:
-  explicit MessagePair(std::shared_ptr<DataT> data);
+  MessagePair(std::shared_ptr<DataT> data, std::shared_ptr<rclcpp::Clock> clock);
 
   [[nodiscard]] MsgT write_message() const;
 
@@ -27,9 +29,7 @@ public:
 template<typename MsgT, typename DataT>
 MsgT MessagePair<MsgT, DataT>::write_message() const {
   auto msg = MsgT();
-  // TODO use translators
-  //  translators::write_msg(msg, *this->data_);
-  msg.data = *this->data_;
+  translators::write_msg(msg, *this->data_, clock_->now());
   return msg;
 }
 

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePairInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePairInterface.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <memory>
+
 #include "modulo_new_core/communication/MessageType.hpp"
+#include "modulo_new_core/exceptions/InvalidMessagePairCastException.hpp"
+#include "modulo_new_core/exceptions/InvalidPointerException.hpp"
 
 namespace modulo_new_core::communication {
 
@@ -36,13 +39,13 @@ inline std::shared_ptr<MessagePair<MsgT, DataT>> MessagePairInterface::get_messa
     message_pair_ptr = std::dynamic_pointer_cast<MessagePair<MsgT, DataT>>(this->shared_from_this());
   } catch (const std::exception& ex) {
     if (validate_pointer) {
-      // TODO proper exception
-      throw std::runtime_error("MessagePair interface is not managed by a valid pointer");
+      throw exceptions::InvalidPointerException("Message pair interface is not managed by a valid pointer");
     }
   }
   if (message_pair_ptr == nullptr && validate_pointer) {
-    // TODO proper exception
-    throw std::runtime_error("Unable to cast MessagePair interface");
+    throw exceptions::InvalidMessagePairCastException(
+        "Unable to case message pair interface to a message pair pointer of requested type"
+    );
   }
   return message_pair_ptr;
 }

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessageType.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessageType.hpp
@@ -3,7 +3,7 @@
 namespace modulo_new_core::communication {
 
 enum class MessageType {
-  BOOL, FLOAT64, FLOAT64_MULTI_ARRAY, INT64, STRING
+  BOOL, FLOAT64, FLOAT64_MULTI_ARRAY, INT32, STRING
 };
 
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/include/modulo_new_core/exceptions/InvalidMessagePairCastException.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/exceptions/InvalidMessagePairCastException.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace modulo_new_core::exceptions {
+class InvalidMessagePairCastException : public std::runtime_error {
+public:
+  explicit InvalidMessagePairCastException(const std::string& msg) : std::runtime_error(msg) {};
+};
+}

--- a/source/modulo_new_core/include/modulo_new_core/exceptions/InvalidPointerException.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/exceptions/InvalidPointerException.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace modulo_new_core::exceptions {
+class InvalidPointerException : public std::runtime_error {
+public:
+  explicit InvalidPointerException(const std::string& msg) : std::runtime_error(msg) {};
+};
+}

--- a/source/modulo_new_core/include/modulo_new_core/translators/ReadStateConversion.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/ReadStateConversion.hpp
@@ -5,21 +5,36 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
-#include <nav_msgs/msg/odometry.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <std_msgs/msg/float64_multi_array.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
-#include <tf2_msgs/msg/tf_message.hpp>
 
 #include <clproto.h>
 #include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/space/cartesian/CartesianPose.hpp>
 #include <state_representation/space/cartesian/CartesianState.hpp>
-#include <state_representation/space/cartesian/CartesianTwist.hpp>
-#include <state_representation/space/cartesian/CartesianWrench.hpp>
 #include <state_representation/space/joint/JointState.hpp>
 
 #include "modulo_new_core/EncodedState.hpp"
 
 namespace modulo_new_core::translators {
+
+/**
+ * @brief Convert a ROS geometry_msgs::msg::Accel to a CartesianState
+ * @param state The CartesianState to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Accel& msg);
+
+/**
+ * @brief Convert a ROS geometry_msgs::msg::AccelStamped to a CartesianState
+ * @param state The CartesianState to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::AccelStamped& msg);
+
 /**
  * @brief Convert a ROS geometry_msgs::msg::Pose to a CartesianState
  * @param state The CartesianState to populate
@@ -63,20 +78,6 @@ void read_msg(state_representation::CartesianState& state, const geometry_msgs::
 void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::TwistStamped& msg);
 
 /**
- * @brief Convert a ROS geometry_msgs::msg::Accel to a CartesianState
- * @param state The CartesianState to populate
- * @param msg The ROS msg to read from
- */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Accel& msg);
-
-/**
- * @brief Convert a ROS geometry_msgs::msg::AccelStamped to a CartesianState
- * @param state The CartesianState to populate
- * @param msg The ROS msg to read from
- */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::AccelStamped& msg);
-
-/**
  * @brief Convert a ROS geometry_msgs::msg::Wrench to a CartesianState
  * @param state The CartesianState to populate
  * @param msg The ROS msg to read from
@@ -89,13 +90,6 @@ void read_msg(state_representation::CartesianState& state, const geometry_msgs::
  * @param msg The ROS msg to read from
  */
 void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::WrenchStamped& msg);
-
-/**
- * @brief Convert a ROS geometry_msgs::msg::WrenchStamped to a CartesianState
- * @param state The CartesianState to populate
- * @param msg The ROS msg to read from
- */
-void read_msg(state_representation::CartesianState& state, const nav_msgs::msg::Odometry& msg);
 
 /**
  * @brief Convert a ROS sensor_msgs::msg::JointState to a JointState
@@ -117,13 +111,48 @@ void read_msg(state_representation::Parameter<T>& state, const U& msg) {
 }
 
 /**
+ * @brief Convert a ROS std_msgs::msg::Bool to a boolean
+ * @param state The state to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(bool& state, const std_msgs::msg::Bool& msg);
+
+/**
+ * @brief Convert a ROS std_msgs::msg::Float64 to a double
+ * @param state The state to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(double& state, const std_msgs::msg::Float64& msg);
+
+/**
+ * @brief Convert a ROS std_msgs::msg::Float64MultiArray to a vector of double
+ * @param state The state to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(std::vector<double>& state, const std_msgs::msg::Float64MultiArray& msg);
+
+/**
+ * @brief Convert a ROS std_msgs::msg::Int32 to an integer
+ * @param state The state to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(int& state, const std_msgs::msg::Int32& msg);
+
+/**
+ * @brief Convert a ROS std_msgs::msg::String to a string
+ * @param state The state to populate
+ * @param msg The ROS msg to read from
+ */
+void read_msg(std::string& state, const std_msgs::msg::String& msg);
+
+/**
  * @brief Convert a ROS std_msgs::msg::UInt8MultiArray message to a State using protobuf decoding
  * @tparam a state_representation::State type object
  * @param state The state to populate
  * @param msg The ROS msg to read from
  */
 template <typename T>
-void read_msg(T& state, const EncodedState& msg) {
+inline void read_msg(T& state, const EncodedState& msg) {
   std::string tmp(msg.data.begin(), msg.data.end());
   state = clproto::decode<T>(tmp);
 }

--- a/source/modulo_new_core/include/modulo_new_core/translators/WriteStateConversion.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/WriteStateConversion.hpp
@@ -6,21 +6,23 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/float64.hpp>
+#include <std_msgs/msg/float64_multi_array.hpp>
+#include <std_msgs/msg/int32.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include <clproto.h>
-#include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/exceptions/EmptyStateException.hpp>
-#include <state_representation/space/joint/JointState.hpp>
-#include <state_representation/space/cartesian/CartesianPose.hpp>
 #include <state_representation/space/cartesian/CartesianState.hpp>
-#include <state_representation/space/cartesian/CartesianTwist.hpp>
-#include <state_representation/space/cartesian/CartesianWrench.hpp>
+#include <state_representation/space/joint/JointState.hpp>
+#include <state_representation/parameters/Parameter.hpp>
 
 #include "modulo_new_core/EncodedState.hpp"
 
 namespace modulo_new_core::translators {
+
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Accel
  * @param msg The ROS msg to populate
@@ -36,14 +38,6 @@ void write_msg(geometry_msgs::msg::Accel& msg, const state_representation::Carte
  * @param time The time of the message
  */
 void write_msg(geometry_msgs::msg::AccelStamped& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
-
-/**
- * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Quaternion
- * @param msg The ROS msg to populate
- * @param state The state to read from
- * @param time The time of the message
- */
-void write_msg(geometry_msgs::msg::Quaternion& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Pose
@@ -137,6 +131,41 @@ template <typename U, typename T>
 void write_msg(U& msg, const state_representation::Parameter<T>& state, const rclcpp::Time&);
 
 /**
+ * @brief Convert a boolean to a ROS std_msgs::msg::Bool
+ * @param msg The ROS msg to populate
+ * @param state The state to read from
+ */
+void write_msg(std_msgs::msg::Bool& msg, const bool& state, const rclcpp::Time& time);
+
+/**
+ * @brief Convert a double to a ROS std_msgs::msg::Float64
+ * @param msg The ROS msg to populate
+ * @param state The state to read from
+ */
+void write_msg(std_msgs::msg::Float64& msg, const double& state, const rclcpp::Time& time);
+
+/**
+ * @brief Convert a vector of double to a ROS std_msgs::msg::Float64MultiArray
+ * @param msg The ROS msg to populate
+ * @param state The state to read from
+ */
+void write_msg(std_msgs::msg::Float64MultiArray& msg, const std::vector<double>& state, const rclcpp::Time& time);
+
+/**
+ * @brief Convert an integer to a ROS std_msgs::msg::Int32
+ * @param msg The ROS msg to populate
+ * @param state The state to read from
+ */
+void write_msg(std_msgs::msg::Int32& msg, const int& state, const rclcpp::Time& time);
+
+/**
+ * @brief Convert a string to a ROS std_msgs::msg::String
+ * @param msg The ROS msg to populate
+ * @param state The state to read from
+ */
+void write_msg(std_msgs::msg::String& msg, const std::string& state, const rclcpp::Time& time);
+
+/**
  * @brief Convert a state to a ROS std_msgs::msg::UInt8MultiArray message using protobuf encoding
  * @tparam a state_representation::State type object
  * @param msg The ROS msg to populate
@@ -144,7 +173,7 @@ void write_msg(U& msg, const state_representation::Parameter<T>& state, const rc
  * @param time The time of the message
  */
 template <typename T>
-void write_msg(EncodedState& msg, const T& state, const rclcpp::Time&) {
+inline void write_msg(EncodedState& msg, const T& state, const rclcpp::Time&) {
   std::string tmp = clproto::encode<T>(state);
   msg.data = std::vector<unsigned char>(tmp.begin(), tmp.end());
 }

--- a/source/modulo_new_core/package.xml
+++ b/source/modulo_new_core/package.xml
@@ -12,9 +12,9 @@
 
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
-  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>tf2_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/source/modulo_new_core/src/communication/MessagePair.cpp
+++ b/source/modulo_new_core/src/communication/MessagePair.cpp
@@ -5,23 +5,29 @@
 namespace modulo_new_core::communication {
 
 template<>
-MessagePair<std_msgs::msg::Bool, bool>::MessagePair(std::shared_ptr<bool>  data) :
-    MessagePairInterface(MessageType::BOOL), data_(std::move(data)) {}
+MessagePair<std_msgs::msg::Bool, bool>::MessagePair(std::shared_ptr<bool> data, std::shared_ptr<rclcpp::Clock> clock) :
+    MessagePairInterface(MessageType::BOOL), data_(std::move(data)), clock_(std::move(clock)) {}
 
 template<>
-MessagePair<std_msgs::msg::Float64, double>::MessagePair(std::shared_ptr<double>  data) :
-    MessagePairInterface(MessageType::FLOAT64), data_(std::move(data)) {}
+MessagePair<std_msgs::msg::Float64, double>::MessagePair(
+    std::shared_ptr<double> data, std::shared_ptr<rclcpp::Clock> clock
+) :
+    MessagePairInterface(MessageType::FLOAT64), data_(std::move(data)), clock_(std::move(clock)) {}
 
 template<>
-MessagePair<std_msgs::msg::Float64MultiArray, std::vector<double>>::MessagePair(std::shared_ptr<std::vector<double>>  data) :
-    MessagePairInterface(MessageType::FLOAT64_MULTI_ARRAY), data_(std::move(data)) {}
+MessagePair<std_msgs::msg::Float64MultiArray, std::vector<double>>::MessagePair(
+    std::shared_ptr<std::vector<double>> data, std::shared_ptr<rclcpp::Clock> clock
+) :
+    MessagePairInterface(MessageType::FLOAT64_MULTI_ARRAY), data_(std::move(data)), clock_(std::move(clock)) {}
 
 template<>
-MessagePair<std_msgs::msg::Int64, int>::MessagePair(std::shared_ptr<int>  data) :
-    MessagePairInterface(MessageType::INT64), data_(std::move(data)) {}
+MessagePair<std_msgs::msg::Int32, int>::MessagePair(std::shared_ptr<int> data, std::shared_ptr<rclcpp::Clock> clock) :
+    MessagePairInterface(MessageType::INT32), data_(std::move(data)), clock_(std::move(clock)) {}
 
 template<>
-MessagePair<std_msgs::msg::String, std::string>::MessagePair(std::shared_ptr<std::string>  data) :
-    MessagePairInterface(MessageType::STRING), data_(std::move(data)) {}
+MessagePair<std_msgs::msg::String, std::string>::MessagePair(
+    std::shared_ptr<std::string> data, std::shared_ptr<rclcpp::Clock> clock
+) :
+    MessagePairInterface(MessageType::STRING), data_(std::move(data)), clock_(std::move(clock)) {}
 
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/src/translators/ReadStateConversion.cpp
+++ b/source/modulo_new_core/src/translators/ReadStateConversion.cpp
@@ -77,4 +77,24 @@ void read_msg(state_representation::JointState& state, const sensor_msgs::msg::J
     state.set_torques(Eigen::VectorXd::Map(msg.effort.data(), msg.effort.size()));
   }
 }
+
+void read_msg(bool& state, const std_msgs::msg::Bool& msg) {
+  state = msg.data;
+}
+
+void read_msg(double& state, const std_msgs::msg::Float64& msg) {
+  state = msg.data;
+}
+
+void read_msg(std::vector<double>& state, const std_msgs::msg::Float64MultiArray& msg) {
+  state = msg.data;
+}
+
+void read_msg(int& state, const std_msgs::msg::Int32& msg) {
+  state = msg.data;
+}
+
+void read_msg(std::string& state, const std_msgs::msg::String& msg) {
+  state = msg.data;
+}
 }// namespace modulo_new_core::translators

--- a/source/modulo_new_core/src/translators/WriteStateConversion.cpp
+++ b/source/modulo_new_core/src/translators/WriteStateConversion.cpp
@@ -1,9 +1,7 @@
 #include "modulo_new_core/translators/WriteStateConversion.hpp"
 
-#include <std_msgs/msg/bool.hpp>
-#include <std_msgs/msg/float64.hpp>
-#include <std_msgs/msg/float64_multi_array.hpp>
-#include <std_msgs/msg/string.hpp>
+#include <state_representation/exceptions/EmptyStateException.hpp>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
 
 using namespace state_representation;
 
@@ -28,27 +26,6 @@ static void write_quaternion(geometry_msgs::msg::Quaternion& msg, const Eigen::Q
   msg.z = quat.z();
 }
 
-void write_msg(geometry_msgs::msg::Point& msg, const CartesianState& state, const rclcpp::Time&) {
-  if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
-  }
-  write_point(msg, state.get_position());
-}
-
-void write_msg(geometry_msgs::msg::Vector3& msg, const CartesianState& state, const rclcpp::Time&) {
-  if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
-  }
-  write_vector3(msg, state.get_position());
-}
-
-void write_msg(geometry_msgs::msg::Quaternion& msg, const CartesianState& state, const rclcpp::Time&) {
-  if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
-  }
-  write_quaternion(msg, state.get_orientation());
-}
-
 void write_msg(geometry_msgs::msg::Accel& msg, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
@@ -62,7 +39,6 @@ void write_msg(geometry_msgs::msg::AccelStamped& msg, const CartesianState& stat
   msg.header.stamp = time;
   msg.header.frame_id = state.get_reference_frame();
 }
-
 
 void write_msg(geometry_msgs::msg::Pose& msg, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
@@ -170,5 +146,25 @@ void write_msg(geometry_msgs::msg::TransformStamped& msg, const Parameter<Cartes
 template <>
 void write_msg(tf2_msgs::msg::TFMessage& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
   write_msg(msg, state.get_value(), time);
+}
+
+void write_msg(std_msgs::msg::Bool& msg, const bool& state, const rclcpp::Time&) {
+  msg.data = state;
+}
+
+void write_msg(std_msgs::msg::Float64& msg, const double& state, const rclcpp::Time&) {
+  msg.data = state;
+}
+
+void write_msg(std_msgs::msg::Float64MultiArray& msg, const std::vector<double>& state, const rclcpp::Time&) {
+  msg.data = state;
+}
+
+void write_msg(std_msgs::msg::Int32& msg, const int& state, const rclcpp::Time&) {
+  msg.data = state;
+}
+
+void write_msg(std_msgs::msg::String& msg, const std::string& state, const rclcpp::Time&) {
+  msg.data = state;
 }
 }// namespace modulo_new_core::translators

--- a/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
@@ -5,9 +5,10 @@
 using namespace modulo_new_core::communication;
 
 template<typename MsgT, typename DataT>
-static void test_message_interface(const DataT& initial_value, const DataT& new_value) {
+static void
+test_message_interface(const DataT& initial_value, const DataT& new_value, const std::shared_ptr<rclcpp::Clock> clock) {
   auto data = std::make_shared<DataT>(initial_value);
-  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data);
+  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, clock);
   EXPECT_EQ(initial_value, *msg_pair->get_data());
   EXPECT_EQ(initial_value, msg_pair->write_message().data);
 
@@ -22,17 +23,26 @@ static void test_message_interface(const DataT& initial_value, const DataT& new_
   EXPECT_EQ(new_value, msg.data);
 }
 
-TEST(MessagePairTest, TestBasicTypes) {
-  test_message_interface<std_msgs::msg::Bool, bool>(false, true);
-  test_message_interface<std_msgs::msg::Float64, double>(0.1, 0.2);
-  test_message_interface<std_msgs::msg::Int64, int>(1, 2);
-  test_message_interface<std_msgs::msg::String, std::string>("this", "that");
+class MessagePairTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    clock_ = std::make_shared<rclcpp::Clock>();
+  }
+
+  std::shared_ptr<rclcpp::Clock> clock_;
+};
+
+TEST_F(MessagePairTest, TestBasicTypes) {
+  test_message_interface<std_msgs::msg::Bool, bool>(false, true, clock_);
+  test_message_interface<std_msgs::msg::Float64, double>(0.1, 0.2, clock_);
+  test_message_interface<std_msgs::msg::Int32, int>(1, 2, clock_);
+  test_message_interface<std_msgs::msg::String, std::string>("this", "that", clock_);
 }
 
-TEST(MessagePairTest, TestDoubleArray) {
+TEST_F(MessagePairTest, TestDoubleArray) {
   std::vector<double> initial_value = {0.1, 0.2, 0.3};
   auto data = std::make_shared<std::vector<double>>(initial_value);
-  auto msg_pair = std::make_shared<MessagePair<std_msgs::msg::Float64MultiArray, std::vector<double>>>(data);
+  auto msg_pair = std::make_shared<MessagePair<std_msgs::msg::Float64MultiArray, std::vector<double>>>(data, clock_);
   for (std::size_t i = 0; i < initial_value.size(); ++i) {
     EXPECT_EQ(initial_value.at(i), msg_pair->get_data()->at(i));
     EXPECT_EQ(initial_value.at(i), msg_pair->write_message().data.at(i));
@@ -41,7 +51,7 @@ TEST(MessagePairTest, TestDoubleArray) {
   std::shared_ptr<MessagePairInterface> msg_pair_interface(msg_pair);
   auto msg = msg_pair_interface->write_message<std_msgs::msg::Float64MultiArray, std::vector<double>>();
   for (std::size_t i = 0; i < initial_value.size(); ++i) {
-    EXPECT_EQ(initial_value.at(i),msg.data.at(i));
+    EXPECT_EQ(initial_value.at(i), msg.data.at(i));
   }
   EXPECT_EQ(initial_value, msg.data);
 
@@ -51,6 +61,6 @@ TEST(MessagePairTest, TestDoubleArray) {
   for (std::size_t i = 0; i < new_value.size(); ++i) {
     EXPECT_EQ(new_value.at(i), msg_pair->get_data()->at(i));
     EXPECT_EQ(new_value.at(i), msg_pair->write_message().data.at(i));
-    EXPECT_EQ(new_value.at(i),msg.data.at(i));
+    EXPECT_EQ(new_value.at(i), msg.data.at(i));
   }
 }


### PR DESCRIPTION
In order to use the translator functions in `MessagePair::write_message()`, I had to implement those translations first, which is what I'm doing here.
Additionally, I added two exceptions to handle pointer casting better.

A point that we can maybe discuss if if the MessagePair should hold it's own clock (initialized from the constructor), or if the `write_message` should take an argument which would be either time or clock

@buschbapti 