### PR TITLE
Component Parameters

### DIFF
--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(ament_cmake_python REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(control_libraries 5.1.0 REQUIRED COMPONENTS state_representation)
+find_library(clproto REQUIRED)
 
 include_directories(include)
 
@@ -29,6 +30,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
     ${PROJECT_SOURCE_DIR}/src/ComponentInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/Component.cpp
     ${PROJECT_SOURCE_DIR}/src/LifecycleComponent.cpp)
+
+target_link_libraries(${PROJECT_NAME} clproto)
 
 # Install Python modules
 ament_python_install_package(${PROJECT_NAME} SCRIPTS_DESTINATION lib/${PROJECT_NAME})
@@ -42,7 +45,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_cpp_components ${TEST_CPP_SOURCES})
   target_include_directories(test_cpp_components PRIVATE include)
-  target_link_libraries(test_cpp_components ${PROJECT_NAME} state_representation)
+  target_link_libraries(test_cpp_components ${PROJECT_NAME} state_representation clproto)
   target_compile_definitions(test_cpp_components PRIVATE TEST_FIXTURES="${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/")
 
   # prevent pluginlib from using boost

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -63,7 +63,7 @@ protected:
    * @param name The name of the parameter
    * @return The ParameterInterface pointer to a Parameter instance
    */
-  std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name);
+  std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name) const;
 
   /**
    * @brief Get a parameter value by name.
@@ -72,7 +72,7 @@ protected:
    * @return The value of the parameter
    */
   template<typename T>
-  T get_parameter_value(const std::string& name);
+  T get_parameter_value(const std::string& name) const;
 
   /**
    * @brief Parameter validation function to be redefined by derived Component classes.
@@ -230,7 +230,7 @@ void ComponentInterface<NodeT>::add_parameter(const std::string& name, const T& 
 
 template<class NodeT>
 template<typename T>
-T ComponentInterface<NodeT>::get_parameter_value(const std::string& name) {
+T ComponentInterface<NodeT>::get_parameter_value(const std::string& name) const {
   return this->parameter_map_.template get_parameter_value<T>(name);
 }
 
@@ -244,7 +244,7 @@ ComponentInterface<NodeT>::add_parameter(const std::shared_ptr<state_representat
 
 template<class NodeT>
 std::shared_ptr<state_representation::ParameterInterface>
-ComponentInterface<NodeT>::get_parameter(const std::string& name) {
+ComponentInterface<NodeT>::get_parameter(const std::string& name) const {
   return this->parameter_map_.get_parameter(name);
 }
 

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -1,17 +1,21 @@
 #pragma once
 
-#include <state_representation/space/cartesian/CartesianPose.hpp>
 #include <rclcpp/parameter.hpp>
 #include <rclcpp/create_timer.hpp>
 #include <rclcpp/node_options.hpp>
+#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_ros/transform_broadcaster.h>
 
+#include <state_representation/parameters/ParameterMap.hpp>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
+
 #include <modulo_new_core/communication/PublisherType.hpp>
 #include <modulo_new_core/translators/message_readers.hpp>
 #include <modulo_new_core/translators/message_writers.hpp>
+#include <modulo_new_core/translators/parameter_translators.hpp>
 
 #include "modulo_components/exceptions/PredicateNotFoundException.hpp"
 #include "modulo_components/utilities/utilities.hpp"
@@ -24,6 +28,8 @@ class ComponentInterface : NodeT {
   friend class ComponentInterfaceTest;
 
 public:
+  friend class ComponentInterfacePublicInterface;
+
   /**
    * @brief Constructor from node options
    * @param node_options node options as used in ROS2 Node
@@ -33,6 +39,53 @@ public:
   );
 
 protected:
+  /**
+   * @brief Add a parameter.
+   * @details This method stores a pointer reference to an existing Parameter object in the local parameter map
+   * and declares the equivalent ROS parameter on the ROS interface.
+   * @param parameter A ParameterInterface pointer to a Parameter instance.
+   */
+  void add_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
+  /**
+   * @brief Add a parameter.
+   * @details This method creates a new Parameter object instance to reference in the local parameter map
+   * and declares the equivalent ROS parameter on the ROS interface.
+   * @tparam T The type of the parameter
+   * @param name The name of the parameter
+   * @param value The value of the parameter
+   */
+  template<typename T>
+  void add_parameter(const std::string& name, const T& value);
+
+  /**
+   * @brief Get a parameter by name.
+   * @param name The name of the parameter
+   * @return The ParameterInterface pointer to a Parameter instance
+   */
+  std::shared_ptr<state_representation::ParameterInterface> get_parameter(const std::string& name);
+
+  /**
+   * @brief Get a parameter value by name.
+   * @tparam T The type of the parameter
+   * @param name The name of the parameter
+   * @return The value of the parameter
+   */
+  template<typename T>
+  T get_parameter_value(const std::string& name);
+
+  /**
+   * @brief Parameter validation function to be redefined by derived Component classes.
+   * @details This method is automatically invoked whenever the ROS interface tried to modify a parameter.
+   * Validation and sanitization can be performed by reading or writing the value of the parameter through the
+   * ParameterInterface pointer, depending on the parameter name and desired component behaviour. If the validation
+   * returns true, the updated parameter value (including any modifications) is applied. If the validation returns
+   * false, any changes to the parameter are discarded and the parameter value is not changed.
+   * @param parameter A ParameterInterface pointer to a Parameter instance
+   * @return The validation result
+   */
+  virtual bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
+
   /**
    * @brief Add a predicate to the map of predicates
    * @param predicate_name the name of the associated predicate
@@ -78,6 +131,13 @@ protected:
   lookup_transform(const std::string& frame_name, const std::string& reference_frame_name = "world") const;
 
 private:
+  /**
+   * @brief Callback function to validate and update parameters on change.
+   * @param parameters The new parameter objects provided by the ROS interface
+   * @return The result of the validation
+   */
+  rcl_interfaces::msg::SetParametersResult on_set_parameters_callback(const std::vector<rclcpp::Parameter>& parameters);
+
   [[nodiscard]] std::string generate_predicate_topic(const std::string& predicate_name) const;
 
   void add_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate);
@@ -91,10 +151,10 @@ private:
   std::map<std::string, utilities::PredicateVariant> predicates_;
   std::map<std::string, std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Bool>>> predicate_publishers_;
 
+  state_representation::ParameterMap parameter_map_;
+  std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> parameter_cb_handle_;
+
   std::shared_ptr<rclcpp::TimerBase> step_timer_;
-  rclcpp::Parameter period_;
-  rclcpp::Parameter has_tf_listener_;
-  rclcpp::Parameter has_tf_broadcaster_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
@@ -105,26 +165,26 @@ ComponentInterface<NodeT>::ComponentInterface(
     const rclcpp::NodeOptions& options, modulo_new_core::communication::PublisherType publisher_type
 ) :
     rclcpp::Node(utilities::parse_node_name(options, "ComponentInterface"), options), publisher_type_(publisher_type) {
-  this->declare_parameter("period", 2.0);
-  this->declare_parameter("has_tf_listener", false);
-  this->declare_parameter("has_tf_broadcaster", false);
+  // register the parameter change callback handler
+  parameter_cb_handle_ = NodeT::add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter>& parameters) -> rcl_interfaces::msg::SetParametersResult {
+        return this->on_set_parameters_callback(parameters);
+      });
+  this->add_parameter("period", 1.0);
+  this->add_parameter("has_tf_listener", false);
+  this->add_parameter("has_tf_broadcaster", false);
 
-  // here I need to do typename NodeT:: because ParameterMap also has get_parameter
-  period_ = NodeT::get_parameter("period");
-  has_tf_listener_ = NodeT::get_parameter("has_tf_listener");
-  has_tf_broadcaster_ = NodeT::get_parameter("has_tf_broadcaster");
-
-  if (has_tf_listener_.as_bool()) {
+  if (this->get_parameter_value<bool>("has_tf_listener")) {
     this->tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
     this->tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*this->tf_buffer_);
   }
-  if (has_tf_broadcaster_.as_bool()) {
+  if (this->get_parameter_value<bool>("has_tf_broadcaster")) {
     this->tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(this->shared_from_this());
   }
 
   this->step_timer_ = this->create_wall_timer(
-      std::chrono::nanoseconds(static_cast<int64_t>(this->period_.as_double() * 1e9)), [this] { this->step(); }
-  );
+      std::chrono::nanoseconds(static_cast<int64_t>(this->get_parameter_value<double>("period") * 1e9)),
+      [this] { this->step(); });
 }
 
 template<class NodeT>
@@ -160,6 +220,66 @@ void ComponentInterface<NodeT>::add_variant_predicate(
         std::make_pair(
             name, this->template create_publisher<std_msgs::msg::Bool>(this->generate_predicate_topic(name), 10)));
   }
+}
+
+template<class NodeT>
+template<typename T>
+void ComponentInterface<NodeT>::add_parameter(const std::string& name, const T& value) {
+  this->add_parameter(state_representation::make_shared_parameter(name, value));
+}
+
+template<class NodeT>
+template<typename T>
+T ComponentInterface<NodeT>::get_parameter_value(const std::string& name) {
+  return this->parameter_map_.template get_parameter_value<T>(name);
+}
+
+template<class NodeT>
+void
+ComponentInterface<NodeT>::add_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
+  parameter_map_.set_parameter(parameter);
+  auto ros_param = modulo_new_core::translators::write_parameter(parameter);
+  NodeT::declare_parameter(parameter->get_name(), ros_param.get_parameter_value());
+}
+
+template<class NodeT>
+std::shared_ptr<state_representation::ParameterInterface>
+ComponentInterface<NodeT>::get_parameter(const std::string& name) {
+  return this->parameter_map_.get_parameter(name);
+}
+
+template<class NodeT>
+bool ComponentInterface<NodeT>::validate_parameter(
+    const std::shared_ptr<state_representation::ParameterInterface>&
+) {
+  return true;
+}
+
+template<class NodeT>
+rcl_interfaces::msg::SetParametersResult
+ComponentInterface<NodeT>::on_set_parameters_callback(const std::vector<rclcpp::Parameter>& parameters) {
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  for (const auto& ros_parameter: parameters) {
+    try {
+      // get the associated parameter interface by name
+      auto parameter = parameter_map_.get_parameter(ros_parameter.get_name());
+
+      // convert the ROS parameter into a ParameterInterface without modifying the original
+      auto new_parameter = modulo_new_core::translators::read_parameter_const(ros_parameter, parameter);
+      if (!validate_parameter(new_parameter)) {
+        result.successful = false;
+        result.reason += "Parameter " + ros_parameter.get_name() + " could not be set! ";
+      } else {
+        // update the value of the parameter in the map
+        modulo_new_core::translators::copy_parameter_value(new_parameter, parameter);
+      }
+    } catch (const std::exception& ex) {
+      result.successful = false;
+      result.reason += ex.what();
+    }
+  }
+  return result;
 }
 
 template<class NodeT>

--- a/source/modulo_components/include/modulo_components/utilities/utilities.hpp
+++ b/source/modulo_components/include/modulo_components/utilities/utilities.hpp
@@ -37,35 +37,4 @@ static std::string parse_node_name(const rclcpp::NodeOptions& options, const std
   return parse_string_argument(options.arguments(), pattern, node_name);
 }
 
-/**
- * @brief Parse a string node namespace from NodeOptions arguments.
- * @param options the NodeOptions structure to parse
- * @param fallback the default namespace if the NodeOptions structure cannot be parsed
- * @return the parsed node namespace or the fallback namespace
- */
-static std::string parse_node_namespace(const rclcpp::NodeOptions& options, const std::string& fallback="") {
-  std::string node_namespace(fallback);
-  const std::string pattern("__ns:=");
-  return parse_string_argument(options.arguments(), pattern, node_namespace);
-}
-
-/**
- * @brief Parse a period in seconds from NodeOptions parameters.
- * @details The parameter must have the name "period"
- * and be interpretable as a value in seconds of type double
- * @param options the NodeOptions structure to parse
- * @param default_period the default period in seconds
- * @return the parsed period or the default period as a chrono duration
- */
-static std::chrono::nanoseconds parse_period(const rclcpp::NodeOptions& options, double default_period = 0.001) {
-  double period = default_period;
-  for (auto& param : options.parameter_overrides()) {
-    if (param.get_name() == "period") {
-      period = param.as_double();
-      break;
-    }
-  }
-  return std::chrono::nanoseconds(static_cast<int64_t>(period * 1e9));
-}
-
 }// namespace modulo_components::utilities

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -13,6 +13,10 @@ protected:
     rclcpp::init(0, nullptr);
   }
 
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
   void SetUp() override {
     component_ = std::make_shared<ComponentInterface<rclcpp::Node>>(
         rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::PUBLISHER

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -19,7 +19,7 @@ public:
   using ComponentInterface<rclcpp::Node>::get_parameter_value;
   using ComponentInterface<rclcpp::Node>::parameter_map_;
 
-  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override {
+  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) override {
     validate_was_called = true;
     return validation_return_value;
   }

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -1,0 +1,92 @@
+#include <gtest/gtest.h>
+#include <rclcpp/node.hpp>
+#include <rclcpp/publisher.hpp>
+#include <rclcpp/node_options.hpp>
+
+#include <state_representation/exceptions/InvalidParameterException.hpp>
+
+#include "modulo_components/ComponentInterface.hpp"
+#include "modulo_new_core/EncodedState.hpp"
+
+namespace modulo_components {
+
+class ComponentInterfacePublicInterface : public ComponentInterface<rclcpp::Node> {
+public:
+  ComponentInterfacePublicInterface(const rclcpp::NodeOptions& node_options) :
+      ComponentInterface<rclcpp::Node>(node_options, modulo_new_core::communication::PublisherType::PUBLISHER) {}
+  using ComponentInterface<rclcpp::Node>::add_parameter;
+  using ComponentInterface<rclcpp::Node>::get_parameter;
+  using ComponentInterface<rclcpp::Node>::get_parameter_value;
+  using ComponentInterface<rclcpp::Node>::parameter_map_;
+
+  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override {
+    validate_was_called = true;
+    return validation_return_value;
+  }
+
+  rclcpp::Parameter get_ros_parameter(const std::string& name) {
+    return rclcpp::Node::get_parameter(name);
+  }
+
+  rcl_interfaces::msg::SetParametersResult set_ros_parameter(const rclcpp::Parameter& parameter) {
+    return rclcpp::Node::set_parameter(parameter);
+  }
+
+  bool validate_was_called = false;
+  bool validation_return_value = true;
+};
+
+class ComponentInterfaceParameterTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override {
+    component_ = std::make_shared<ComponentInterfacePublicInterface>(rclcpp::NodeOptions());
+  }
+
+  template<typename T>
+  void expect_parameter_value(const T& value) {
+    EXPECT_STREQ(component_->get_ros_parameter("test").value_to_string().c_str(), std::to_string(value).c_str());
+    EXPECT_EQ(component_->get_parameter_value<T>("test"), value);
+    EXPECT_EQ(component_->parameter_map_.get_parameter_value<T>("test"), value);
+  }
+
+  std::shared_ptr<ComponentInterfacePublicInterface> component_;
+};
+
+
+TEST_F(ComponentInterfaceParameterTest, AddParameter) {
+  EXPECT_THROW(component_->get_parameter("test"), state_representation::exceptions::InvalidParameterException);
+  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  auto param = state_representation::make_shared_parameter("test", 1);
+  component_->add_parameter(param);
+
+  // Adding the parameter should declare and set the value and call the validation function
+  EXPECT_TRUE(component_->validate_was_called);
+  EXPECT_NO_THROW(component_->get_parameter("test"));
+  EXPECT_NO_THROW(component_->get_ros_parameter("test"));
+  expect_parameter_value<int>(1);
+
+  // Setting the parameter value should call the validation function and update the referenced value
+  component_->validate_was_called = false;
+  component_->set_ros_parameter({"test", 2});
+  EXPECT_TRUE(component_->validate_was_called);
+  expect_parameter_value<int>(2);
+  EXPECT_EQ(param->get_value(), 2);
+
+  // If the validation function returns false, setting the parameter value should _not_ update the referenced value
+  component_->validate_was_called = false;
+  component_->validation_return_value = false;
+  component_->set_ros_parameter({"test", 3});
+  EXPECT_TRUE(component_->validate_was_called);
+  expect_parameter_value<int>(2);
+  EXPECT_EQ(param->get_value(), 2);
+}
+
+} // namespace modulo_components


### PR DESCRIPTION
* Implement add_ and get_ methods for component parameters, using
the modulo parameter translators.

* Link clproto in CMakeLists because of parameter translators

* Add tests for component parameter behaviour


This PR follows #57 and applies the translation logic in the ComponentInterface.

@buschbapti @domire8 