### PR TITLE
Improve test coverage in modulo new core

### DIFF
--- a/source/modulo_new_core/include/modulo_new_core/translators/message_readers.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/message_readers.hpp
@@ -14,10 +14,13 @@
 
 #include <clproto.h>
 #include <state_representation/parameters/Parameter.hpp>
-#include <state_representation/space/cartesian/CartesianState.hpp>
-#include <state_representation/space/joint/JointState.hpp>
+#include <state_representation/space/cartesian/CartesianPose.hpp>
+#include <state_representation/space/joint/JointPositions.hpp>
+#include <state_representation/space/Jacobian.hpp>
 
 #include "modulo_new_core/EncodedState.hpp"
+
+#include <rclcpp/rclcpp.hpp>
 
 namespace modulo_new_core::translators {
 
@@ -105,7 +108,7 @@ void read_msg(state_representation::JointState& state, const sensor_msgs::msg::J
  * @param state The Parameter<T> to populate
  * @param msg The ROS msg to read from
  */
-template <typename T, typename U>
+template<typename T, typename U>
 void read_msg(state_representation::Parameter<T>& state, const U& msg) {
   state.set_value(msg.data);
 }
@@ -151,9 +154,166 @@ void read_msg(std::string& state, const std_msgs::msg::String& msg);
  * @param state The state to populate
  * @param msg The ROS msg to read from
  */
-template <typename T>
+template<typename T>
 inline void read_msg(T& state, const EncodedState& msg) {
   std::string tmp(msg.data.begin(), msg.data.end());
   state = clproto::decode<T>(tmp);
+}
+
+template<>
+inline void read_msg(std::shared_ptr<state_representation::State>& state, const EncodedState& msg) {
+  using namespace state_representation;
+  std::string tmp(msg.data.begin(), msg.data.end());
+  auto new_state = clproto::decode<std::shared_ptr<State>>(tmp);
+  switch (new_state->get_type()) {
+    case StateType::STATE:
+      *state = *new_state;
+      break;
+    case StateType::SPATIAL_STATE: {
+      auto derived_state = std::dynamic_pointer_cast<SpatialState>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<SpatialState>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::CARTESIAN_STATE: {
+      auto derived_state = std::dynamic_pointer_cast<CartesianState>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<CartesianState>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::CARTESIAN_POSE: {
+      auto derived_state = std::dynamic_pointer_cast<CartesianPose>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<CartesianPose>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::CARTESIAN_TWIST: {
+      auto derived_state = std::dynamic_pointer_cast<CartesianTwist>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<CartesianTwist>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::CARTESIAN_ACCELERATION: {
+      auto derived_state = std::dynamic_pointer_cast<CartesianAcceleration>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<CartesianAcceleration>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::CARTESIAN_WRENCH: {
+      auto derived_state = std::dynamic_pointer_cast<CartesianWrench>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<CartesianWrench>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::JACOBIAN: {
+      auto derived_state = std::dynamic_pointer_cast<Jacobian>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<Jacobian>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::JOINT_STATE: {
+      auto derived_state = std::dynamic_pointer_cast<JointState>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<JointState>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::JOINT_POSITIONS: {
+      auto derived_state = std::dynamic_pointer_cast<JointPositions>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<JointPositions>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::JOINT_VELOCITIES: {
+      auto derived_state = std::dynamic_pointer_cast<JointVelocities>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<JointVelocities>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::JOINT_ACCELERATIONS: {
+      auto derived_state = std::dynamic_pointer_cast<JointAccelerations>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<JointAccelerations>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::JOINT_TORQUES: {
+      auto derived_state = std::dynamic_pointer_cast<JointTorques>(state->shared_from_this());
+      *derived_state = *std::dynamic_pointer_cast<JointTorques>(new_state);
+      state = derived_state;
+      break;
+    }
+    case StateType::PARAMETER: {
+      auto param_ptr = std::dynamic_pointer_cast<ParameterInterface>(new_state);
+      switch (param_ptr->get_parameter_type()) {
+        case ParameterType::BOOL: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<bool>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<bool>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::BOOL_ARRAY: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<std::vector<bool>>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<std::vector<bool>>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::INT: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<int>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<int>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::INT_ARRAY: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<std::vector<int>>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<std::vector<int>>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::DOUBLE: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<double>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<double>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::DOUBLE_ARRAY: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<std::vector<double>>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<std::vector<double>>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::STRING: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<std::string>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<std::string>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::STRING_ARRAY: {
+          auto
+              derived_state = std::dynamic_pointer_cast<Parameter<std::vector<std::string>>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<std::vector<std::string>>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::VECTOR: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<Eigen::VectorXd>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<Eigen::VectorXd>>(new_state);
+          state = derived_state;
+          break;
+        }
+        case ParameterType::MATRIX: {
+          auto derived_state = std::dynamic_pointer_cast<Parameter<Eigen::MatrixXd>>(state->shared_from_this());
+          *derived_state = *std::dynamic_pointer_cast<Parameter<Eigen::MatrixXd>>(new_state);
+          state = derived_state;
+          break;
+        }
+        default:
+          throw std::invalid_argument(
+              "The ParameterType contained by parameter " + param_ptr->get_name() + " is unsupported."
+          );
+      }
+      break;
+    }
+    default:
+      throw std::invalid_argument("The StateType contained by state " + new_state->get_name() + " is unsupported.");
+  }
 }
 }// namespace modulo_new_core::translators

--- a/source/modulo_new_core/include/modulo_new_core/translators/message_readers.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/message_readers.hpp
@@ -20,8 +20,6 @@
 
 #include "modulo_new_core/EncodedState.hpp"
 
-#include <rclcpp/rclcpp.hpp>
-
 namespace modulo_new_core::translators {
 
 /**

--- a/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "modulo_new_core/communication/MessagePair.hpp"
+#include "modulo_new_core/communication/PublisherHandler.hpp"
+#include "modulo_new_core/communication/SubscriptionHandler.hpp"
+
+using namespace std::chrono_literals;
+using namespace modulo_new_core::communication;
+
+template<typename MsgT>
+class MinimalPublisher : public rclcpp::Node {
+public:
+  MinimalPublisher(const std::string& topic_name, std::shared_ptr<MessagePairInterface> message_pair) :
+      Node("minimal_publisher") {
+    auto publisher = this->create_publisher<MsgT>(topic_name, 10);
+    this->publisher_interface_ = std::make_shared<PublisherHandler<rclcpp::Publisher<MsgT>, MsgT>>(
+        PublisherType::PUBLISHER, publisher
+    )->create_publisher_interface(message_pair);
+    timer_ = this->create_wall_timer(10ms, [this]() { this->publisher_interface_->publish(); });
+  }
+
+private:
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::shared_ptr<PublisherInterface> publisher_interface_;
+};
+
+template<typename MsgT>
+class MinimalSubscriber : public rclcpp::Node {
+public:
+  MinimalSubscriber(const std::string& topic_name, std::shared_ptr<MessagePairInterface> message_pair) :
+      Node("minimal_subscriber") {
+    auto subscription_handler = std::make_shared<SubscriptionHandler<MsgT>>(message_pair);
+    auto subscription = this->create_subscription<MsgT>(topic_name, 10, subscription_handler->get_callback());
+    this->subscription_interface_ = subscription_handler->create_subscription_interface(subscription);
+  }
+
+  MinimalSubscriber(const std::string& topic_name, std::function<void(std::shared_ptr<MsgT>)> callback) :
+      Node("minimal_subscriber") {
+    auto subscription = this->create_subscription<MsgT>(topic_name, 10, callback);
+    this->subscription_interface_ =
+        std::make_shared<SubscriptionHandler<MsgT>>()->create_subscription_interface(subscription);
+  }
+
+private:
+  std::shared_ptr<SubscriptionInterface> subscription_interface_;
+};
+
+class CommunicationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    rclcpp::init(0, nullptr);
+
+    exec_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    clock_ = std::make_shared<rclcpp::Clock>();
+  }
+
+  void TearDown() override {
+    rclcpp::shutdown();
+  }
+
+  template<typename MsgT>
+  void add_nodes(
+      const std::string& topic_name, const std::shared_ptr<MessagePairInterface>& pub_message,
+      const std::shared_ptr<MessagePairInterface>& sub_message
+  ) {
+    pub_node_ = std::make_shared<MinimalPublisher<MsgT>>(topic_name, pub_message);
+    sub_node_ = std::make_shared<MinimalSubscriber<MsgT>>(topic_name, sub_message);
+    exec_->add_node(pub_node_);
+    exec_->add_node(sub_node_);
+  }
+
+  template<typename MsgT>
+  void add_nodes(
+      const std::string& topic_name, const std::shared_ptr<MessagePairInterface>& pub_message,
+      std::function<void(std::shared_ptr<MsgT>)> callback
+  ) {
+    pub_node_ = std::make_shared<MinimalPublisher<MsgT>>(topic_name, pub_message);
+    sub_node_ = std::make_shared<MinimalSubscriber<MsgT>>(topic_name, callback);
+    exec_->add_node(pub_node_);
+    exec_->add_node(sub_node_);
+  }
+
+  void clear_nodes() {
+    pub_node_.reset();
+    sub_node_.reset();
+  }
+
+  template<typename MsgT, typename DataT>
+  void communicate(const DataT& initial_value, const DataT& new_value) {
+    auto pub_data = std::make_shared<DataT>(new_value);
+    auto pub_message = make_shared_message_pair(pub_data, this->clock_);
+    auto sub_data = std::make_shared<DataT>(initial_value);
+    auto sub_message = make_shared_message_pair(sub_data, this->clock_);
+    this->add_nodes<MsgT>("/test_topic", pub_message, sub_message);
+
+    for (std::size_t i = 0; i < 20; ++i) {
+      this->exec_->spin_once();
+    }
+
+    EXPECT_EQ(*pub_data, *sub_data);
+    this->clear_nodes();
+  }
+
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
+  std::shared_ptr<rclcpp::Node> pub_node_;
+  std::shared_ptr<rclcpp::Node> sub_node_;
+  std::shared_ptr<rclcpp::Clock> clock_;
+};
+
+TEST_F(CommunicationTest, BasicTypes) {
+  this->communicate<std_msgs::msg::Bool, bool>(false, true);
+  this->communicate<std_msgs::msg::Float64, double>(1.0, 2.0);
+  this->communicate<std_msgs::msg::Float64MultiArray, std::vector<double>>({1.0, 2.0}, {3.0, 4.0});
+  this->communicate<std_msgs::msg::Int32, int>(1, 2);
+  this->communicate<std_msgs::msg::String, std::string>("this", "that");
+}

--- a/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
@@ -74,17 +74,6 @@ protected:
     exec_->add_node(sub_node_);
   }
 
-  template<typename MsgT>
-  void add_nodes(
-      const std::string& topic_name, const std::shared_ptr<MessagePairInterface>& pub_message,
-      std::function<void(std::shared_ptr<MsgT>)> callback
-  ) {
-    pub_node_ = std::make_shared<MinimalPublisher<MsgT>>(topic_name, pub_message);
-    sub_node_ = std::make_shared<MinimalSubscriber<MsgT>>(topic_name, callback);
-    exec_->add_node(pub_node_);
-    exec_->add_node(sub_node_);
-  }
-
   void clear_nodes() {
     pub_node_.reset();
     sub_node_.reset();

--- a/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
@@ -48,7 +48,7 @@ TEST_F(MessagePairTest, BasicTypes) {
   test_message_interface<std_msgs::msg::String, std::string>("this", "that", clock_);
 }
 
-TEST_F(MessagePairTest, TestCartesianState) {
+TEST_F(MessagePairTest, EncodedState) {
   auto initial_value = state_representation::CartesianState::Random("test");
   auto data = state_representation::make_shared_state(initial_value);
   auto msg_pair =

--- a/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
@@ -73,7 +73,7 @@ TEST_F(MessagePairTest, EncodedState) {
   msg_pair->set_data(data);
   msg = modulo_new_core::EncodedState();
   modulo_new_core::translators::write_msg(msg, data, clock_->now());
-  msg_pair_interface->read<modulo_new_core::EncodedState , state_representation::State>(msg);
+  msg_pair_interface->read<modulo_new_core::EncodedState, state_representation::State>(msg);
   EXPECT_TRUE(initial_value.data().isApprox(
       std::dynamic_pointer_cast<state_representation::CartesianState>(msg_pair->get_data())->data()));
 }

--- a/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
@@ -55,7 +55,7 @@ TEST_F(PublisherTest, BasicTypes) {
   test_publisher_interface<std_msgs::msg::String, std::string>(node, "this");
 }
 
-TEST_F(PublisherTest, CartesianState) {
+TEST_F(PublisherTest, EncodedState) {
   // create message pair
   auto data =
       std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));

--- a/source/modulo_new_core/test/cpp_tests/communication/test_subscription_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_subscription_handler.cpp
@@ -48,7 +48,7 @@ TEST_F(SubscriptionTest, BasicTypes) {
   test_subscription_interface<std_msgs::msg::String, std::string>(node, "this");
 }
 
-TEST_F(SubscriptionTest, CartesianState) {
+TEST_F(SubscriptionTest, EncodedState) {
   // create message pair
   auto data =
       std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));

--- a/source/modulo_new_core/test/cpp_tests/translators/parameters/test_parameter_translators.cpp
+++ b/source/modulo_new_core/test/cpp_tests/translators/parameters/test_parameter_translators.cpp
@@ -33,7 +33,7 @@ static std::tuple<
                        std::make_tuple(1.0, state_representation::ParameterType::DOUBLE),
                    }, {
                        std::make_tuple(
-                           std::vector<double>({true, false, true}), state_representation::ParameterType::DOUBLE_ARRAY),
+                           std::vector<double>({1.0, 2.0, 3.0}), state_representation::ParameterType::DOUBLE_ARRAY),
                    }, {
                        std::make_tuple("test", state_representation::ParameterType::STRING),
                    }, {


### PR DESCRIPTION
Slightly over the limit of 250 lines due to another big switch case for the reading of a shared pointer of state.

The main change is the test coverage of the Publisher and Subscriber interface with 2 nodes communicating and checking that the messages have been received for all supported message types