### PR TITLE
Subscription handler/interface and add_input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 ARG BASE_TAG=galactic
 FROM ghcr.io/aica-technology/ros2-control-libraries:${BASE_TAG} as dependencies
-
-# upgrade ament_cmake_python
-RUN sudo apt update && sudo apt install -y ros-${ROS_DISTRO}-ament-cmake-python && sudo rm -rf /var/lib/apt/lists/*
 WORKDIR ${HOME}/ros2_ws
 
 

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -34,6 +34,7 @@ protected:
 
 private:
   using ComponentInterface<rclcpp::Node>::create_output;
+  using ComponentInterface<rclcpp::Node>::outputs_;
   using ComponentInterface<rclcpp::Node>::qos_;
 };
 

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -25,6 +25,7 @@ protected:
    * @param signal_name Name of the output signal
    * @param data Data to transmit on the output signal
    * @param fixed_topic If true, the topic name of the output signal is fixed
+   * @param default_topic If set, the default value for the topic name to use
    */
   template<typename DataT>
   void add_output(

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -30,6 +30,7 @@ template<class NodeT>
 class ComponentInterface : public NodeT {
 public:
   friend class ComponentInterfacePublicInterface;
+  friend class ComponentInterfaceParameterPublicInterface;
 
   /**
    * @brief Constructor from node options

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -139,12 +139,28 @@ protected:
    */
   void set_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function);
 
+  /**
+   * @brief Add and configure an input signal of the component.
+   * @tparam DataT Type of the data pointer
+   * @param signal_name Name of the output signal
+   * @param data Data to transmit on the output signal
+   * @param fixed_topic If true, the topic name of the output signal is fixed
+   * @param default_topic If set, the default value for the topic name to use
+   */
   template<typename DataT>
   void add_input(
       const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false,
       const std::string& default_topic = ""
   );
 
+  /**
+   * @brief Add and configure an input signal of the component.
+   * @tparam MsgT The ROS message type of the subscription
+   * @param signal_name Name of the output signal
+   * @param callback The callback to use for the subscription
+   * @param fixed_topic If true, the topic name of the output signal is fixed
+   * @param default_topic If set, the default value for the topic name to use
+   */
   template<typename MsgT>
   void add_input(
       const std::string& signal_name, const std::function<void(const std::shared_ptr<MsgT>)>& callback,

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -303,13 +303,13 @@ void ComponentInterface<NodeT>::add_variant_predicate(
 ) {
   if (this->predicates_.find(name) != this->predicates_.end()) {
     RCLCPP_DEBUG_STREAM(this->get_logger(), "Predicate " << name << " already exists, overwriting.");
-    this->predicates_.at(name) = predicate;
   } else {
-    this->predicates_.insert(std::make_pair(name, predicate));
-    this->predicate_publishers_.insert(
-        std::make_pair(
-            name, this->template create_publisher<std_msgs::msg::Bool>(this->generate_predicate_topic(name), 10)));
+    this->predicate_publishers_.insert_or_assign(
+        name, this->template create_publisher<std_msgs::msg::Bool>(
+            this->generate_predicate_topic(name), 10
+        ));
   }
+  this->predicates_.insert_or_assign(name, predicate);
 }
 
 template<class NodeT>

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -27,6 +27,7 @@ protected:
    * @param signal_name Name of the output signal
    * @param data Data to transmit on the output signal
    * @param fixed_topic If true, the topic name of the output signal is fixed
+   * @param default_topic If set, the default value for the topic name to use
    */
   template<typename DataT>
   void add_output(const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false);

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -51,6 +51,7 @@ private:
   bool deactivate_outputs();
 
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::create_output;
+  using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::outputs_;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::qos_;
 };
 

--- a/source/modulo_components/include/modulo_components/exceptions/SignalAlreadyExistsException.hpp
+++ b/source/modulo_components/include/modulo_components/exceptions/SignalAlreadyExistsException.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace modulo_components::exceptions {
+class SignalAlreadyExistsException : public std::runtime_error {
+public:
+  explicit SignalAlreadyExistsException(const std::string& msg) : std::runtime_error(msg) {};
+};
+}

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -7,6 +7,19 @@
 #include "modulo_new_core/EncodedState.hpp"
 
 namespace modulo_components {
+
+class ComponentInterfacePublicInterface : public ComponentInterface<rclcpp::Node> {
+public:
+  explicit ComponentInterfacePublicInterface(const rclcpp::NodeOptions& node_options) :
+      ComponentInterface<rclcpp::Node>(node_options, modulo_new_core::communication::PublisherType::PUBLISHER) {}
+  using ComponentInterface<rclcpp::Node>::add_predicate;
+  using ComponentInterface<rclcpp::Node>::get_predicate;
+  using ComponentInterface<rclcpp::Node>::set_predicate;
+  using ComponentInterface<rclcpp::Node>::predicates_;
+  using ComponentInterface<rclcpp::Node>::add_input;
+  using ComponentInterface<rclcpp::Node>::inputs_;
+};
+
 class ComponentInterfaceTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
@@ -18,83 +31,67 @@ protected:
   }
 
   void SetUp() override {
-    component_ = std::make_shared<ComponentInterface<rclcpp::Node>>(
-        rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::PUBLISHER
-    );
+    component_ = std::make_shared<ComponentInterfacePublicInterface>(rclcpp::NodeOptions());
   }
 
-  std::map<std::string, utilities::PredicateVariant> get_predicate_map() {
-    return component_->predicates_;
-  }
-
-  void add_predicate(const std::string& name, bool value) {
-    component_->add_predicate(name, value);
-  }
-
-  void add_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function) {
-    component_->add_predicate(predicate_name, predicate_function);
-  }
-
-  bool get_predicate(const std::string& predicate_name) const {
-    return component_->get_predicate(predicate_name);
-  }
-
-  void set_predicate(const std::string& predicate_name, bool predicate_value) {
-    component_->set_predicate(predicate_name, predicate_value);
-  }
-
-  void set_predicate(const std::string& predicate_name, const std::function<bool(void)>& predicate_function) {
-    component_->set_predicate(predicate_name, predicate_function);
-  }
-
-  std::shared_ptr<ComponentInterface<rclcpp::Node>> component_;
+  std::shared_ptr<ComponentInterfacePublicInterface> component_;
 };
 
 TEST_F(ComponentInterfaceTest, AddBoolPredicate) {
-  add_predicate("foo", true);
-  auto predicates = get_predicate_map();
-  auto predicate_iterator = predicates.find("foo");
-  EXPECT_TRUE(predicate_iterator != predicates.end());
+  this->component_->add_predicate("foo", true);
+  auto predicate_iterator = this->component_->predicates_.find("foo");
+  EXPECT_TRUE(predicate_iterator != this->component_->predicates_.end());
   auto value = std::get<bool>(predicate_iterator->second);
   EXPECT_TRUE(value);
 }
 
 TEST_F(ComponentInterfaceTest, AddFunctionPredicate) {
-  add_predicate("bar", [&]() { return false; });
-  auto predicates = get_predicate_map();
-  auto predicate_iterator = predicates.find("bar");
-  EXPECT_TRUE(predicate_iterator != predicates.end());
+  this->component_->add_predicate("bar", [&]() { return false; });
+  auto predicate_iterator = component_->predicates_.find("bar");
+  EXPECT_TRUE(predicate_iterator != component_->predicates_.end());
   auto value_callback = std::get<std::function<bool(void)>>(predicate_iterator->second);
   EXPECT_FALSE((value_callback)());
 }
 
 TEST_F(ComponentInterfaceTest, GetPredicateValue) {
-  add_predicate("foo", true);
-  EXPECT_TRUE(get_predicate("foo"));
-  add_predicate("bar", [&]() { return true; });
-  EXPECT_TRUE(get_predicate("bar"));
+  this->component_->add_predicate("foo", true);
+  EXPECT_TRUE(this->component_->get_predicate("foo"));
+  this->component_->add_predicate("bar", [&]() { return true; });
+  EXPECT_TRUE(this->component_->get_predicate("bar"));
   // predicate does not exist, expect false
-  EXPECT_FALSE(get_predicate("test"));
+  EXPECT_FALSE(this->component_->get_predicate("test"));
   // error in callback function except false
-  add_predicate(
+  this->component_->add_predicate(
       "error", [&]() {
         throw std::runtime_error("An error occurred");
         return false;
       }
   );
-  EXPECT_FALSE(get_predicate("error"));
+  EXPECT_FALSE(this->component_->get_predicate("error"));
 }
 
 TEST_F(ComponentInterfaceTest, SetPredicateValue) {
-  add_predicate("foo", true);
-  set_predicate("foo", false);
-  EXPECT_FALSE(get_predicate("foo"));
+  this->component_->add_predicate("foo", true);
+  this->component_->set_predicate("foo", false);
+  EXPECT_FALSE(this->component_->get_predicate("foo"));
   // predicate does not exist so setting won't do anything
-  set_predicate("bar", true);
-  EXPECT_FALSE(get_predicate("bar"));
-  add_predicate("bar", true);
-  set_predicate("bar", [&]() { return false; });
-  EXPECT_FALSE(get_predicate("bar"));
+  this->component_->set_predicate("bar", true);
+  EXPECT_FALSE(this->component_->get_predicate("bar"));
+  this->component_->add_predicate("bar", true);
+  this->component_->set_predicate("bar", [&]() { return false; });
+  EXPECT_FALSE(this->component_->get_predicate("bar"));
 }
 
-} // namespace modulo_components
+TEST_F(ComponentInterfaceTest, AddInput) {
+  auto data = std::make_shared<bool>(true);
+  EXPECT_NO_THROW(this->component_->add_input("_tEsT_#1@3", data, true));
+  auto inputs_iterator = component_->inputs_.find("test_13");
+  EXPECT_TRUE(inputs_iterator != component_->inputs_.end());
+
+  EXPECT_NO_THROW(this->component_->template add_input<std_msgs::msg::Bool>(
+      "_tEsT_#1@5", [](const std::shared_ptr<std_msgs::msg::Bool> msg) {}
+  ));
+  inputs_iterator = component_->inputs_.find("test_15");
+  EXPECT_TRUE(inputs_iterator != component_->inputs_.end());
+}
+}

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -89,9 +89,15 @@ TEST_F(ComponentInterfaceTest, AddInput) {
   EXPECT_TRUE(inputs_iterator != component_->inputs_.end());
 
   EXPECT_NO_THROW(this->component_->template add_input<std_msgs::msg::Bool>(
-      "_tEsT_#1@5", [](const std::shared_ptr<std_msgs::msg::Bool> msg) {}
+      "_tEsT_#1@5", [](const std::shared_ptr<std_msgs::msg::Bool>) {}
   ));
   inputs_iterator = component_->inputs_.find("test_15");
   EXPECT_TRUE(inputs_iterator != component_->inputs_.end());
+
+  this->component_->template add_input<std_msgs::msg::String>(
+      "test_13", [](const std::shared_ptr<std_msgs::msg::String>) {}
+  );
+  EXPECT_EQ(this->component_->inputs_.at("test_13")->get_message_pair()->get_type(),
+            modulo_new_core::communication::MessageType::BOOL);
 }
 }

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -12,7 +12,7 @@ namespace modulo_components {
 
 class ComponentInterfacePublicInterface : public ComponentInterface<rclcpp::Node> {
 public:
-  ComponentInterfacePublicInterface(const rclcpp::NodeOptions& node_options) :
+  explicit ComponentInterfacePublicInterface(const rclcpp::NodeOptions& node_options) :
       ComponentInterface<rclcpp::Node>(node_options, modulo_new_core::communication::PublisherType::PUBLISHER) {}
   using ComponentInterface<rclcpp::Node>::add_parameter;
   using ComponentInterface<rclcpp::Node>::get_parameter;

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -10,9 +10,9 @@
 
 namespace modulo_components {
 
-class ComponentInterfacePublicInterface : public ComponentInterface<rclcpp::Node> {
+class ComponentInterfaceParameterPublicInterface : public ComponentInterface<rclcpp::Node> {
 public:
-  explicit ComponentInterfacePublicInterface(const rclcpp::NodeOptions& node_options) :
+  explicit ComponentInterfaceParameterPublicInterface(const rclcpp::NodeOptions& node_options) :
       ComponentInterface<rclcpp::Node>(node_options, modulo_new_core::communication::PublisherType::PUBLISHER) {}
   using ComponentInterface<rclcpp::Node>::add_parameter;
   using ComponentInterface<rclcpp::Node>::get_parameter;
@@ -52,7 +52,7 @@ protected:
   }
 
   void SetUp() override {
-    component_ = std::make_shared<ComponentInterfacePublicInterface>(rclcpp::NodeOptions());
+    component_ = std::make_shared<ComponentInterfaceParameterPublicInterface>(rclcpp::NodeOptions());
     param_ = state_representation::make_shared_parameter("test", 1);
   }
 
@@ -63,7 +63,7 @@ protected:
     EXPECT_EQ(component_->parameter_map_.get_parameter_value<T>("test"), value);
   }
 
-  std::shared_ptr<ComponentInterfacePublicInterface> component_;
+  std::shared_ptr<ComponentInterfaceParameterPublicInterface> component_;
   std::shared_ptr<state_representation::Parameter<int>> param_;
 };
 

--- a/source/modulo_new_core/CMakeLists.txt
+++ b/source/modulo_new_core/CMakeLists.txt
@@ -30,6 +30,8 @@ ament_auto_add_library(modulo_new_core SHARED
     ${PROJECT_SOURCE_DIR}/src/communication/MessagePair.cpp
     ${PROJECT_SOURCE_DIR}/src/communication/MessagePairInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/communication/PublisherInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/communication/SubscriptionHandler.cpp
+    ${PROJECT_SOURCE_DIR}/src/communication/SubscriptionInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/translators/parameter_translators.cpp
     ${PROJECT_SOURCE_DIR}/src/translators/message_readers.cpp
     ${PROJECT_SOURCE_DIR}/src/translators/message_writers.cpp)

--- a/source/modulo_new_core/include/modulo_new_core/communication/SubscriptionHandler.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/SubscriptionHandler.hpp
@@ -7,7 +7,7 @@ namespace modulo_new_core::communication {
 template<typename MsgT>
 class SubscriptionHandler : public SubscriptionInterface {
 public:
-  explicit SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair);
+  explicit SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair = nullptr);
 
   [[nodiscard]] std::shared_ptr<rclcpp::Subscription<MsgT>> get_subscription() const;
 
@@ -34,13 +34,6 @@ void SubscriptionHandler<MsgT>::set_subscription(const std::shared_ptr<rclcpp::S
   }
   this->subscription_ = subscription;
 }
-
-//auto handler = std::make_shared<communication::SubscriptionHandler<RecT, MsgT>>(recipient, timeout);
-//handler->set_subscription(this->create_subscription<MsgT>(channel, queue_size, [handler](const std::shared_ptr<MsgT> msg) { handler->subscription_callback(msg); }));
-//this->handlers_.insert(std::make_pair(channel, std::make_pair(handler, always_active)));
-//if (always_active) {
-//handler->activate();
-//}
 
 template<typename MsgT>
 std::shared_ptr<SubscriptionInterface> SubscriptionHandler<MsgT>::create_subscription_interface(

--- a/source/modulo_new_core/include/modulo_new_core/communication/SubscriptionHandler.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/SubscriptionHandler.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "modulo_new_core/communication/SubscriptionInterface.hpp"
+
+namespace modulo_new_core::communication {
+
+template<typename MsgT>
+class SubscriptionHandler : public SubscriptionInterface {
+public:
+  explicit SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair);
+
+  [[nodiscard]] std::shared_ptr<rclcpp::Subscription<MsgT>> get_subscription() const;
+
+  void set_subscription(const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription);
+
+  std::function<void(const std::shared_ptr<MsgT>)> get_callback();
+
+  std::shared_ptr<SubscriptionInterface>
+  create_subscription_interface(const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription);
+
+private:
+  std::shared_ptr<rclcpp::Subscription<MsgT>> subscription_;
+};
+
+template<typename MsgT>
+std::shared_ptr<rclcpp::Subscription<MsgT>> SubscriptionHandler<MsgT>::get_subscription() const {
+  return this->subscription_;
+}
+
+template<typename MsgT>
+void SubscriptionHandler<MsgT>::set_subscription(const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription) {
+  if (subscription == nullptr) {
+    throw exceptions::NullPointerException("Provide a valid pointer");
+  }
+  this->subscription_ = subscription;
+}
+
+//auto handler = std::make_shared<communication::SubscriptionHandler<RecT, MsgT>>(recipient, timeout);
+//handler->set_subscription(this->create_subscription<MsgT>(channel, queue_size, [handler](const std::shared_ptr<MsgT> msg) { handler->subscription_callback(msg); }));
+//this->handlers_.insert(std::make_pair(channel, std::make_pair(handler, always_active)));
+//if (always_active) {
+//handler->activate();
+//}
+
+template<typename MsgT>
+std::shared_ptr<SubscriptionInterface> SubscriptionHandler<MsgT>::create_subscription_interface(
+    const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription
+) {
+  this->set_subscription(subscription);
+  return std::shared_ptr<SubscriptionInterface>(this->shared_from_this());
+}
+
+}// namespace modulo_new_core::communication

--- a/source/modulo_new_core/include/modulo_new_core/communication/SubscriptionInterface.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/SubscriptionInterface.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <rclcpp/subscription.hpp>
+#include "modulo_new_core/communication/MessagePair.hpp"
+
+namespace modulo_new_core::communication {
+
+// forward declaration of derived Subscription class
+template<typename MsgT>
+class SubscriptionHandler;
+
+class SubscriptionInterface : public std::enable_shared_from_this<SubscriptionInterface> {
+public:
+  explicit SubscriptionInterface(std::shared_ptr<MessagePairInterface> message_pair = nullptr);
+
+  SubscriptionInterface(const SubscriptionInterface& subscription) = default;
+
+  virtual ~SubscriptionInterface() = default;
+
+  template<typename MsgT>
+  std::shared_ptr<SubscriptionHandler<MsgT>> get_handler(bool validate_pointer = true);
+
+  [[nodiscard]] std::shared_ptr<MessagePairInterface> get_message_pair() const;
+
+  void set_message_pair(const std::shared_ptr<MessagePairInterface>& message_pair);
+
+private:
+  std::shared_ptr<MessagePairInterface> message_pair_;
+};
+
+template<typename MsgT>
+inline std::shared_ptr<SubscriptionHandler<MsgT>> SubscriptionInterface::get_handler(bool validate_pointer) {
+  std::shared_ptr<SubscriptionHandler<MsgT>> subscription_ptr;
+  try {
+    subscription_ptr = std::dynamic_pointer_cast<SubscriptionHandler<MsgT>>(this->shared_from_this());
+  } catch (const std::exception& ex) {
+    if (validate_pointer) {
+      throw exceptions::InvalidPointerException("Subscription interface is not managed by a valid pointer");
+    }
+  }
+  if (subscription_ptr == nullptr && validate_pointer) {
+    throw exceptions::InvalidPointerCastException(
+        "Unable to cast subscription interface to a subscription pointer of requested type"
+    );
+  }
+  return subscription_ptr;
+}
+
+}// namespace modulo_new_core::communication

--- a/source/modulo_new_core/src/communication/SubscriptionHandler.cpp
+++ b/source/modulo_new_core/src/communication/SubscriptionHandler.cpp
@@ -1,0 +1,79 @@
+#include "modulo_new_core/communication/SubscriptionHandler.hpp"
+
+#include <utility>
+
+namespace modulo_new_core::communication {
+
+template<>
+SubscriptionHandler<std_msgs::msg::Bool>::SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair) :
+    SubscriptionInterface(std::move(message_pair)) {}
+
+template<>
+SubscriptionHandler<std_msgs::msg::Float64>::SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair) :
+    SubscriptionInterface(std::move(message_pair)) {}
+template<>
+SubscriptionHandler<std_msgs::msg::Float64MultiArray>::SubscriptionHandler(
+    std::shared_ptr<MessagePairInterface> message_pair
+) :
+    SubscriptionInterface(std::move(message_pair)) {}
+
+template<>
+SubscriptionHandler<std_msgs::msg::Int32>::SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair) :
+    SubscriptionInterface(std::move(message_pair)) {}
+
+template<>
+SubscriptionHandler<std_msgs::msg::String>::SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair) :
+    SubscriptionInterface(std::move(message_pair)) {}
+
+template<>
+SubscriptionHandler<EncodedState>::SubscriptionHandler(std::shared_ptr<MessagePairInterface> message_pair) :
+    SubscriptionInterface(std::move(message_pair)) {}
+
+template<>
+std::function<void(const std::shared_ptr<std_msgs::msg::Bool>)>
+SubscriptionHandler<std_msgs::msg::Bool>::get_callback() {
+  return [this](const std::shared_ptr<std_msgs::msg::Bool> message) {
+    this->get_message_pair()->template read<std_msgs::msg::Bool, bool>(*message);
+  };
+}
+
+template<>
+std::function<void(const std::shared_ptr<std_msgs::msg::Float64>)>
+SubscriptionHandler<std_msgs::msg::Float64>::get_callback() {
+  return [this](const std::shared_ptr<std_msgs::msg::Float64> message) {
+    this->get_message_pair()->template read<std_msgs::msg::Float64, double>(*message);
+  };
+}
+
+template<>
+std::function<void(const std::shared_ptr<std_msgs::msg::Float64MultiArray>)>
+SubscriptionHandler<std_msgs::msg::Float64MultiArray>::get_callback() {
+  return [this](const std::shared_ptr<std_msgs::msg::Float64MultiArray> message) {
+    this->get_message_pair()->template read<std_msgs::msg::Float64MultiArray, std::vector<double>>(*message);
+  };
+}
+
+template<>
+std::function<void(const std::shared_ptr<std_msgs::msg::Int32>)>
+SubscriptionHandler<std_msgs::msg::Int32>::get_callback() {
+  return [this](const std::shared_ptr<std_msgs::msg::Int32> message) {
+    this->get_message_pair()->template read<std_msgs::msg::Int32, int>(*message);
+  };
+}
+
+template<>
+std::function<void(const std::shared_ptr<std_msgs::msg::String>)>
+SubscriptionHandler<std_msgs::msg::String>::get_callback() {
+  return [this](const std::shared_ptr<std_msgs::msg::String> message) {
+    this->get_message_pair()->template read<std_msgs::msg::String, std::string>(*message);
+  };
+}
+
+template<>
+std::function<void(const std::shared_ptr<EncodedState>)> SubscriptionHandler<EncodedState>::get_callback() {
+  return [this](const std::shared_ptr<EncodedState> message) {
+    this->get_message_pair()->template read<EncodedState, state_representation::State>(*message);
+  };
+}
+
+}// namespace modulo_new_core::communication

--- a/source/modulo_new_core/src/communication/SubscriptionInterface.cpp
+++ b/source/modulo_new_core/src/communication/SubscriptionInterface.cpp
@@ -1,0 +1,19 @@
+#include "modulo_new_core/communication/SubscriptionInterface.hpp"
+
+namespace modulo_new_core::communication {
+
+SubscriptionInterface::SubscriptionInterface(std::shared_ptr<MessagePairInterface> message_pair) :
+    message_pair_(std::move(message_pair)) {}
+
+std::shared_ptr<MessagePairInterface> SubscriptionInterface::get_message_pair() const {
+  return this->message_pair_;
+}
+
+void SubscriptionInterface::set_message_pair(const std::shared_ptr<MessagePairInterface>& message_pair) {
+  if (message_pair == nullptr) {
+    throw exceptions::NullPointerException("Provide a valid pointer");
+  }
+  this->message_pair_ = message_pair;
+}
+
+}// namespace modulo_new_core::communication

--- a/source/modulo_new_core/test/cpp_tests/communication/test_subscription_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_subscription_handler.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <rclcpp/node.hpp>
+
+#include "modulo_new_core/communication/SubscriptionHandler.hpp"
+#include "modulo_new_core/exceptions/NullPointerException.hpp"
+
+using namespace modulo_new_core::communication;
+
+template<typename MsgT, typename DataT>
+static void test_subscription_interface(const std::shared_ptr<rclcpp::Node>& node, const DataT& value) {
+  // create message pair
+  auto data = std::make_shared<DataT>(value);
+  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, node->get_clock());
+
+  // create subscription handler
+  auto subscription_handler = std::make_shared<SubscriptionHandler<MsgT>>(msg_pair);
+  auto subscription = node->template create_subscription<MsgT>(
+      "topic", 10, subscription_handler->get_callback());
+
+  // use in subscription interface
+  auto subscription_interface = subscription_handler->create_subscription_interface(subscription);
+}
+
+class SubscriptionTest : public ::testing::Test {
+public:
+  static void SetUpTestSuite() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
+protected:
+  void SetUp() {
+    node = std::make_shared<rclcpp::Node>("test_node");
+  }
+
+  std::shared_ptr<rclcpp::Node> node;
+};
+
+TEST_F(SubscriptionTest, BasicTypes) {
+  test_subscription_interface<std_msgs::msg::Bool, bool>(node, true);
+  test_subscription_interface<std_msgs::msg::Float64, double>(node, 0.1);
+  test_subscription_interface<std_msgs::msg::Float64MultiArray, std::vector<double>>(node, {0.1, 0.2, 0.3});
+  test_subscription_interface<std_msgs::msg::Int32, int>(node, 1);
+  test_subscription_interface<std_msgs::msg::String, std::string>(node, "this");
+}
+
+TEST_F(SubscriptionTest, CartesianState) {
+  // create message pair
+  auto data =
+      std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));
+  auto msg_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
+      data, node->get_clock());
+
+  // create subscription handler
+  auto subscription_handler = std::make_shared<SubscriptionHandler<modulo_new_core::EncodedState>>(msg_pair);
+  auto subscription = node->create_subscription<modulo_new_core::EncodedState>(
+      "topic", 10, subscription_handler->get_callback());
+
+  // use in subscription interface
+  auto subscription_interface = subscription_handler->create_subscription_interface(subscription);
+}


### PR DESCRIPTION
Quite a big step IMO, I added a SubscriptionInterface and SubscriptionHandler to `modulo_new_core` in order to be able to create and store ROS subscriptions in non-templated pointers.
Subscriptions can be added in two ways, see `add_input` in ComponentInterface:
- Either by providing a shared pointer to a variable, which creates a message pair to read the state in the subscription callback
- or by providing a callback function

I would like to update the tests so they run on both the LifecycleNode and the Node but that can be done in a subsequent PR