### PR TITLE
Support write/read for MessagePair<EncodedState, State>

### DIFF
--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
@@ -40,8 +40,7 @@ inline MsgT MessagePair<MsgT, DataT>::write_message() const {
 template<>
 inline EncodedState MessagePair<EncodedState, state_representation::State>::write_message() const {
   auto msg = EncodedState();
-  // TODO write the translators
-//  translators::write_msg(msg, this->data_, clock_->now());
+  translators::write_msg(msg, this->data_, clock_->now());
   return msg;
 }
 
@@ -51,9 +50,8 @@ inline void MessagePair<MsgT, DataT>::read_message(const MsgT& message) {
 }
 
 template<>
-inline void MessagePair<EncodedState, state_representation::State>::read_message(const EncodedState&) {
-  // TODO write the translators
-//  translators::read_msg(this->data_, message, clock_->now());
+inline void MessagePair<EncodedState, state_representation::State>::read_message(const EncodedState& message) {
+  translators::read_msg(this->data_, message);
 }
 
 template<typename MsgT, typename DataT>

--- a/source/modulo_new_core/include/modulo_new_core/translators/message_writers.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/message_writers.hpp
@@ -134,6 +134,7 @@ void write_msg(U& msg, const state_representation::Parameter<T>& state, const rc
  * @brief Convert a boolean to a ROS std_msgs::msg::Bool
  * @param msg The ROS msg to populate
  * @param state The state to read from
+ * @param time The time of the message
  */
 void write_msg(std_msgs::msg::Bool& msg, const bool& state, const rclcpp::Time& time);
 
@@ -141,6 +142,7 @@ void write_msg(std_msgs::msg::Bool& msg, const bool& state, const rclcpp::Time& 
  * @brief Convert a double to a ROS std_msgs::msg::Float64
  * @param msg The ROS msg to populate
  * @param state The state to read from
+ * @param time The time of the message
  */
 void write_msg(std_msgs::msg::Float64& msg, const double& state, const rclcpp::Time& time);
 
@@ -148,6 +150,7 @@ void write_msg(std_msgs::msg::Float64& msg, const double& state, const rclcpp::T
  * @brief Convert a vector of double to a ROS std_msgs::msg::Float64MultiArray
  * @param msg The ROS msg to populate
  * @param state The state to read from
+ * @param time The time of the message
  */
 void write_msg(std_msgs::msg::Float64MultiArray& msg, const std::vector<double>& state, const rclcpp::Time& time);
 
@@ -155,6 +158,7 @@ void write_msg(std_msgs::msg::Float64MultiArray& msg, const std::vector<double>&
  * @brief Convert an integer to a ROS std_msgs::msg::Int32
  * @param msg The ROS msg to populate
  * @param state The state to read from
+ * @param time The time of the message
  */
 void write_msg(std_msgs::msg::Int32& msg, const int& state, const rclcpp::Time& time);
 
@@ -162,6 +166,7 @@ void write_msg(std_msgs::msg::Int32& msg, const int& state, const rclcpp::Time& 
  * @brief Convert a string to a ROS std_msgs::msg::String
  * @param msg The ROS msg to populate
  * @param state The state to read from
+ * @param time The time of the message
  */
 void write_msg(std_msgs::msg::String& msg, const std::string& state, const rclcpp::Time& time);
 
@@ -172,7 +177,7 @@ void write_msg(std_msgs::msg::String& msg, const std::string& state, const rclcp
  * @param state The state to read from
  * @param time The time of the message
  */
-template <typename T>
+template<typename T>
 inline void write_msg(EncodedState& msg, const T& state, const rclcpp::Time&) {
   std::string tmp = clproto::encode<T>(state);
   msg.data = std::vector<unsigned char>(tmp.begin(), tmp.end());

--- a/source/modulo_new_core/src/translators/message_writers.cpp
+++ b/source/modulo_new_core/src/translators/message_writers.cpp
@@ -117,7 +117,7 @@ void write_msg(tf2_msgs::msg::TFMessage& msg, const CartesianState& state, const
   msg.transforms.push_back(transform);
 }
 
-template <typename U, typename T>
+template<typename U, typename T>
 void write_msg(U& msg, const Parameter<T>& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
@@ -133,17 +133,17 @@ template void write_msg<std_msgs::msg::Bool, bool>(std_msgs::msg::Bool& msg, con
 
 template void write_msg<std_msgs::msg::String, std::string>(std_msgs::msg::String& msg, const Parameter<std::string>& state, const rclcpp::Time&);
 
-template <>
+template<>
 void write_msg(geometry_msgs::msg::Transform& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
   write_msg(msg, state.get_value(), time);
 }
 
-template <>
+template<>
 void write_msg(geometry_msgs::msg::TransformStamped& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
   write_msg(msg, state.get_value(), time);
 }
 
-template <>
+template<>
 void write_msg(tf2_msgs::msg::TFMessage& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
   write_msg(msg, state.get_value(), time);
 }

--- a/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
@@ -55,27 +55,26 @@ TEST_F(PublisherTest, BasicTypes) {
   test_publisher_interface<std_msgs::msg::String, std::string>(node, "this");
 }
 
-// FIXME after translators are done
-//TEST_F(PublisherTest, CartesianState) {
-//  // create message pair
-//  auto data =
-//      std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));
-//  auto msg_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
-//      data, node->get_clock());
-//
-//  // create publisher handler
-//  auto publisher = node->create_publisher<modulo_new_core::EncodedState>("topic", 10);
-//  auto publisher_handler = std::make_shared<PublisherHandler<rclcpp::Publisher<modulo_new_core::EncodedState>,
-//                                                             modulo_new_core::EncodedState>>(
-//      PublisherType::PUBLISHER, publisher
-//  );
-//
-//  // use in publisher interface
-//  std::shared_ptr<PublisherInterface> publisher_interface(publisher_handler);
-//  EXPECT_THROW(publisher_interface->publish(), modulo_new_core::exceptions::NullPointerException);
-//  publisher_interface->set_message_pair(msg_pair);
-//  EXPECT_NO_THROW(publisher_interface->publish());
-//
-//  publisher_interface = create_publisher_interface(publisher_handler, msg_pair);
-//  EXPECT_NO_THROW(publisher_interface->publish());
-//}
+TEST_F(PublisherTest, CartesianState) {
+  // create message pair
+  auto data =
+      std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));
+  auto msg_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
+      data, node->get_clock());
+
+  // create publisher handler
+  auto publisher = node->create_publisher<modulo_new_core::EncodedState>("topic", 10);
+  auto publisher_handler = std::make_shared<PublisherHandler<rclcpp::Publisher<modulo_new_core::EncodedState>,
+                                                             modulo_new_core::EncodedState>>(
+      PublisherType::PUBLISHER, publisher
+  );
+
+  // use in publisher interface
+  std::shared_ptr<PublisherInterface> publisher_interface(publisher_handler);
+  EXPECT_THROW(publisher_interface->publish(), modulo_new_core::exceptions::NullPointerException);
+  publisher_interface->set_message_pair(msg_pair);
+  EXPECT_NO_THROW(publisher_interface->publish());
+
+  publisher_interface = publisher_handler->create_publisher_interface(msg_pair);
+  EXPECT_NO_THROW(publisher_interface->publish());
+}

--- a/source/modulo_new_core/test/cpp_tests/translators/test_messages.cpp
+++ b/source/modulo_new_core/test/cpp_tests/translators/test_messages.cpp
@@ -208,7 +208,7 @@ TEST_F(MessageTranslatorsTest, TestEncodedState) {
   EXPECT_EQ(state_.get_reference_frame(), new_state.get_reference_frame());
 }
 
-TEST_F(TranslatorsTest, TestEncodedStatePointer) {
+TEST_F(MessageTranslatorsTest, TestEncodedStatePointer) {
   auto state_ptr = state_representation::make_shared_state(state_);
   auto msg = modulo_new_core::EncodedState();
   write_msg(msg, state_ptr, clock_.now());

--- a/source/modulo_new_core/test/cpp_tests/translators/test_messages.cpp
+++ b/source/modulo_new_core/test/cpp_tests/translators/test_messages.cpp
@@ -207,3 +207,15 @@ TEST_F(MessageTranslatorsTest, TestEncodedState) {
   EXPECT_EQ(state_.get_name(), new_state.get_name());
   EXPECT_EQ(state_.get_reference_frame(), new_state.get_reference_frame());
 }
+
+TEST_F(TranslatorsTest, TestEncodedStatePointer) {
+  auto state_ptr = state_representation::make_shared_state(state_);
+  auto msg = modulo_new_core::EncodedState();
+  write_msg(msg, state_ptr, clock_.now());
+  auto new_state_ptr = state_representation::make_shared_state(state_representation::CartesianState());
+  read_msg(new_state_ptr, msg);
+  auto new_state = *std::dynamic_pointer_cast<state_representation::CartesianState>(new_state_ptr);
+  EXPECT_TRUE(state_.data().isApprox(new_state.data()));
+  EXPECT_EQ(state_.get_name(), new_state.get_name());
+  EXPECT_EQ(state_.get_reference_frame(), new_state.get_reference_frame());
+}


### PR DESCRIPTION
Now that we have the most recent changes from control libraries (encode/decode shared pointer of State), we can use that in the translators and message pair to read and write the encoded state pair (and also publish it with the PublisherInteface)

@buschbapti 