### PR TITLE
Component parameter description and improvements

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -78,6 +78,17 @@ protected:
   T get_parameter_value(const std::string& name) const;
 
   /**
+   * @brief Set the value of a parameter.
+   * @details The parameter must have been previously declared. This method preserves the reference
+   * to the original Parameter instance
+   * @tparam T The type of the parameter
+   * @param name The name of the parameter
+   * @return The value of the parameter
+   */
+  template<typename T>
+  void set_parameter_value(const std::string& name, const T& value);
+
+  /**
    * @brief Parameter validation function to be redefined by derived Component classes.
    * @details This method is automatically invoked whenever the ROS interface tried to modify a parameter.
    * Validation and sanitization can be performed by reading or writing the value of the parameter through the
@@ -260,6 +271,16 @@ template<class NodeT>
 std::shared_ptr<state_representation::ParameterInterface>
 ComponentInterface<NodeT>::get_parameter(const std::string& name) const {
   return this->parameter_map_.get_parameter(name);
+}
+
+template<class NodeT>
+template<typename T>
+void ComponentInterface<NodeT>::set_parameter_value(const std::string& name, const T& value) {
+  rcl_interfaces::msg::SetParametersResult result = NodeT::set_parameter(
+      modulo_new_core::translators::write_parameter(state_representation::make_shared_parameter(name, value)));
+  if (!result.successful) {
+    throw state_representation::exceptions::InvalidParameterException(result.reason);
+  }
 }
 
 template<class NodeT>

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -17,6 +17,7 @@ public:
   using ComponentInterface<rclcpp::Node>::add_parameter;
   using ComponentInterface<rclcpp::Node>::get_parameter;
   using ComponentInterface<rclcpp::Node>::get_parameter_value;
+  using ComponentInterface<rclcpp::Node>::set_parameter_value;
   using ComponentInterface<rclcpp::Node>::parameter_map_;
 
   bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) override {
@@ -30,6 +31,10 @@ public:
 
   rcl_interfaces::msg::SetParametersResult set_ros_parameter(const rclcpp::Parameter& parameter) {
     return rclcpp::Node::set_parameter(parameter);
+  }
+
+  std::string get_parameter_description(const std::string& name) {
+    return rclcpp::Node::describe_parameter(name).description;
   }
 
   bool validate_was_called = false;
@@ -48,6 +53,7 @@ protected:
 
   void SetUp() override {
     component_ = std::make_shared<ComponentInterfacePublicInterface>(rclcpp::NodeOptions());
+    param_ = state_representation::make_shared_parameter("test", 1);
   }
 
   template<typename T>
@@ -58,27 +64,92 @@ protected:
   }
 
   std::shared_ptr<ComponentInterfacePublicInterface> component_;
+  std::shared_ptr<state_representation::Parameter<int>> param_;
 };
 
-
 TEST_F(ComponentInterfaceParameterTest, AddParameter) {
-  EXPECT_THROW(component_->get_parameter("test"), state_representation::exceptions::InvalidParameterException);
+  EXPECT_THROW(auto discard = component_->get_parameter("test"),
+               state_representation::exceptions::InvalidParameterException);
   EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
-  auto param = state_representation::make_shared_parameter("test", 1);
-  component_->add_parameter(param);
+  component_->add_parameter(param_, "Test parameter");
 
   // Adding the parameter should declare and set the value and call the validation function
   EXPECT_TRUE(component_->validate_was_called);
-  EXPECT_NO_THROW(component_->get_parameter("test"));
+  EXPECT_NO_THROW(auto discard = component_->get_parameter("test"));
   EXPECT_NO_THROW(component_->get_ros_parameter("test"));
   expect_parameter_value<int>(1);
+}
+
+TEST_F(ComponentInterfaceParameterTest, AddNameValueParameter) {
+  EXPECT_THROW(auto discard = component_->get_parameter("test"),
+               state_representation::exceptions::InvalidParameterException);
+  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  component_->add_parameter("test", 1, "Test parameter");
+
+  // Adding the parameter should declare and set the value and call the validation function
+  EXPECT_TRUE(component_->validate_was_called);
+  EXPECT_NO_THROW(auto discard = component_->get_parameter("test"));
+  EXPECT_NO_THROW(component_->get_ros_parameter("test"));
+  expect_parameter_value<int>(1);
+}
+
+TEST_F(ComponentInterfaceParameterTest, AddParameterAgain) {
+  EXPECT_THROW(auto
+                   discard = component_->get_parameter("test"),
+               state_representation::exceptions::InvalidParameterException);
+  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  component_->add_parameter(param_, "Test parameter");
+
+  // Adding an existing parameter again should just set the value
+  component_->validate_was_called = false;
+  EXPECT_NO_THROW(component_->add_parameter("test", 2, "foo"));
+  EXPECT_TRUE(component_->validate_was_called);
+  expect_parameter_value<int>(2);
+  EXPECT_EQ(param_->get_value(), 2);
+}
+
+TEST_F(ComponentInterfaceParameterTest, SetParameter) {
+  // setting before adding should not work
+  EXPECT_THROW(component_->set_parameter_value("test", 1), rclcpp::exceptions::ParameterNotDeclaredException);
+
+  // validation should not be invoked as the parameter did not exist
+  EXPECT_FALSE(component_->validate_was_called);
+  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+
+  component_->add_parameter(param_, "Test parameter");
+
+  // Setting the parameter value should call the validation function and update the referenced value
+  component_->validate_was_called = false;
+  EXPECT_NO_THROW(component_->set_parameter_value("test", 2));
+  EXPECT_TRUE(component_->validate_was_called);
+  expect_parameter_value<int>(2);
+  EXPECT_EQ(param_->get_value(), 2);
+
+  // If the validation function returns false, setting the parameter value should _not_ update the referenced value
+  component_->validate_was_called = false;
+  component_->validation_return_value = false;
+  EXPECT_THROW(component_->set_parameter_value("test", 3), state_representation::exceptions::InvalidParameterException);
+  EXPECT_TRUE(component_->validate_was_called);
+  expect_parameter_value<int>(2);
+  EXPECT_EQ(param_->get_value(), 2);
+
+  // Setting a value with an incompatible type should not update the parameter
+  EXPECT_THROW(component_->set_parameter_value<std::string>("test", "foo"),
+               state_representation::exceptions::InvalidParameterException);
+  EXPECT_TRUE(component_->validate_was_called);
+  expect_parameter_value<int>(2);
+  EXPECT_EQ(param_->get_value(), 2);
+}
+
+TEST_F(ComponentInterfaceParameterTest, SetParameterROS) {
+  component_->add_parameter(param_, "Test parameter");
 
   // Setting the parameter value should call the validation function and update the referenced value
   component_->validate_was_called = false;
   component_->set_ros_parameter({"test", 2});
   EXPECT_TRUE(component_->validate_was_called);
   expect_parameter_value<int>(2);
-  EXPECT_EQ(param->get_value(), 2);
+  EXPECT_EQ(param_->get_value(), 2);
 
   // If the validation function returns false, setting the parameter value should _not_ update the referenced value
   component_->validate_was_called = false;
@@ -86,7 +157,14 @@ TEST_F(ComponentInterfaceParameterTest, AddParameter) {
   component_->set_ros_parameter({"test", 3});
   EXPECT_TRUE(component_->validate_was_called);
   expect_parameter_value<int>(2);
-  EXPECT_EQ(param->get_value(), 2);
+  EXPECT_EQ(param_->get_value(), 2);
+}
+
+TEST_F(ComponentInterfaceParameterTest, GetParameterDescription) {
+  component_->add_parameter(param_, "Test parameter");
+  EXPECT_STREQ(component_->get_parameter_description("test").c_str(), "Test parameter");
+
+  EXPECT_THROW(component_->get_parameter_description("foo"), rclcpp::exceptions::ParameterNotDeclaredException);
 }
 
 } // namespace modulo_components


### PR DESCRIPTION
I kept this separate from #58 to prevent it from being too large. Mainly, I want to encourage parameter descriptions in C++. I also added a helper function to set the parameter value (for when you add a parameter by name and value and don't hold a ParameterInterface as a class property that you can modify directly). 

Finally it became clear that the TF broadcaster and listener would not work as parameters. The idea is that derived classes can selectively enable or disable these. Parameters are intended to be a user-facing API over the ROS interface, while derived classes should use protected functions or properties as the "API" to base classes. In addition, because base class construction happens before derived class construction, the only way for a derived class to update these parameters would be to modify the NodeOptions struct to override the parameter value on construction. For these reasons, the TF broadcaster and listener can now instead be set simply by calling the appropriate protected functions.

@buschbapti @domire8 