### PR TITLE
Parameter translators in python

### DIFF
--- a/source/modulo_components/src/ComponentInterface.cpp
+++ b/source/modulo_components/src/ComponentInterface.cpp
@@ -2,12 +2,12 @@
 
 namespace modulo_components {
 
-template<NodeT>
+template<class NodeT>
 rclcpp::QoS ComponentInterface<NodeT>::get_qos() const {
   return this->qos_;
 }
 
-template<NodeT>
+template<class NodeT>
 void ComponentInterface<NodeT>::set_qos(const rclcpp::QoS& qos) {
   this->qos_ = qos;
 }

--- a/source/modulo_new_core/modulo_new_core/translators/parameter_translators.py
+++ b/source/modulo_new_core/modulo_new_core/translators/parameter_translators.py
@@ -1,0 +1,154 @@
+from rclpy import Parameter
+import state_representation as sr
+import clproto
+import numpy as np
+from typing import Union
+
+
+def write_parameter(parameter: sr.Parameter) -> Parameter:
+    if parameter.get_parameter_type() == sr.ParameterType.BOOL or \
+            parameter.get_parameter_type() == sr.ParameterType.BOOL_ARRAY or \
+            parameter.get_parameter_type() == sr.ParameterType.INT or \
+            parameter.get_parameter_type() == sr.ParameterType.INT_ARRAY or \
+            parameter.get_parameter_type() == sr.ParameterType.DOUBLE or \
+            parameter.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY or \
+            parameter.get_parameter_type() == sr.ParameterType.STRING or \
+            parameter.get_parameter_type() == sr.ParameterType.STRING_ARRAY:
+        return Parameter(parameter.get_name(), value=parameter.get_value())
+    elif parameter.get_parameter_type() == sr.ParameterType.STATE:
+        if parameter.get_parameter_state_type() == sr.StateType.CARTESIAN_STATE:
+            return Parameter(parameter.get_name(), Parameter.Type.STRING, clproto.to_json(
+                clproto.encode(parameter.get_value(), clproto.MessageType.CARTESIAN_STATE_MESSAGE)))
+        elif parameter.get_parameter_state_type() == sr.StateType.CARTESIAN_POSE:
+            return Parameter(parameter.get_name(), Parameter.Type.STRING, clproto.to_json(
+                clproto.encode(parameter.get_value(), clproto.MessageType.CARTESIAN_POSE_MESSAGE)))
+        elif parameter.get_parameter_state_type() == sr.StateType.JOINT_STATE:
+            return Parameter(parameter.get_name(), Parameter.Type.STRING, clproto.to_json(
+                clproto.encode(parameter.get_value(), clproto.MessageType.JOINT_STATE_MESSAGE)))
+        if parameter.get_parameter_state_type() == sr.StateType.JOINT_POSITIONS:
+            return Parameter(parameter.get_name(), Parameter.Type.STRING, clproto.to_json(
+                clproto.encode(parameter.get_value(), clproto.MessageType.JOINT_POSITIONS_MESSAGE)))
+        else:
+            raise RuntimeError(f"Parameter {parameter.get_name()} could not be written!")
+    elif parameter.get_parameter_type() == sr.ParameterType.VECTOR or \
+            parameter.get_parameter_type() == sr.ParameterType.MATRIX:
+        return Parameter(parameter.get_name(), value=parameter.get_value().flatten().tolist())
+    else:
+        raise RuntimeError(f"Parameter {parameter.get_name()} could not be written!")
+
+
+def copy_parameter_value(source_parameter: sr.Parameter, parameter: sr.Parameter):
+    if source_parameter.get_parameter_type() != parameter.get_parameter_type():
+        raise RuntimeError(f"Source parameter {source_parameter.get_name()} to be copied does not have the same type "
+                           f"as destination parameter {parameter.get_name()}")
+    if source_parameter.get_parameter_type() == sr.ParameterType.BOOL or \
+            source_parameter.get_parameter_type() == sr.ParameterType.BOOL_ARRAY or \
+            source_parameter.get_parameter_type() == sr.ParameterType.INT or \
+            source_parameter.get_parameter_type() == sr.ParameterType.INT_ARRAY or \
+            source_parameter.get_parameter_type() == sr.ParameterType.DOUBLE or \
+            source_parameter.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY or \
+            source_parameter.get_parameter_type() == sr.ParameterType.STRING or \
+            source_parameter.get_parameter_type() == sr.ParameterType.STRING_ARRAY or \
+            source_parameter.get_parameter_type() == sr.ParameterType.VECTOR or \
+            source_parameter.get_parameter_type() == sr.ParameterType.MATRIX:
+        parameter.set_value(source_parameter.get_value())
+    elif source_parameter.get_parameter_type() == sr.ParameterType.STATE:
+        if source_parameter.get_parameter_state_type() != parameter.get_parameter_state_type():
+            raise RuntimeError(
+                f"Source parameter {source_parameter.get_name()} to be copied does not have the same state type "
+                f"as destination parameter {parameter.get_name()}")
+        if source_parameter.get_parameter_state_type() == sr.StateType.CARTESIAN_STATE or \
+                source_parameter.get_parameter_state_type() == sr.StateType.CARTESIAN_POSE or \
+                source_parameter.get_parameter_state_type() == sr.StateType.JOINT_STATE or \
+                source_parameter.get_parameter_state_type() == sr.StateType.JOINT_POSITIONS:
+            parameter.set_value(source_parameter.get_value())
+        else:
+            raise RuntimeError(f"Could not copy the value from source parameter {source_parameter.get_name()} "
+                               f"into parameter {parameter.get_name()}")
+    else:
+        raise RuntimeError(f"Could not copy the value from source parameter {source_parameter.get_name()} "
+                           f"into parameter {parameter.get_name()}")
+
+
+def read_parameter(ros_parameter: Parameter, parameter: Union[None, sr.Parameter] = None) -> sr.Parameter:
+    def read_new_parameter(ros_param: Parameter) -> sr.Parameter:
+        if ros_param.type_ == Parameter.Type.BOOL:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().bool_value, sr.ParameterType.BOOL)
+        elif ros_param.type_ == Parameter.Type.BOOL_ARRAY:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().bool_array_value,
+                                sr.ParameterType.BOOL_ARRAY)
+        elif ros_param.type_ == Parameter.Type.INTEGER:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().integer_value, sr.ParameterType.INT)
+        elif ros_param.type_ == Parameter.Type.INTEGER_ARRAY:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().integer_array_value,
+                                sr.ParameterType.INT_ARRAY)
+        elif ros_param.type_ == Parameter.Type.DOUBLE:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().double_value, sr.ParameterType.DOUBLE)
+        elif ros_param.type_ == Parameter.Type.DOUBLE_ARRAY:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().double_array_value,
+                                sr.ParameterType.DOUBLE_ARRAY)
+        elif ros_param.type_ == Parameter.Type.STRING_ARRAY:
+            return sr.Parameter(ros_param.name, ros_param.get_parameter_value().string_array_value,
+                                sr.ParameterType.STRING_ARRAY)
+        elif ros_param.type_ == Parameter.Type.STRING:
+            encoding = ""
+            try:
+                encoding = clproto.from_json(ros_param.get_parameter_value().string_value)
+            except Exception:
+                if not clproto.is_valid(encoding):
+                    return sr.Parameter(ros_param.name, ros_param.get_parameter_value().string_value,
+                                        sr.ParameterType.STRING)
+            message_type = clproto.check_message_type(encoding)
+            if message_type == clproto.MessageType.CARTESIAN_STATE_MESSAGE:
+                return sr.Parameter(ros_param.name, clproto.decode(encoding), sr.ParameterType.STATE,
+                                    sr.StateType.CARTESIAN_STATE)
+            elif message_type == clproto.MessageType.CARTESIAN_POSE_MESSAGE:
+                return sr.Parameter(ros_param.name, clproto.decode(encoding), sr.ParameterType.STATE,
+                                    sr.StateType.CARTESIAN_POSE)
+            elif message_type == clproto.MessageType.JOINT_STATE_MESSAGE:
+                return sr.Parameter(ros_param.name, clproto.decode(encoding), sr.ParameterType.STATE,
+                                    sr.StateType.JOINT_STATE)
+            elif message_type == clproto.MessageType.JOINT_POSITIONS_MESSAGE:
+                return sr.Parameter(ros_param.name, clproto.decode(encoding), sr.ParameterType.STATE,
+                                    sr.StateType.JOINT_POSITIONS)
+            else:
+                raise RuntimeError(f"Parameter {ros_param.name} has an unsupported encoded message type!")
+        elif ros_param.type_ == Parameter.Type.BYTE_ARRAY:
+            raise RuntimeError("Parameter byte arrays are not currently supported.")
+        else:
+            raise RuntimeError(f"Parameter {ros_param.name} could not be read!")
+
+    new_parameter = read_new_parameter(ros_parameter)
+    if parameter is None:
+        return new_parameter
+    else:
+        copy_parameter_value(new_parameter, parameter)
+        return parameter
+
+
+def read_parameter_const(ros_parameter: Parameter, parameter: sr.Parameter) -> sr.Parameter:
+    if ros_parameter.name != parameter.get_name():
+        raise RuntimeError(
+            f"The ROS parameter {ros_parameter.name} to be read does not have the same name as the reference parameter {parameter.get_name()}")
+    new_parameter = read_parameter(ros_parameter)
+    if new_parameter.get_parameter_type() == parameter.get_parameter_type():
+        return new_parameter
+    elif new_parameter.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY:
+        value = new_parameter.get_value()
+        if parameter.get_parameter_type() == sr.ParameterType.VECTOR:
+            vector = np.array(value)
+            return sr.Parameter(parameter.get_name(), vector, sr.ParameterType.VECTOR)
+        elif parameter.get_parameter_type() == sr.ParameterType.MATRIX:
+            matrix = parameter.get_value()
+            if matrix.size != len(value):
+                raise RuntimeError(f"The ROS parameter {ros_parameter.name} with type double array has size "
+                                   f"{len(value)} while the reference parameter matrix {parameter.get_name()} "
+                                   f"has size {len(matrix)}")
+            matrix = np.array(value).reshape(matrix.shape)
+            return sr.Parameter(parameter.get_name(), matrix, sr.ParameterType.MATRIX)
+        else:
+            raise RuntimeError(f"The ROS parameter {ros_parameter.name} with type double array cannot be interpreted "
+                               f"by reference parameter {parameter.get_name()} (type code "
+                               f"{parameter.get_parameter_type()}")
+    else:
+        raise RuntimeError(f"Something went wrong while reading parameter {parameter.get_name()}")

--- a/source/modulo_new_core/test/python_tests/conftest.py
+++ b/source/modulo_new_core/test/python_tests/conftest.py
@@ -21,10 +21,14 @@ def clock():
 
 @pytest.fixture
 def parameters():
-    return {"bool": [True, sr.ParameterType.BOOL], "bool_array": [[True, False], sr.ParameterType.BOOL_ARRAY],
-            "int": [1, sr.ParameterType.INT], "int_array": [[1, 2], sr.ParameterType.INT_ARRAY],
-            "double": [1.0, sr.ParameterType.DOUBLE], "double_array": [[1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY],
-            "string": ["1", sr.ParameterType.STRING], "string_array": [["1", "2"], sr.ParameterType.STRING_ARRAY]
+    return {"bool": [True, sr.ParameterType.BOOL, False],
+            "bool_array": [[True, False], sr.ParameterType.BOOL_ARRAY, [False]],
+            "int": [1, sr.ParameterType.INT, 2],
+            "int_array": [[1, 2], sr.ParameterType.INT_ARRAY, [2]],
+            "double": [1.0, sr.ParameterType.DOUBLE, 2.0],
+            "double_array": [[1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY, [2.0]],
+            "string": ["1", sr.ParameterType.STRING, "2"],
+            "string_array": [["1", "2"], sr.ParameterType.STRING_ARRAY, ["2"]]
             }
 
 
@@ -39,4 +43,3 @@ def state_parameters():
             "joint_positions": [sr.JointPositions().Random("test", 3), sr.StateType.JOINT_POSITIONS,
                                 clproto.JOINT_POSITIONS_MESSAGE]
             }
-

--- a/source/modulo_new_core/test/python_tests/conftest.py
+++ b/source/modulo_new_core/test/python_tests/conftest.py
@@ -1,18 +1,42 @@
+import clproto
 import pytest
 import rclpy.clock
-from state_representation import CartesianState, JointState
+import state_representation as sr
 
 
 @pytest.fixture
 def cart_state():
-    return CartesianState().Random("test", "ref")
+    return sr.CartesianState().Random("test", "ref")
 
 
 @pytest.fixture
 def joint_state():
-    return JointState().Random("robot", 3)
+    return sr.JointState().Random("robot", 3)
 
 
 @pytest.fixture
 def clock():
     return rclpy.clock.Clock()
+
+
+@pytest.fixture
+def parameters():
+    return {"bool": [True, sr.ParameterType.BOOL], "bool_array": [[True, False], sr.ParameterType.BOOL_ARRAY],
+            "int": [1, sr.ParameterType.INT], "int_array": [[1, 2], sr.ParameterType.INT_ARRAY],
+            "double": [1.0, sr.ParameterType.DOUBLE], "double_array": [[1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY],
+            "string": ["1", sr.ParameterType.STRING], "string_array": [["1", "2"], sr.ParameterType.STRING_ARRAY]
+            }
+
+
+@pytest.fixture
+def state_parameters():
+    return {"cartesian_state": [sr.CartesianState().Random("test"), sr.StateType.CARTESIAN_STATE,
+                                clproto.CARTESIAN_STATE_MESSAGE],
+            "cartesian_pose": [sr.CartesianPose().Random("test"), sr.StateType.CARTESIAN_POSE,
+                               clproto.CARTESIAN_POSE_MESSAGE],
+            "joint_state": [sr.JointState().Random("test", 3), sr.StateType.JOINT_STATE,
+                            clproto.JOINT_STATE_MESSAGE],
+            "joint_positions": [sr.JointPositions().Random("test", 3), sr.StateType.JOINT_POSITIONS,
+                                clproto.JOINT_POSITIONS_MESSAGE]
+            }
+

--- a/source/modulo_new_core/test/python_tests/translators/test_messages.py
+++ b/source/modulo_new_core/test/python_tests/translators/test_messages.py
@@ -52,7 +52,7 @@ def test_pose(cart_state: sr.CartesianState, clock: rclpy.clock.Clock):
     msg = geometry_msgs.msg.Pose()
     modulo_writers.write_msg(msg, cart_state)
     assert_np_array_equal(read_xyz(msg.position), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.orientation), cart_state.get_orientation())
+    assert_np_array_equal(read_quaternion(msg.orientation), cart_state.get_orientation_coefficients())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
@@ -64,7 +64,7 @@ def test_pose(cart_state: sr.CartesianState, clock: rclpy.clock.Clock):
     modulo_writers.write_msg_stamped(msg_stamped, cart_state, clock.now().to_msg())
     assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
     assert_np_array_equal(read_xyz(msg.position), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.orientation), cart_state.get_orientation())
+    assert_np_array_equal(read_quaternion(msg.orientation), cart_state.get_orientation_coefficients())
     new_state = sr.CartesianState("new")
     modulo_readers.read_msg_stamped(new_state, msg_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()
@@ -75,7 +75,7 @@ def test_transform(cart_state: sr.CartesianState, clock: rclpy.clock.Clock):
     msg = geometry_msgs.msg.Transform()
     modulo_writers.write_msg(msg, cart_state)
     assert_np_array_equal(read_xyz(msg.translation), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.rotation), cart_state.get_orientation())
+    assert_np_array_equal(read_quaternion(msg.rotation), cart_state.get_orientation_coefficients())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
@@ -88,7 +88,7 @@ def test_transform(cart_state: sr.CartesianState, clock: rclpy.clock.Clock):
     assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
     assert msg_stamped.child_frame_id == cart_state.get_name()
     assert_np_array_equal(read_xyz(msg.translation), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.rotation), cart_state.get_orientation())
+    assert_np_array_equal(read_quaternion(msg.rotation), cart_state.get_orientation_coefficients())
     new_state = sr.CartesianState("new")
     modulo_readers.read_msg_stamped(new_state, msg_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()

--- a/source/modulo_new_core/test/python_tests/translators/test_parameters.py
+++ b/source/modulo_new_core/test/python_tests/translators/test_parameters.py
@@ -1,0 +1,130 @@
+import clproto
+import numpy as np
+import pytest
+import state_representation as sr
+from modulo_new_core.translators.parameter_translators import write_parameter, read_parameter, read_parameter_const
+from rclpy import Parameter
+
+
+def assert_np_array_equal(a: np.array, b: np.array, places=3):
+    try:
+        np.testing.assert_almost_equal(a, b, decimal=places)
+    except AssertionError as e:
+        pytest.fail(f'{e}')
+
+
+def test_parameter_write(parameters):
+    for name, value_types in parameters.items():
+        param = sr.Parameter(name, value_types[0], value_types[1])
+        ros_param = write_parameter(param)
+        assert ros_param.to_parameter_msg() == Parameter(name, value=value_types[0]).to_parameter_msg()
+
+
+def test_parameter_read_write(parameters):
+    for name, value_types in parameters.items():
+        ros_param = Parameter(name, value=value_types[0])
+        param = read_parameter(ros_param)
+        assert ros_param.name == param.get_name()
+        assert param.get_parameter_type() == value_types[1]
+        assert param.get_value() == value_types[0]
+
+        new_ros_param = write_parameter(param)
+        assert ros_param.to_parameter_msg() == new_ros_param.to_parameter_msg()
+
+
+def test_parameter_const_read(parameters):
+    for name, value_types in parameters.items():
+        param = sr.Parameter(name, value_types[0], value_types[1])
+        ros_param = Parameter(name, value=value_types[0])
+
+        new_param = read_parameter_const(ros_param, param)
+        assert new_param.get_name() == param.get_name()
+        assert new_param.get_parameter_type() == param.get_parameter_type()
+        assert new_param.get_value() == param.get_value()
+
+        new_param.set_name("other")
+        assert new_param.get_name() != param.get_name()
+
+
+def test_parameter_non_const_read(parameters):
+    for name, value_types in parameters.items():
+        param = sr.Parameter(name, value_types[0], value_types[1])
+        ros_param = Parameter(name, value=value_types[0])
+
+        param_ref = param
+        new_param = read_parameter(ros_param, param)
+        assert new_param.get_name() == ros_param.name
+        assert new_param.get_parameter_type() == value_types[1]
+        assert new_param.get_value() == value_types[0]
+
+        assert param_ref.get_name() == ros_param.name
+        assert param_ref.get_parameter_type() == value_types[1]
+        assert param_ref.get_value() == value_types[0]
+
+
+def test_state_parameter_write(state_parameters):
+    for name, value_types in state_parameters.items():
+        param = sr.Parameter(name, value_types[0], sr.ParameterType.STATE, value_types[1])
+        ros_param = write_parameter(param)
+        assert ros_param.name == param.get_name()
+        assert clproto.decode(clproto.from_json(ros_param.value)).get_name() == value_types[0].get_name()
+
+
+def test_state_parameter_read_write(state_parameters):
+    for name, value_types in state_parameters.items():
+        json = clproto.to_json(clproto.encode(value_types[0], value_types[2]))
+        ros_param = Parameter(name, value=json)
+        param = read_parameter(ros_param)
+        assert ros_param.name == param.get_name()
+        assert param.get_parameter_type() == sr.ParameterType.STATE
+        assert param.get_parameter_state_type() == value_types[1]
+
+        assert_np_array_equal(param.get_value().data(), value_types[0].data())
+        assert param.get_value().get_name() == value_types[0].get_name()
+
+        new_ros_param = write_parameter(param)
+        assert ros_param.name == new_ros_param.name
+        assert ros_param.type_ == new_ros_param.type_
+        assert_np_array_equal(
+            clproto.decode(clproto.from_json(new_ros_param.get_parameter_value().string_value)).data(),
+            value_types[0].data())
+
+
+def test_vector_parameter_read_write():
+    vec = np.random.rand(3)
+    param = sr.Parameter("vector", vec, sr.ParameterType.VECTOR)
+    ros_param = write_parameter(param)
+    assert ros_param.name == param.get_name()
+    assert ros_param.type_ == Parameter.Type.DOUBLE_ARRAY
+    ros_vec = ros_param.get_parameter_value().double_array_value
+    assert vec.tolist() == ros_vec.tolist()
+
+    new_param = read_parameter(ros_param)
+    assert new_param.get_name() == ros_param.name
+    assert new_param.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY
+    assert new_param.get_value() == ros_vec.tolist()
+
+    new_param = read_parameter_const(ros_param, param)
+    assert new_param.get_name() == ros_param.name
+    assert new_param.get_parameter_type() == sr.ParameterType.VECTOR
+    assert_np_array_equal(new_param.get_value(), vec)
+
+
+def test_matrix_parameter_read_write():
+    mat = np.random.rand(3, 4)
+    param = sr.Parameter("matrix", mat, sr.ParameterType.MATRIX)
+    ros_param = write_parameter(param)
+    assert ros_param.name == param.get_name()
+    assert ros_param.type_ == Parameter.Type.DOUBLE_ARRAY
+    ros_mat = ros_param.get_parameter_value().double_array_value
+    assert mat.flatten().tolist() == ros_mat.tolist()
+
+    new_param = read_parameter(ros_param)
+    assert new_param.get_name() == ros_param.name
+    assert new_param.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY
+    assert new_param.get_value() == ros_mat.tolist()
+
+    new_param = read_parameter_const(ros_param, param)
+    assert new_param.get_name() == ros_param.name
+    assert new_param.get_parameter_type() == sr.ParameterType.MATRIX
+    assert_np_array_equal(new_param.get_value().flatten(), mat.flatten())

--- a/source/modulo_new_core/test/python_tests/translators/test_parameters.py
+++ b/source/modulo_new_core/test/python_tests/translators/test_parameters.py
@@ -48,7 +48,7 @@ def test_parameter_const_read(parameters):
 
 def test_parameter_non_const_read(parameters):
     for name, value_types in parameters.items():
-        param = sr.Parameter(name, value_types[0], value_types[1])
+        param = sr.Parameter(name, value_types[2], value_types[1])
         ros_param = Parameter(name, value=value_types[0])
 
         param_ref = param
@@ -67,7 +67,9 @@ def test_state_parameter_write(state_parameters):
         param = sr.Parameter(name, value_types[0], sr.ParameterType.STATE, value_types[1])
         ros_param = write_parameter(param)
         assert ros_param.name == param.get_name()
-        assert clproto.decode(clproto.from_json(ros_param.value)).get_name() == value_types[0].get_name()
+        state = clproto.decode(clproto.from_json(ros_param.value))
+        assert state.get_name() == value_types[0].get_name()
+        assert_np_array_equal(state.data(), value_types[0].data())
 
 
 def test_state_parameter_read_write(state_parameters):
@@ -75,7 +77,7 @@ def test_state_parameter_read_write(state_parameters):
         json = clproto.to_json(clproto.encode(value_types[0], value_types[2]))
         ros_param = Parameter(name, value=json)
         param = read_parameter(ros_param)
-        assert ros_param.name == param.get_name()
+        assert param.get_name() == ros_param.name
         assert param.get_parameter_type() == sr.ParameterType.STATE
         assert param.get_parameter_state_type() == value_types[1]
 
@@ -127,4 +129,5 @@ def test_matrix_parameter_read_write():
     new_param = read_parameter_const(ros_param, param)
     assert new_param.get_name() == ros_param.name
     assert new_param.get_parameter_type() == sr.ParameterType.MATRIX
-    assert_np_array_equal(new_param.get_value().flatten(), mat.flatten())
+    assert_np_array_equal(new_param.get_value(), mat)
+    assert new_param.get_value().shape == mat.shape


### PR DESCRIPTION
Sadly there are no switch cases with our python version, so a lot of if conditions. I decided to list all possible cases to be precise and to not implicitely include possible new supported parameter types. All in all, the cpp behavior is quite well replicated, with `read_parameter` and `read_parameter_const`. The replicated tests pass exactly in the same way :+1: