### PR TITLE
Add parameter translators

### DIFF
--- a/source/modulo_new_core/CMakeLists.txt
+++ b/source/modulo_new_core/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(include)
 ament_auto_add_library(modulo_new_core SHARED
     ${PROJECT_SOURCE_DIR}/src/communication/MessagePairInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/communication/PublisherInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/translators/parameter_translators.cpp
     ${PROJECT_SOURCE_DIR}/src/translators/ReadStateConversion.cpp
     ${PROJECT_SOURCE_DIR}/src/translators/WriteStateConversion.cpp)
 

--- a/source/modulo_new_core/include/modulo_new_core/translators/parameter_translators.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/parameter_translators.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <state_representation/parameters/Parameter.hpp>
+
+namespace modulo_new_core::translators {
+
+/**
+ * @brief Write a ROS Parameter from a ParameterInterface pointer.
+ * @param parameter the ParameterInterface pointer with a name and value
+ * @return A new ROS Parameter object
+ */
+rclcpp::Parameter write_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
+/**
+ * @brief Create a new ParameterInterface from a ROS Parameter object.
+ * @param ros_parameter the ROS parameter object to read
+ * @return A new ParameterInterface pointer
+ */
+std::shared_ptr<state_representation::ParameterInterface> read_parameter(const rclcpp::Parameter& ros_parameter);
+
+/**
+ * @brief Update the parameter value of a ParameterInterface from a ROS Parameter object.
+ * @details The destination ParameterInterface must have a compatible parameter name and type.
+ * @param ros_parameter the ROS parameter object to read
+ * @param parameter An existing ParameterInterface pointer which will have
+ */
+void read_parameter(
+    const rclcpp::Parameter& ros_parameter, std::shared_ptr<state_representation::ParameterInterface>& parameter
+);
+
+}

--- a/source/modulo_new_core/src/translators/parameter_translators.cpp
+++ b/source/modulo_new_core/src/translators/parameter_translators.cpp
@@ -1,0 +1,225 @@
+#include "modulo_new_core/translators/parameter_translators.hpp"
+
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
+#include <state_representation/space/joint/JointState.hpp>
+#include <state_representation/space/joint/JointPositions.hpp>
+
+#include <clproto.h>
+
+using namespace state_representation;
+
+namespace modulo_new_core::translators {
+
+rclcpp::Parameter write_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
+  switch (parameter->get_parameter_type()) {
+    case ParameterType::BOOL:
+      return {parameter->get_name(), parameter->get_parameter_value<bool>()};
+    case ParameterType::BOOL_ARRAY:
+      return {parameter->get_name(), parameter->get_parameter_value<std::vector<bool>>()};
+    case ParameterType::INT:
+      return {parameter->get_name(), parameter->get_parameter_value<int>()};
+    case ParameterType::INT_ARRAY:
+      return {parameter->get_name(), parameter->get_parameter_value<std::vector<int>>()};
+    case ParameterType::DOUBLE:
+      return {parameter->get_name(), parameter->get_parameter_value<double>()};
+    case ParameterType::DOUBLE_ARRAY:
+      return {parameter->get_name(), parameter->get_parameter_value<std::vector<double>>()};
+    case ParameterType::STRING:
+      return {parameter->get_name(), parameter->get_parameter_value<std::string>()};
+    case ParameterType::STRING_ARRAY:
+      return {parameter->get_name(), parameter->get_parameter_value<std::vector<std::string>>()};
+    case ParameterType::STATE: {
+      switch (parameter->get_parameter_state_type()) {
+        case StateType::CARTESIAN_STATE:
+          return {parameter->get_name(), clproto::to_json(parameter->get_parameter_value<CartesianState>())};
+        case StateType::CARTESIAN_POSE:
+          return {parameter->get_name(), clproto::to_json(parameter->get_parameter_value<CartesianPose>())};
+        case StateType::JOINT_STATE:
+          return {parameter->get_name(), clproto::to_json(parameter->get_parameter_value<JointState>())};
+        case StateType::JOINT_POSITIONS:
+          return {parameter->get_name(), clproto::to_json(parameter->get_parameter_value<JointPositions>())};
+        default:
+          break;
+      }
+      break;
+    }
+    case ParameterType::VECTOR: {
+      auto eigen_vector = parameter->get_parameter_value<Eigen::VectorXd>();
+      std::vector<double> vec(eigen_vector.data(), eigen_vector.data() + eigen_vector.size());
+      return {parameter->get_name(), vec};
+    }
+    case ParameterType::MATRIX: {
+      auto eigen_matrix = parameter->get_parameter_value<Eigen::MatrixXd>();
+      std::vector<double> vec(eigen_matrix.data(), eigen_matrix.data() + eigen_matrix.size());
+      return {parameter->get_name(), vec};
+    }
+    default:
+      break;
+  }
+  throw InvalidParameterException("Parameter " + parameter->get_name() + " could not be written!");
+}
+
+std::shared_ptr<state_representation::ParameterInterface> read_parameter(const rclcpp::Parameter& parameter) {
+  switch (parameter.get_type()) {
+    case rclcpp::PARAMETER_BOOL:
+      return make_shared_parameter(parameter.get_name(), parameter.as_bool());
+    case rclcpp::PARAMETER_BOOL_ARRAY:
+      return make_shared_parameter(parameter.get_name(), parameter.as_bool_array());
+    case rclcpp::PARAMETER_INTEGER:
+      return make_shared_parameter(parameter.get_name(), static_cast<int>(parameter.as_int()));
+    case rclcpp::PARAMETER_INTEGER_ARRAY: {
+      auto array = parameter.as_integer_array();
+      std::vector<int> int_array(array.begin(), array.end());
+      return make_shared_parameter(parameter.get_name(), int_array);
+    }
+    case rclcpp::PARAMETER_DOUBLE:
+      return make_shared_parameter(parameter.get_name(), parameter.as_double());
+    case rclcpp::PARAMETER_DOUBLE_ARRAY:
+      return make_shared_parameter(parameter.get_name(), parameter.as_double_array());
+    case rclcpp::PARAMETER_STRING_ARRAY:
+      return make_shared_parameter<std::vector<std::string>>(parameter.get_name(), parameter.as_string_array());
+    case rclcpp::PARAMETER_STRING: {
+      // TODO: consider dedicated clproto::decode<std::shared_ptr<ParameterInterface>>(msg) specialization in library
+      std::string encoding;
+      try {
+        encoding = clproto::from_json(parameter.as_string());
+      } catch (const clproto::JsonParsingException&) {}
+      if (!clproto::is_valid(encoding)) {
+        return make_shared_parameter<std::string>(parameter.get_name(), parameter.as_string());
+      }
+      switch (clproto::check_message_type(encoding)) {
+        case clproto::CARTESIAN_STATE_MESSAGE:
+          return make_shared_parameter<CartesianState>(parameter.get_name(), clproto::decode<CartesianState>(encoding));
+        case clproto::CARTESIAN_POSE_MESSAGE:
+          return make_shared_parameter<CartesianPose>(parameter.get_name(), clproto::decode<CartesianPose>(encoding));
+        case clproto::JOINT_STATE_MESSAGE:
+          return make_shared_parameter<JointState>(parameter.get_name(), clproto::decode<JointState>(encoding));
+        case clproto::JOINT_POSITIONS_MESSAGE:
+          return make_shared_parameter<JointPositions>(parameter.get_name(), clproto::decode<JointPositions>(encoding));
+        default:
+          throw InvalidParameterException(
+              "Parameter " + parameter.get_name() + " has an unsupported encoded message type");
+      }
+    }
+    case rclcpp::PARAMETER_BYTE_ARRAY:
+      // TODO: try clproto decode, re-use logic from above
+      throw InvalidParameterException("Parameter byte arrays are not currently supported.");
+    default:
+      // TODO: handle default
+      break;
+  }
+  throw InvalidParameterException("Parameter " + parameter.get_name() + " could not be read!");
+}
+
+void read_parameter(
+    const rclcpp::Parameter& ros_parameter, std::shared_ptr<state_representation::ParameterInterface>& parameter
+) {
+  if (ros_parameter.get_name() != parameter->get_name()) {
+    // TODO: throw mismatch parameter exception
+  }
+  auto new_parameter = read_parameter(ros_parameter);
+  if (new_parameter->get_parameter_type() != parameter->get_parameter_type()
+      && new_parameter->get_parameter_type() != ParameterType::STRING
+      && new_parameter->get_parameter_type() != ParameterType::DOUBLE_ARRAY) {
+    // TODO: throw mismatch parameter exception
+  }
+  switch (new_parameter->get_parameter_type()) {
+    case ParameterType::BOOL:
+      parameter->set_parameter_value<bool>(new_parameter->get_parameter_value<bool>());
+      break;
+    case ParameterType::BOOL_ARRAY:
+      parameter->set_parameter_value<std::vector<bool>>(new_parameter->get_parameter_value<std::vector<bool>>());
+      break;
+    case ParameterType::INT:
+      parameter->set_parameter_value<int>(new_parameter->get_parameter_value<int>());
+      break;
+    case ParameterType::INT_ARRAY:
+      parameter->set_parameter_value<std::vector<int>>(new_parameter->get_parameter_value<std::vector<int>>());
+      break;
+    case ParameterType::DOUBLE:
+      parameter->set_parameter_value<double>(new_parameter->get_parameter_value<double>());
+      break;
+    case ParameterType::DOUBLE_ARRAY: {
+      auto value = new_parameter->get_parameter_value<std::vector<double>>();
+      switch (parameter->get_parameter_type()) {
+        case ParameterType::DOUBLE_ARRAY:
+          parameter->set_parameter_value<std::vector<double>>(value);
+          break;
+        case ParameterType::VECTOR: {
+          Eigen::VectorXd vector = Eigen::Map<Eigen::VectorXd>(value.data(), static_cast<Eigen::Index>(value.size()));
+          parameter->set_parameter_value<Eigen::VectorXd>(vector);
+          break;
+        }
+        case ParameterType::MATRIX: {
+          auto matrix = parameter->get_parameter_value<Eigen::MatrixXd>();
+          if (static_cast<std::size_t>(matrix.size()) != value.size()) {
+            // TODO: throw mismatch matrix size
+          }
+          matrix = Eigen::Map<Eigen::MatrixXd>(value.data(), matrix.rows(), matrix.cols());
+          parameter->set_parameter_value<Eigen::MatrixXd>(matrix);
+          break;
+        }
+        default:
+          // TODO: throw mismatch parameter exception
+          break;
+      }
+      break;
+    }
+    case ParameterType::STRING_ARRAY:
+      parameter->set_parameter_value<std::vector<std::string>>(
+          new_parameter->get_parameter_value<std::vector<std::string>>());
+      break;
+    case ParameterType::STRING: {
+      auto value = new_parameter->get_parameter_value<std::string>();
+      switch (parameter->get_parameter_type()) {
+        case ParameterType::STRING:
+          parameter->set_parameter_value<std::string>(value);
+          break;
+        case ParameterType::STATE: {
+          std::string encoding;
+          try {
+            encoding = clproto::from_json(value);
+          } catch (const clproto::JsonParsingException&) {
+            // TODO: optional handling, otherwise just rethrow
+            throw;
+          }
+          try {
+            switch (clproto::check_message_type(encoding)) {
+              case clproto::CARTESIAN_POSE_MESSAGE:
+                parameter->set_parameter_value<CartesianPose>(clproto::decode<CartesianPose>(encoding));
+                break;
+              case clproto::JOINT_STATE_MESSAGE:
+                parameter->set_parameter_value<JointState>(clproto::decode<JointState>(encoding));
+                break;
+              case clproto::JOINT_POSITIONS_MESSAGE:
+                parameter->set_parameter_value<JointPositions>(clproto::decode<JointPositions>(encoding));
+                break;
+              default:
+                // TODO: throw unsupported parameter state type
+                break;
+            }
+          } catch (const clproto::DecodingException&) {
+            // TODO: optional handling, otherwise just rethrow
+            throw;
+          }
+        }
+        default:
+          // TODO: throw mismatch parameter exception
+          break;
+      }
+      break;
+    }
+    case ParameterType::VECTOR:
+      parameter->set_parameter_value<Eigen::VectorXd>(new_parameter->get_parameter_value<Eigen::VectorXd>());
+      break;
+    case ParameterType::MATRIX:
+      parameter->set_parameter_value<Eigen::MatrixXd>(new_parameter->get_parameter_value<Eigen::MatrixXd>());
+      break;
+    default:
+      break;
+  }
+  throw InvalidParameterException("Parameter " + ros_parameter.get_name() + " could not be translated!");
+}
+
+}

--- a/source/modulo_new_core/test/cpp_tests/translators/parameters/test_parameter_readers.cpp
+++ b/source/modulo_new_core/test/cpp_tests/translators/parameters/test_parameter_readers.cpp
@@ -1,0 +1,158 @@
+#include <gtest/gtest.h>
+
+#include <clproto.h>
+#include <state_representation/space/cartesian/CartesianState.hpp>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
+#include <state_representation/space/joint/JointState.hpp>
+#include <state_representation/space/joint/JointPositions.hpp>
+
+#include "modulo_new_core/translators/parameter_translators.hpp"
+
+using namespace modulo_new_core::translators;
+
+// Parameterized test fixture by type and expected value
+// See also: http://www.ashermancinelli.com/gtest-type-val-param
+
+template<typename T> using RParamT = std::vector<std::tuple<T, state_representation::ParameterType>>;
+
+static std::tuple<
+    RParamT<bool>,
+    RParamT<std::vector<bool>>,
+    RParamT<int>,
+    RParamT<std::vector<int>>,
+    RParamT<double>,
+    RParamT<std::vector<double>>,
+    RParamT<std::string>,
+    RParamT<std::vector<std::string>>
+> read_test_params{{
+                       std::make_tuple(true, state_representation::ParameterType::BOOL),
+                       std::make_tuple(false, state_representation::ParameterType::BOOL),
+                   }, {
+                       std::make_tuple(
+                           std::vector<bool>({true, false, true}), state_representation::ParameterType::BOOL_ARRAY),
+                   }, {
+                       std::make_tuple(0, state_representation::ParameterType::INT),
+                       std::make_tuple(1, state_representation::ParameterType::INT),
+                   }, {
+                       std::make_tuple(std::vector<int>({1, 2, 3}), state_representation::ParameterType::INT_ARRAY),
+                   }, {
+                       std::make_tuple(1.0, state_representation::ParameterType::DOUBLE),
+                   }, {
+                       std::make_tuple(
+                           std::vector<double>({true, false, true}), state_representation::ParameterType::DOUBLE_ARRAY),
+                   }, {
+                       std::make_tuple("test", state_representation::ParameterType::STRING),
+                   }, {
+                       std::make_tuple(
+                           std::vector<std::string>({"1", "2", "3"}),
+                           state_representation::ParameterType::STRING_ARRAY),
+                   },
+};
+
+template<typename T>
+class ReadParameterTest : public testing::Test {
+public:
+  ReadParameterTest() : test_params_{std::get<RParamT<T>>(read_test_params)} {}
+protected:
+  void test_read_parameter(T value, state_representation::ParameterType expected_type) {
+    ros_param_ = rclcpp::Parameter("test", value);
+    param_ = read_parameter(ros_param_);
+    ASSERT_NO_THROW(param_ = read_parameter(ros_param_));
+    EXPECT_EQ(param_->get_name(), ros_param_.get_name());
+    EXPECT_EQ(param_->get_parameter_type(), expected_type);
+    EXPECT_EQ(param_->get_parameter_value<T>(), value);
+  }
+
+  void test_rewrite_parameter() {
+    rclcpp::Parameter new_ros_param;
+    ASSERT_NO_THROW(new_ros_param = write_parameter(param_));
+    EXPECT_EQ(new_ros_param, ros_param_);
+  }
+
+  std::shared_ptr<state_representation::ParameterInterface> param_;
+  rclcpp::Parameter ros_param_;
+  RParamT<T> test_params_;
+};
+TYPED_TEST_SUITE_P(ReadParameterTest);
+
+TYPED_TEST_P(ReadParameterTest, ReadAndReWrite) {
+  for (auto const& [value, type]: this->test_params_) {
+    this->test_read_parameter(value, type);
+    this->test_rewrite_parameter();
+  }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(ReadParameterTest, ReadAndReWrite);
+
+using ReadTestTypes = testing::Types<
+    bool, std::vector<bool>, int, std::vector<int>, double, std::vector<double>, std::string, std::vector<std::string>>;
+INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, ReadParameterTest, ReadTestTypes);
+
+/*
+ * Test reading and rewriting parameters containing states
+ */
+
+static std::tuple<
+    state_representation::CartesianState,
+    state_representation::CartesianPose,
+    state_representation::JointState,
+    state_representation::JointPositions
+> read_test_states{
+    state_representation::CartesianState::Random("frame", "reference"),
+    state_representation::CartesianPose::Random("frame", "reference"),
+    state_representation::JointState::Random("robot", 3),
+    state_representation::JointPositions::Random("robot", 3),
+};
+
+template<typename T>
+class ReadStateParameterTest : public testing::Test {
+public:
+  ReadStateParameterTest() : test_state_{std::get<T>(read_test_states)} {}
+protected:
+
+  void check_state_equality(const T& new_state) {
+    EXPECT_STREQ(new_state.get_name().c_str(), this->test_state_.get_name().c_str());
+    EXPECT_EQ(new_state.get_type(), this->test_state_.get_type());
+    EXPECT_NEAR(state_representation::dist(new_state, this->test_state_), 0.0, 1e-9);
+  }
+
+  void test_read_parameter() {
+    std::string json = clproto::to_json<T>(this->test_state_);
+    ros_param_ = rclcpp::Parameter("test", json);
+    param_ = read_parameter(ros_param_);
+    ASSERT_NO_THROW(param_ = read_parameter(ros_param_));
+    EXPECT_EQ(param_->get_name(), ros_param_.get_name());
+    EXPECT_EQ(param_->get_parameter_type(), state_representation::ParameterType::STATE);
+    EXPECT_EQ(param_->get_parameter_state_type(), this->test_state_.get_type());
+
+    ASSERT_NO_THROW(check_state_equality(param_->get_parameter_value<T>()));
+  }
+
+  void test_rewrite_parameter() {
+    rclcpp::Parameter new_ros_param;
+    ASSERT_NO_THROW(new_ros_param = write_parameter(param_));
+    EXPECT_STREQ(new_ros_param.get_name().c_str(), ros_param_.get_name().c_str());
+    EXPECT_EQ(new_ros_param.get_type(), ros_param_.get_type());
+    EXPECT_NO_THROW(check_state_equality(clproto::from_json<T>(new_ros_param.as_string())));
+  }
+
+  std::shared_ptr<state_representation::ParameterInterface> param_;
+  rclcpp::Parameter ros_param_;
+  T test_state_;
+};
+TYPED_TEST_SUITE_P(ReadStateParameterTest);
+
+TYPED_TEST_P(ReadStateParameterTest, ReadAndReWriteState) {
+  this->test_read_parameter();
+  this->test_rewrite_parameter();
+}
+
+REGISTER_TYPED_TEST_SUITE_P(ReadStateParameterTest, ReadAndReWriteState);
+
+using ReadStateTestTypes = testing::Types<
+    state_representation::CartesianState,
+    state_representation::CartesianPose,
+    state_representation::JointState,
+    state_representation::JointPositions
+>;
+INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, ReadStateParameterTest, ReadStateTestTypes);


### PR DESCRIPTION
* Implement parameter translators to read and write between ROS parameters and state representation ParameterInterface pointers

* Add parameterized test fixtures to test reading and rewriting a ROS parameter object

This is a work in progress on parameter logic in the new component, but the first stage is worth reviewing now. The idea is to be able to go back and forth between ROS parameters and ParameterInterface, in some cases using json encoding to store State parameters in ROS parameter strings. I haven't implemented tests for the `read_parameter` which takes an existing Parameter by reference.

@buschbapti @domire8 