### PR TITLE
Implementation of publisher interface

### DIFF
--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherHandler.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherHandler.hpp
@@ -11,6 +11,9 @@ public:
 
   void publish(const MsgT& message) const;
 
+  std::shared_ptr<PublisherInterface>
+  create_publisher_interface(const std::shared_ptr<MessagePairInterface>& message_pair);
+
 private:
   std::shared_ptr<PubT> publisher_;
 };
@@ -22,6 +25,15 @@ PublisherHandler<PubT, MsgT>::PublisherHandler(PublisherType type, std::shared_p
 template<typename PubT, typename MsgT>
 void PublisherHandler<PubT, MsgT>::publish(const MsgT& message) const {
   this->publisher_->publish(message);
+}
+
+template<typename PubT, typename MsgT>
+std::shared_ptr<PublisherInterface> PublisherHandler<PubT, MsgT>::create_publisher_interface(
+    const std::shared_ptr<MessagePairInterface>& message_pair
+) {
+  std::shared_ptr<PublisherInterface> publisher_interface(this->shared_from_this());
+  publisher_interface->set_message_pair(message_pair);
+  return publisher_interface;
 }
 
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
@@ -56,9 +56,4 @@ inline std::shared_ptr<PublisherHandler<PubT, MsgT>> PublisherInterface::get_pub
   return publisher_ptr;
 }
 
-static std::shared_ptr<PublisherInterface> create_publisher_interface(const std::shared_ptr<PublisherInterface>& publisher, const std::shared_ptr<MessagePairInterface>& message_pair) {
-  publisher->set_message_pair(message_pair);
-  return publisher;
-}
-
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
@@ -38,4 +38,28 @@ private:
   std::shared_ptr<MessagePairInterface> message_pair_;
 };
 
+template<typename PubT, typename MsgT>
+inline std::shared_ptr<PublisherHandler<PubT, MsgT>> PublisherInterface::get_publisher(bool validate_pointer) {
+  std::shared_ptr<PublisherHandler<PubT, MsgT>> publisher_ptr;
+  try {
+    publisher_ptr = std::dynamic_pointer_cast<PublisherHandler<PubT, MsgT>>(this->shared_from_this());
+  } catch (const std::exception& ex) {
+    if (validate_pointer) {
+      throw exceptions::InvalidPointerException("Publisher interface is not managed by a valid pointer");
+    }
+  }
+  if (publisher_ptr == nullptr && validate_pointer) {
+    throw exceptions::InvalidPointerCastException(
+        "Unable to cast publisher interface to a publisher pointer of requested type"
+    );
+  }
+  return publisher_ptr;
+}
+
+static std::shared_ptr<PublisherInterface> create_publisher_interface(const std::shared_ptr<PublisherInterface>& publisher, const std::shared_ptr<MessagePairInterface>& message_pair) {
+  auto pub = std::shared_ptr<PublisherInterface>(publisher);
+  pub->set_message_pair(message_pair);
+  return pub;
+}
+
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
@@ -57,9 +57,8 @@ inline std::shared_ptr<PublisherHandler<PubT, MsgT>> PublisherInterface::get_pub
 }
 
 static std::shared_ptr<PublisherInterface> create_publisher_interface(const std::shared_ptr<PublisherInterface>& publisher, const std::shared_ptr<MessagePairInterface>& message_pair) {
-  auto pub = std::shared_ptr<PublisherInterface>(publisher);
-  pub->set_message_pair(message_pair);
-  return pub;
+  publisher->set_message_pair(message_pair);
+  return publisher;
 }
 
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/src/communication/PublisherInterface.cpp
+++ b/source/modulo_new_core/src/communication/PublisherInterface.cpp
@@ -15,6 +15,51 @@ namespace modulo_new_core::communication {
 
 PublisherInterface::PublisherInterface(PublisherType type) : type_(type) {}
 
+void PublisherInterface::publish() {
+  if (this->message_pair_ == nullptr) {
+    throw exceptions::NullPointerException("Message pair is not set, nothing to publish");
+  }
+  switch (this->message_pair_->get_type()) {
+    case MessageType::BOOL:
+      this->publish(this->message_pair_->write<std_msgs::msg::Bool, bool>());
+      break;
+    case MessageType::FLOAT64:
+      this->publish(this->message_pair_->write<std_msgs::msg::Float64, double>());
+      break;
+    case MessageType::FLOAT64_MULTI_ARRAY:
+      this->publish(this->message_pair_->write<std_msgs::msg::Float64MultiArray, std::vector<double>>());
+      break;
+    case MessageType::INT32:
+      this->publish(this->message_pair_->write<std_msgs::msg::Int32, int>());
+      break;
+    case MessageType::STRING:
+      this->publish(this->message_pair_->write<std_msgs::msg::String, std::string>());
+      break;
+    case MessageType::ENCODED_STATE:
+      this->publish(this->message_pair_->write<EncodedState, state_representation::State>());
+      break;
+  }
+}
+
+template<typename MsgT>
+void PublisherInterface::publish(const MsgT& message) {
+  switch (this->get_type()) {
+    case PublisherType::PUBLISHER:
+      this->template get_publisher<rclcpp::Publisher<MsgT>, MsgT>()->publish(message);
+      break;
+    case PublisherType::LIFECYCLE_PUBLISHER:
+      this->template get_publisher<rclcpp_lifecycle::LifecyclePublisher<MsgT>, MsgT>()->publish(message);
+      break;
+  }
+}
+
+void PublisherInterface::set_message_pair(const std::shared_ptr<MessagePairInterface>& message_pair) {
+  if (message_pair == nullptr) {
+    throw exceptions::NullPointerException("Provide a valid pointer");
+  }
+  this->message_pair_ = message_pair;
+}
+
 PublisherType PublisherInterface::get_type() const {
   return this->type_;
 }

--- a/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <rclcpp/node.hpp>
+
+#include "modulo_new_core/communication/PublisherHandler.hpp"
+#include "modulo_new_core/communication/MessagePair.hpp"
+#include "modulo_new_core/exceptions/NullPointerException.hpp"
+
+using namespace modulo_new_core::communication;
+
+template<typename MsgT, typename DataT>
+static void test_publisher_interface(const std::shared_ptr<rclcpp::Node>& node, const DataT& value) {
+  // create message pair
+  auto data = std::make_shared<DataT>(value);
+  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, node->get_clock());
+
+  // create publisher handler
+  auto publisher = node->create_publisher<MsgT>("topic", 10);
+  auto publisher_handler =
+      std::make_shared<PublisherHandler<rclcpp::Publisher<MsgT>, MsgT>>(PublisherType::PUBLISHER, publisher);
+
+  // use in publisher interface
+  std::shared_ptr<PublisherInterface> publisher_interface(publisher_handler);
+  EXPECT_THROW(publisher_interface->publish(), modulo_new_core::exceptions::NullPointerException);
+  publisher_interface->set_message_pair(msg_pair);
+  EXPECT_NO_THROW(publisher_interface->publish());
+
+  publisher_interface = create_publisher_interface(publisher_handler, msg_pair);
+  EXPECT_NO_THROW(publisher_interface->publish());
+}
+
+class PublisherTest : public ::testing::Test {
+protected:
+  void SetUp() {
+    rclcpp::init(0, nullptr);
+    node = std::make_shared<rclcpp::Node>("test_node");
+  }
+
+  void TearDown() {
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::Node> node;
+};
+
+TEST_F(PublisherTest, BasicTypes) {
+  test_publisher_interface<std_msgs::msg::Bool, bool>(node, true);
+  test_publisher_interface<std_msgs::msg::Float64, double>(node, 0.1);
+  test_publisher_interface<std_msgs::msg::Float64MultiArray, std::vector<double>>(node, {0.1, 0.2, 0.3});
+  test_publisher_interface<std_msgs::msg::Int32, int>(node, 1);
+  test_publisher_interface<std_msgs::msg::String, std::string>(node, "this");
+}
+
+// FIXME after translators are done
+//TEST_F(PublisherTest, CartesianState) {
+//  // create message pair
+//  auto data =
+//      std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));
+//  auto msg_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
+//      data, node->get_clock());
+//
+//  // create publisher handler
+//  auto publisher = node->create_publisher<modulo_new_core::EncodedState>("topic", 10);
+//  auto publisher_handler = std::make_shared<PublisherHandler<rclcpp::Publisher<modulo_new_core::EncodedState>,
+//                                                             modulo_new_core::EncodedState>>(
+//      PublisherType::PUBLISHER, publisher
+//  );
+//
+//  // use in publisher interface
+//  std::shared_ptr<PublisherInterface> publisher_interface(publisher_handler);
+//  EXPECT_THROW(publisher_interface->publish(), modulo_new_core::exceptions::NullPointerException);
+//  publisher_interface->set_message_pair(msg_pair);
+//  EXPECT_NO_THROW(publisher_interface->publish());
+//
+//  publisher_interface = create_publisher_interface(publisher_handler, msg_pair);
+//  EXPECT_NO_THROW(publisher_interface->publish());
+//}

--- a/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
@@ -30,14 +30,18 @@ static void test_publisher_interface(const std::shared_ptr<rclcpp::Node>& node, 
 }
 
 class PublisherTest : public ::testing::Test {
-protected:
-  void SetUp() {
+public:
+  static void SetUpTestSuite() {
     rclcpp::init(0, nullptr);
-    node = std::make_shared<rclcpp::Node>("test_node");
   }
 
-  void TearDown() {
+  static void TearDownTestSuite() {
     rclcpp::shutdown();
+  }
+
+protected:
+  void SetUp() {
+    node = std::make_shared<rclcpp::Node>("test_node");
   }
 
   std::shared_ptr<rclcpp::Node> node;

--- a/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
@@ -25,7 +25,7 @@ static void test_publisher_interface(const std::shared_ptr<rclcpp::Node>& node, 
   publisher_interface->set_message_pair(msg_pair);
   EXPECT_NO_THROW(publisher_interface->publish());
 
-  publisher_interface = create_publisher_interface(publisher_handler, msg_pair);
+  auto publisher_interface_ptr = publisher_handler->create_publisher_interface(msg_pair);
   EXPECT_NO_THROW(publisher_interface->publish());
 }
 


### PR DESCRIPTION
Another small increment towards our new components.
This PR adds the implementation of the previously defined `publish` method for the `PublisherInterface`. Due to the fact that this method doesn't have arguments or templates, two switch cases are needed to get and publish the correct message with the correct publisher type.