### PR TITLE
Add the base ComponentInterface class in python

### DIFF
--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -30,6 +30,9 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
     ${PROJECT_SOURCE_DIR}/src/Component.cpp
     ${PROJECT_SOURCE_DIR}/src/LifecycleComponent.cpp)
 
+# Install Python modules
+ament_python_install_package(${PROJECT_NAME} SCRIPTS_DESTINATION lib/${PROJECT_NAME})
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -156,7 +156,6 @@ void ComponentInterface<NodeT>::add_variant_predicate(
     this->predicates_.at(name) = predicate;
   } else {
     this->predicates_.insert(std::make_pair(name, predicate));
-    // TODO add publisher with message interface
     this->predicate_publishers_.insert(
         std::make_pair(
             name, this->template create_publisher<std_msgs::msg::Bool>(this->generate_predicate_topic(name), 10)));

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -48,8 +48,8 @@ protected:
   void add_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function);
 
   /**
-   * @brief Get the value of the predicate given as parameter, if the predicate is not found or the callable function
-   * fails return false
+   * @brief Get the logical value of a predicate.
+   * @details If the predicate is not found or the callable function fails, the return value is false.
    * @param predicate_name the name of the predicate to retrieve from the
    * map of predicates
    * @return the value of the predicate as a boolean

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -48,7 +48,8 @@ protected:
   void add_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function);
 
   /**
-   * @brief Get the value of the predicate given as parameter
+   * @brief Get the value of the predicate given as parameter, if the predicate is not found or the callable function
+   * fails return false
    * @param predicate_name the name of the predicate to retrieve from the
    * map of predicates
    * @return the value of the predicate as a boolean
@@ -56,7 +57,7 @@ protected:
   [[nodiscard]] bool get_predicate(const std::string& predicate_name) const;
 
   /**
-   * @brief Set the value of the predicate given as parameter
+   * @brief Set the value of the predicate given as parameter, if the predicate is not found does not do anything
    * @param predicate_name the name of the predicate to retrieve from the
    * map of predicates
    * @param predicate_value the new value of the predicate
@@ -64,10 +65,10 @@ protected:
   void set_predicate(const std::string& predicate_name, bool predicate_value);
 
   /**
-   * @brief Set the value of the predicate given as parameter
+   * @brief Set the value of the predicate given as parameter, if the predicate is not found does not do anything
    * @param predicate_name the name of the predicate to retrieve from the
    * map of predicates
-   * @param predicate_function the function to periodically call that returns the value of the predicate
+   * @param predicate_function the function to call that returns the value of the predicate
    */
   void set_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function);
 

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -1,0 +1,102 @@
+from rclpy.node import Node
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+from tf2_ros import TransformBroadcaster
+from rcl_interfaces.msg import ParameterDescriptor
+from std_msgs.msg import Bool
+
+from typing import Union
+from typing import Callable
+
+
+class ComponentInterface(Node):
+    """
+    Abstract class to represent a Component in python, following the same logic pattern
+    as the c++ modulo_component::ComponentInterface class.
+    ...
+    Attributes:
+        predicates (dict(Parameters(bool))): map of predicates added to the Component.
+        predicate_publishers (dict(rclpy.Publisher(Bool))): map of publishers associated to each predicate.
+        tf_buffer (tf2_ros.Buffer): the buffer to lookup transforms published on tf2.
+        tf_listener (tf2_ros.TransformListener): the listener to lookup transforms published on tf2.
+        tf_broadcaster (tf2_ros.TransformBroadcaster): the broadcaster to publish transforms on tf2
+    Parameters:
+        period (double): period (in s) between step function calls.
+        has_tf_listener (bool): if true, add a tf listener to enable calls to lookup transforms.
+        has_tf_broadcaster (bool): if true, add a tf broadcaster to enable the publishing of transforms.
+    """
+
+    def __init__(self, node_name, *kargs, **kwargs):
+        """
+        Constructs all the necessary attributes and declare all the parameters.
+            Parameters:
+                node_name (str): name of the node to be passed to the base Node class
+        """
+        super().__init__(node_name, *kargs, **kwargs)
+        self.declare_parameter('period', 0.1,
+                               ParameterDescriptor(description="Period (in s) between step function calls."))
+        self.declare_parameter('has_tf_listener', False,
+                               ParameterDescriptor(
+                                   description="If true, add a tf listener to enable calls to lookup transforms."))
+        self.declare_parameter('has_tf_broadcaster', False,
+                               ParameterDescriptor(
+                                   description="If true, add a tf broadcaster to enable the publishing of transforms."))
+
+        self._period = self.get_parameter('period').get_parameter_value().double_value
+        self._has_tf_listener = self.get_parameter('has_tf_listener').get_parameter_value().double_value
+        self._has_tf_broadcaster = self.get_parameter('has_tf_broadcaster').get_parameter_value().double_value
+        self._predicates = {}
+        self._predicates_publishers = {}
+
+        if self._has_tf_listener:
+            self.__tf_buffer = Buffer()
+            self.__tf_listener = TransformListener(self.__tf_buffer, self)
+        if self._has_tf_broadcaster:
+            self.__tf_broadcaster = TransformBroadcaster(self)
+
+        self.create_timer(self._period, self.__step)
+
+    def __step(self):
+        for predicate_name in self._predicates.keys():
+            msg = Bool()
+            msg.data = self.get_predicate(predicate_name)
+            if predicate_name not in self._predicates_publishers.keys():
+                self.get_logger().error(f"No publisher for predicate {predicate_name} found.",
+                                        throttle_duration_sec=1.0)
+                return
+            self._predicates_publishers[predicate_name].publish(msg)
+
+    def __generate_predicate_topic(self, predicate_name: str) -> str:
+        return f'/predicates/{self.get_name()}/{predicate_name}'
+
+    def add_predicate(self, predicate_name: str, predicate_value: Union[bool, Callable]):
+        if predicate_name in self._predicates.keys():
+            self.get_logger().debug(f"Predicate {predicate_name} already exists, overwriting.")
+        else:
+            # TODO: add publisher with message interface
+            self._predicates_publishers[predicate_name] = self.create_publisher(Bool, self.__generate_predicate_topic(
+                predicate_name), 10)
+        self._predicates[predicate_name] = predicate_value
+
+    def get_predicate(self, predicate_name: str) -> bool:
+        if predicate_name not in self._predicates.keys():
+            self.get_logger().error(f"Predicate {predicate_name} does not exists, returning false.",
+                                    throttle_duration_sec=1.0)
+            return False
+        value = self._predicates[predicate_name]
+        if callable(value):
+            bool_value = False
+            try:
+                bool_value = value()
+            except Exception as e:
+                self.get_logger().error(f"Error while evaluating the callback function: {e}",
+                                        throttle_duration_sec=1.0)
+            return bool_value
+        return value
+
+    def set_predicate(self, predicate_name: str, predicate_value: Union[bool, Callable]):
+        if predicate_name not in self._predicates.keys():
+            self.get_logger().error(f"Predicate {predicate_name} does not exists, can't set it with a new value.",
+                                    throttle_duration_sec=1.0)
+            return
+        self._predicates[predicate_name] = predicate_value

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -85,14 +85,14 @@ class ComponentInterface(Node):
 
     def get_predicate(self, predicate_name: str) -> bool:
         """
-        Get the value of the predicate given as parameter, if the predicate is not found or the callable function fails
+        Get the value of the predicate given as parameter. If the predicate is not found or the callable function fails,
         return false.
 
         :param predicate_name: the name of the predicate to retrieve from the map of predicates
         :return: the value of the predicate as a boolean
         """
         if predicate_name not in self._predicates.keys():
-            self.get_logger().error(f"Predicate {predicate_name} does not exists, returning false.",
+            self.get_logger().error(f"Predicate {predicate_name} does not exist, returning false.",
                                     throttle_duration_sec=1.0)
             return False
         value = self._predicates[predicate_name]
@@ -114,7 +114,7 @@ class ComponentInterface(Node):
         :param predicate_value: the new value of the predicate as a bool or a callable function
         """
         if predicate_name not in self._predicates.keys():
-            self.get_logger().error(f"Predicate {predicate_name} does not exists, can't set it with a new value.",
+            self.get_logger().error(f"Cannot set predicate {predicate_name} with a new value because it does not exist.",
                                     throttle_duration_sec=1.0)
             return
         self._predicates[predicate_name] = predicate_value

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -46,7 +46,7 @@ class ComponentInterface(Node):
         self._has_tf_listener = self.get_parameter('has_tf_listener').get_parameter_value().double_value
         self._has_tf_broadcaster = self.get_parameter('has_tf_broadcaster').get_parameter_value().double_value
         self._predicates = {}
-        self._predicates_publishers = {}
+        self._predicate_publishers = {}
 
         if self._has_tf_listener:
             self.__tf_buffer = Buffer()
@@ -60,11 +60,11 @@ class ComponentInterface(Node):
         for predicate_name in self._predicates.keys():
             msg = Bool()
             msg.data = self.get_predicate(predicate_name)
-            if predicate_name not in self._predicates_publishers.keys():
+            if predicate_name not in self._predicate_publishers.keys():
                 self.get_logger().error(f"No publisher for predicate {predicate_name} found.",
                                         throttle_duration_sec=1.0)
                 return
-            self._predicates_publishers[predicate_name].publish(msg)
+            self._predicate_publishers[predicate_name].publish(msg)
 
     def __generate_predicate_topic(self, predicate_name: str) -> str:
         return f'/predicates/{self.get_name()}/{predicate_name}'
@@ -79,7 +79,7 @@ class ComponentInterface(Node):
         if predicate_name in self._predicates.keys():
             self.get_logger().debug(f"Predicate {predicate_name} already exists, overwriting.")
         else:
-            self._predicates_publishers[predicate_name] = self.create_publisher(Bool, self.__generate_predicate_topic(
+            self._predicate_publishers[predicate_name] = self.create_publisher(Bool, self.__generate_predicate_topic(
                 predicate_name), 10)
         self._predicates[predicate_name] = predicate_value
 

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -79,7 +79,6 @@ class ComponentInterface(Node):
         if predicate_name in self._predicates.keys():
             self.get_logger().debug(f"Predicate {predicate_name} already exists, overwriting.")
         else:
-            # TODO: add publisher with message interface
             self._predicates_publishers[predicate_name] = self.create_publisher(Bool, self.__generate_predicate_topic(
                 predicate_name), 10)
         self._predicates[predicate_name] = predicate_value

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -70,6 +70,12 @@ class ComponentInterface(Node):
         return f'/predicates/{self.get_name()}/{predicate_name}'
 
     def add_predicate(self, predicate_name: str, predicate_value: Union[bool, Callable]):
+        """
+        Add a predicate to the map of predicates.
+
+        :param predicate_name: the name of the associated predicate
+        :param predicate_value: the value of the predicate as a bool or a callable function
+        """
         if predicate_name in self._predicates.keys():
             self.get_logger().debug(f"Predicate {predicate_name} already exists, overwriting.")
         else:
@@ -79,6 +85,13 @@ class ComponentInterface(Node):
         self._predicates[predicate_name] = predicate_value
 
     def get_predicate(self, predicate_name: str) -> bool:
+        """
+        Get the value of the predicate given as parameter, if the predicate is not found or the callable function fails
+        return false.
+
+        :param predicate_name: the name of the predicate to retrieve from the map of predicates
+        :return: the value of the predicate as a boolean
+        """
         if predicate_name not in self._predicates.keys():
             self.get_logger().error(f"Predicate {predicate_name} does not exists, returning false.",
                                     throttle_duration_sec=1.0)
@@ -95,6 +108,12 @@ class ComponentInterface(Node):
         return value
 
     def set_predicate(self, predicate_name: str, predicate_value: Union[bool, Callable]):
+        """
+        Set the value of the predicate given as parameter, if the predicate is not found does not do anything.
+
+        :param predicate_name: the name of the predicate to retrieve from the map of predicates
+        :param predicate_value: the new value of the predicate as a bool or a callable function
+        """
         if predicate_name not in self._predicates.keys():
             self.get_logger().error(f"Predicate {predicate_name} does not exists, can't set it with a new value.",
                                     throttle_duration_sec=1.0)

--- a/source/modulo_components/test/python/conftest.py
+++ b/source/modulo_components/test/python/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+import rclpy
+
+
+@pytest.fixture
+def ros_context():
+    rclpy.init()
+    yield
+    rclpy.shutdown()

--- a/source/modulo_components/test/python/test_component_interface.py
+++ b/source/modulo_components/test/python/test_component_interface.py
@@ -1,0 +1,48 @@
+import pytest
+
+from modulo_components.component_interface import ComponentInterface
+
+
+def raise_(ex):
+    raise ex
+
+
+@pytest.fixture()
+def component_interface(ros_context):
+    yield ComponentInterface('component_interface')
+
+
+def test_add_bool_predicate(component_interface):
+    component_interface.add_predicate('foo', True)
+    assert 'foo' in component_interface._predicates.keys()
+    assert component_interface._predicates['foo']
+
+
+def test_add_function_predicate(component_interface):
+    component_interface.add_predicate('foo', lambda: False)
+    assert 'foo' in component_interface._predicates.keys()
+    assert not component_interface._predicates['foo']()
+
+
+def test_get_predicate(component_interface):
+    component_interface.add_predicate('foo', True)
+    assert component_interface.get_predicate('foo')
+    component_interface.add_predicate('bar', lambda: True)
+    assert component_interface.get_predicate('bar')
+    # predicate does not exist, expect false
+    assert not component_interface.get_predicate('test')
+    # error in callback function except false
+    component_interface.add_predicate('error', lambda: raise_(RuntimeError("An error occurred")))
+    assert not component_interface.get_predicate('error')
+
+
+def test_set_predicate(component_interface):
+    component_interface.add_predicate('foo', True)
+    component_interface.set_predicate('foo', False)
+    assert not component_interface.get_predicate('foo')
+    # predicate does not exist so setting won't do anything
+    component_interface.set_predicate('bar', True)
+    assert not component_interface.get_predicate('bar')
+    component_interface.add_predicate('bar', True)
+    component_interface.set_predicate('bar', lambda: False)
+    assert not component_interface.get_predicate('bar')


### PR DESCRIPTION
This PR introduces the `ComponentInterface` class in python with testing of the predicate interface.