### PR TITLE
Add docstrings and QoS getter/setter

### DIFF
--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -19,6 +19,13 @@ public:
   explicit Component(const rclcpp::NodeOptions& node_options);
 
 protected:
+  /**
+   * @brief Add and configure an output signal of the component.
+   * @tparam DataT Type of the data pointer
+   * @param signal_name Name of the output signal
+   * @param data Data to transmit on the output signal
+   * @param fixed_topic If true, the topic name of the output signal is fixed
+   */
   template<typename DataT>
   void add_output(
       const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false,

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -150,20 +150,51 @@ protected:
    */
   void add_tf_listener();
 
+  /**
+   * @brief Helper function to parse the signal name and add an unconfigured
+   * PublisherInterface to the map of outputs.
+   * @tparam DataT Type of the data pointer
+   * @param signal_name Name of the output signal
+   * @param data Data to transmit on the output signal
+   * @param fixed_topic If true, the topic name of the output signal is fixed
+   */
   template<typename DataT>
   void create_output(
       const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false,
       const std::string& default_topic = ""
   );
 
+  /**
+   * @brief Getter of the Quality of Service attribute.
+   * @return The Quality of Service attribute
+   */
+  [[nodiscard]] rclcpp::QoS get_qos() const;
+
+  /**
+   * @brief Set the Quality of Service for ROS publishers and subscribers.
+   * @param qos The desired Quality of Service
+   */
+  void set_qos(const rclcpp::QoS& qos);
+
+  /**
+   * @brief Send a transform to TF.
+   * @param transform The transform to send
+   */
   void send_transform(const state_representation::CartesianPose& transform);
 
+  /**
+   * @brief Look up a transform from TF.
+   * @param frame_name The desired frame of the transform
+   * @param reference_frame_name The desired reference frame of the transform
+   * @return If it exists, the requested transform
+   */
   [[nodiscard]] state_representation::CartesianPose
   lookup_transform(const std::string& frame_name, const std::string& reference_frame_name = "world") const;
 
-  std::map<std::string, std::shared_ptr<modulo_new_core::communication::PublisherInterface>> outputs_;
+  std::map<std::string, std::shared_ptr<modulo_new_core::communication::PublisherInterface>>
+      outputs_; ///< Map of outputs
 
-  rclcpp::QoS qos_ = rclcpp::QoS(10);
+  rclcpp::QoS qos_ = rclcpp::QoS(10); ///< Quality of Service for ROS publishers and subscribers
 
 private:
   /**
@@ -181,18 +212,21 @@ private:
 
   void step();
 
-  modulo_new_core::communication::PublisherType publisher_type_;
+  modulo_new_core::communication::PublisherType
+      publisher_type_; ///< Type of the output publishers (one of PUBLISHER, LIFECYCLE_PUBLISHER)
 
-  std::map<std::string, utilities::PredicateVariant> predicates_;
-  std::map<std::string, std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Bool>>> predicate_publishers_;
+  std::map<std::string, utilities::PredicateVariant> predicates_; ///< Map of predicates
+  std::map<std::string, std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Bool>>>
+      predicate_publishers_; ///< Map of predicate publishers
 
-  state_representation::ParameterMap parameter_map_;
-  std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle> parameter_cb_handle_;
+  state_representation::ParameterMap parameter_map_; ///< ParameterMap for handling parameters
+  std::shared_ptr<rclcpp::node_interfaces::OnSetParametersCallbackHandle>
+      parameter_cb_handle_; ///< ROS callback function handle for setting parameters
 
-  std::shared_ptr<rclcpp::TimerBase> step_timer_;
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  std::shared_ptr<rclcpp::TimerBase> step_timer_; ///< Timer for the step function
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_; ///< TF buffer
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_; ///< TF listener
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_; ///< TF broadcaster
 };
 
 template<class NodeT>

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -21,14 +21,33 @@ public:
   explicit LifecycleComponent(const rclcpp::NodeOptions& node_options);
 
 protected:
+  /**
+   * @brief Add an output signal of the component.
+   * @tparam DataT Type of the data pointer
+   * @param signal_name Name of the output signal
+   * @param data Data to transmit on the output signal
+   * @param fixed_topic If true, the topic name of the output signal is fixed
+   */
   template<typename DataT>
   void add_output(const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false);
 
 private:
+  /**
+   * @brief Configure all outputs.
+   * @return True configuration was successful
+   */
   bool configure_outputs();
 
+  /**
+   * @brief Activate all outputs.
+   * @return True activation was successful
+   */
   bool activate_outputs();
 
+  /**
+   * @brief Deactivate all outputs.
+   * @return True deactivation was successful
+   */
   bool deactivate_outputs();
 
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::create_output;

--- a/source/modulo_components/src/ComponentInterface.cpp
+++ b/source/modulo_components/src/ComponentInterface.cpp
@@ -1,6 +1,15 @@
 #include "modulo_components/ComponentInterface.hpp"
 
-
 namespace modulo_components {
+
+template<NodeT>
+rclcpp::QoS ComponentInterface<NodeT>::get_qos() const {
+  return this->qos_;
+}
+
+template<NodeT>
+void ComponentInterface<NodeT>::set_qos(const rclcpp::QoS& qos) {
+  this->qos_ = qos;
+}
 
 }// namespace modulo_components

--- a/source/modulo_new_core/include/modulo_new_core/EncodedState.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/EncodedState.hpp
@@ -3,5 +3,11 @@
 #include <std_msgs/msg/u_int8_multi_array.hpp>
 
 namespace modulo_new_core {
-	typedef std_msgs::msg::UInt8MultiArray EncodedState;
+
+/**
+ * @typedef EncodedState
+ * @brief Define the EncodedState as UInt8MultiArray message type.
+ */
+typedef std_msgs::msg::UInt8MultiArray EncodedState;
+
 }

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
@@ -9,22 +9,49 @@
 
 namespace modulo_new_core::communication {
 
+/**
+ * @class MessagePair
+ * @brief The MessagePair stores a pointer to a variable and
+ * translates the value of this pointer back and forth between
+ * the corresponding ROS messages.
+ * @tparam MsgT ROS message type of the MessagePair
+ * @tparam DataT Data type corresponding to the ROS message type
+ */
 template<typename MsgT, typename DataT>
 class MessagePair : public MessagePairInterface {
 public:
+  /**
+   * @brief Constructor of the MessagePair.
+   * @param data The pointer referring to the data stored in the MessagePair
+   * @param clock The ROS clock for translating messages
+   */
   MessagePair(std::shared_ptr<DataT> data, std::shared_ptr<rclcpp::Clock> clock);
 
+  /**
+   * @brief Write the value of the data pointer to a ROS message.
+   * @return The value of the data pointer as a ROS message
+   */
   [[nodiscard]] MsgT write_message() const;
 
+  /**
+   * @brief Read a ROS message and store the value in the data pointer.
+   * @param message The ROS message to read
+   */
   void read_message(const MsgT& message);
 
+  /**
+   * @brief Get the data pointer.
+   */
   [[nodiscard]] std::shared_ptr<DataT> get_data() const;
 
+  /**
+   * @brief Set the data pointer.
+   */
   void set_data(const std::shared_ptr<DataT>& data);
 
 private:
-  std::shared_ptr<DataT> data_;
-  std::shared_ptr<rclcpp::Clock> clock_;
+  std::shared_ptr<DataT> data_; ///< Pointer referring to the data stored in the MessagePair
+  std::shared_ptr<rclcpp::Clock> clock_; ///< ROS clock for translating messages
 };
 
 template<typename MsgT, typename DataT>

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePairInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePairInterface.hpp
@@ -12,27 +12,79 @@ namespace modulo_new_core::communication {
 template<typename MsgT, typename DataT>
 class MessagePair;
 
+/**
+ * @class MessagePairInterface
+ * @brief Interface class to enable non-templated writing and reading ROS messages
+ * from derived MessagePair instances through dynamic downcasting.
+ */
 class MessagePairInterface : public std::enable_shared_from_this<MessagePairInterface> {
 public:
+  /**
+   * @brief Constructor with the message type
+   * @param type The message type of the message pair
+   */
   explicit MessagePairInterface(MessageType type);
 
+  /**
+   * @brief Default virtual destructor.
+   */
   virtual ~MessagePairInterface() = default;
 
+  /**
+   * @brief Copy constructor from another MessagePairInterface.
+   */
   MessagePairInterface(const MessagePairInterface& message_pair) = default;
 
+  /**
+   * @brief Get a pointer to a derived MessagePair instance from a MessagePairInterface pointer.
+   * @details If a MessagePairInterface pointer is used to address a derived MessagePair instance,
+   * this method will return a pointer to that derived instance through dynamic down-casting.
+   * The downcast will fail if the base MessagePairInterface object has no reference count
+   * (if the object is not owned by any pointer), or if the derived object is not a correctly
+   * typed instance of a MessagePair. By default, an InvalidPointerCastException is thrown when
+   * the downcast fails. If this validation is disabled by setting the validate_pointer flag to false,
+   * it will not throw an exception and instead return a null pointer.
+   * @tparam MsgT The ROS message type of the MessagePair
+   * @tparam DataT The data type of the MessagePair
+   * @param validate_pointer If true, throw an exception when downcasting fails
+   * @return A pointer to a derived MessagePair instance of the desired type, or a null pointer
+   * if downcasting failed and validate_pointer was set to false.
+   */
   template<typename MsgT, typename DataT>
   [[nodiscard]] std::shared_ptr<MessagePair<MsgT, DataT>> get_message_pair(bool validate_pointer = true);
 
+  /**
+   * @brief Get the ROS message of a derived MessagePair instance through the MessagePairInterface pointer.
+   * @details This throws an InvalidPointerCastException if the MessagePairInterface does not point to a
+   * valid MessagePair instance or if the specified types does not match the type of the MessagePair instance.
+   * @see MessagePairInterface::get_message_pair()
+   * @tparam MsgT The ROS message type of the MessagePair
+   * @tparam DataT The data type of the MessagePair
+   * @return The ROS message containing the data from the underlying MessagePair instance
+   */
   template<typename MsgT, typename DataT>
   [[nodiscard]] MsgT write();
 
+  /**
+   * @brief Read a ROS message and set the data of the derived MessagePair instance through the
+   * MessagePairInterface pointer.
+   * @details This throws an InvalidPointerCastException if the MessagePairInterface does not point to
+   * a valid MessagePair instance or if the specified types does not match the type of the MessagePair instance.
+   * @tparam MsgT The ROS message type of the MessagePair
+   * @tparam DataT The data type of the MessagePair
+   * @param message The ROS message to read from
+   */
   template<typename MsgT, typename DataT>
   void read(const MsgT& message);
 
+  /**
+   * @brief Get the MessageType of the MessagePairInterface.
+   * @see MessageType
+   */
   MessageType get_type() const;
 
 private:
-  MessageType type_;
+  MessageType type_; /// The message type of the MessagePairInterface
 };
 
 template<typename MsgT, typename DataT>

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessageType.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessageType.hpp
@@ -2,6 +2,10 @@
 
 namespace modulo_new_core::communication {
 
+/**
+ * @brief Enum of all supported ROS message types for the MessagePairInterface
+ * @see MessagePairInterface
+ */
 enum class MessageType {
   BOOL, FLOAT64, FLOAT64_MULTI_ARRAY, INT32, STRING, ENCODED_STATE
 };

--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherHandler.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherHandler.hpp
@@ -7,22 +7,48 @@
 
 namespace modulo_new_core::communication {
 
+/**
+ * @class PublisherHandler
+ * @brief The PublisherHandler handles different types of ROS publishers to activate, deactivate and publish
+ * data with those publishers.
+ * @tparam PubT The ROS publisher type
+ * @tparam MsgT The ROS message type of the ROS publisher
+ */
 template<typename PubT, typename MsgT>
 class PublisherHandler : public PublisherInterface {
 public:
+  /**
+   * @brief Constructor with the publisher type and the pointer to the ROS publisher.
+   * @param type The publisher type
+   * @param publisher The pointer to the ROS publisher
+   */
   PublisherHandler(PublisherType type, std::shared_ptr<PubT> publisher);
 
+  /**
+   * @brief Activate the ROS publisher if applicable.
+   */
   void on_activate();
 
+  /**
+   * @brief Deactivate the ROS publisher if applicable.
+   */
   void on_deactivate();
 
+  /**
+   * @brief Publish the ROS message through the ROS publisher.
+   * @param message The ROS message to publish
+   */
   void publish(const MsgT& message) const;
 
+  /**
+   * @brief Create a PublisherInterface instance from the current PublisherHandler.
+   * @param message_pair The message pair of the PublisherInterface
+   */
   std::shared_ptr<PublisherInterface>
   create_publisher_interface(const std::shared_ptr<MessagePairInterface>& message_pair);
 
 private:
-  std::shared_ptr<PubT> publisher_;
+  std::shared_ptr<PubT> publisher_; ///< The ROS publisher
 };
 
 template<typename PubT, typename MsgT>

--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherInterface.hpp
@@ -13,35 +13,107 @@ namespace modulo_new_core::communication {
 template<typename PubT, typename MsgT>
 class PublisherHandler;
 
+/**
+ * @class PublisherInterface
+ * @brief Interface class to enable non-templated activating/deactivating/publishing of ROS publishers
+ * from derived PublisherHandler instances through dynamic downcasting.
+ */
 class PublisherInterface : public std::enable_shared_from_this<PublisherInterface> {
 public:
+  /**
+   * @brief Constructor with the message type and message pair.
+   * @param type The type of the publisher interface
+   * @param message_pair The message pair with the data to be published
+   */
   explicit PublisherInterface(PublisherType type, std::shared_ptr<MessagePairInterface> message_pair = nullptr);
 
+  /**
+   * @brief Copy constructor from another PublisherInterface.
+   */
   PublisherInterface(const PublisherInterface& publisher) = default;
 
+  /**
+   * @brief Default virtual destructor.
+   */
   virtual ~PublisherInterface() = default;
 
+  /**
+   * @brief Get a pointer to a derived PublisherHandler instance from a PublisherInterface pointer.
+   * @details If a PublisherInterface pointer is used to address a derived PublisherHandler instance,
+   * this method will return a pointer to that derived instance through dynamic down-casting.
+   * The downcast will fail if the base PublisherInterface object has no reference count
+   * (if the object is not owned by any pointer), or if the derived object is not a correctly
+   * typed instance of a PublisherHandler. By default, an InvalidPointerCastException is thrown when
+   * the downcast fails. If this validation is disabled by setting the validate_pointer flag to false,
+   * it will not throw an exception and instead return a null pointer.
+   * @tparam PubT The ROS publisher type
+   * @tparam MsgT The ROS message type
+   * @param validate_pointer If true, throw an exception when downcasting fails
+   * @return A pointer to a derived PublisherHandler instance of the desired type, or a null pointer
+   * if downcasting failed and validate_pointer was set to false.
+   */
   template<typename PubT, typename MsgT>
   std::shared_ptr<PublisherHandler<PubT, MsgT>> get_handler(bool validate_pointer = true);
 
+  /**
+   * @brief Activate ROS publisher of a derived PublisherHandler instance through the PublisherInterface pointer.
+   * @details This throws an InvalidPointerCastException if the PublisherInterface does not point to
+   * a valid PublisherHandler instance or if the type of the message pair does not match the
+   * type of the PublisherHandler instance.
+   * @see PublisherInterface::get_handler()
+   */
   void activate();
 
+  /**
+   * @brief Deactivate ROS publisher of a derived PublisherHandler instance through the PublisherInterface pointer.
+   * @details This throws an InvalidPointerCastException if the PublisherInterface does not point to
+   * a valid PublisherHandler instance or if the type of the message pair does not match the
+   * type of the PublisherHandler instance.
+   * @see PublisherInterface::get_handler()
+   */
   void deactivate();
 
+  /**
+   * @brief Publish the data stored in the message pair through the ROS publisher of a derived PublisherHandler
+   * instance through the PublisherInterface pointer.
+   * @details This throws an InvalidPointerCastException if the PublisherInterface does not point to
+   * a valid PublisherHandler instance or if the type of the message pair does not match the
+   * type of the PublisherHandler instance.
+   * @see PublisherInterface::get_handler()
+   */
   void publish();
 
+  /**
+   * @brief Get the pointer to the message pair of the PublisherInterface.
+   */
   [[nodiscard]] std::shared_ptr<MessagePairInterface> get_message_pair() const;
 
+  /**
+   * @brief Set the pointer to the message pair of the PublisherInterface.
+   */
   void set_message_pair(const std::shared_ptr<MessagePairInterface>& message_pair);
 
+  /**
+   * @brief Get the type of the publisher interface.
+   * @see PublisherType
+   */
   PublisherType get_type() const;
 
 private:
+  /**
+   * @brief Publish the data stored in the message pair through the ROS publisher of a derived PublisherHandler
+   * instance through the PublisherInterface pointer.
+   * @details This throws an InvalidPointerCastException if the PublisherInterface does not point to a
+   * valid PublisherHandler instance or if the specified type does not match the type of the PublisherHandler instance.
+   * @see PublisherInterface::get_handler()
+   * @tparam MsgT Message type of the PublisherHandler
+   * @param message The ROS message to publish through the ROS publisher
+   */
   template<typename MsgT>
   void publish(const MsgT& message);
 
-  PublisherType type_;
-  std::shared_ptr<MessagePairInterface> message_pair_;
+  PublisherType type_; ///< The type of the publisher interface
+  std::shared_ptr<MessagePairInterface> message_pair_; ///< The pointer to the stored MessagePair instance
 };
 
 template<typename PubT, typename MsgT>

--- a/source/modulo_new_core/include/modulo_new_core/communication/PublisherType.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/PublisherType.hpp
@@ -2,6 +2,10 @@
 
 namespace modulo_new_core::communication {
 
+/**
+ * @brief Enum of supported ROS publisher types for the PublisherInterface.
+ * @see PublisherInterface
+ */
 enum class PublisherType {
   PUBLISHER, LIFECYCLE_PUBLISHER
 };


### PR DESCRIPTION
As title says, only code change is the protected getter and setter of the Quality of Service attribute for publishers/subscribers. Everything else are just docstrings
@buschbapti 