### PR TITLE
Improve components tests

### DIFF
--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -39,7 +39,7 @@ ament_python_install_package(${PROJECT_NAME} SCRIPTS_DESTINATION lib/${PROJECT_N
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
-  include_directories(test/cpp/include)
+  include_directories(${PROJECT_SOURCE_DIR}/test/cpp/include)
 
   # add cpp tests
   file(GLOB_RECURSE TEST_CPP_SOURCES ${PROJECT_SOURCE_DIR}/test/ test_*.cpp)

--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -39,6 +39,7 @@ ament_python_install_package(${PROJECT_NAME} SCRIPTS_DESTINATION lib/${PROJECT_N
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  include_directories(test/cpp/include)
 
   # add cpp tests
   file(GLOB_RECURSE TEST_CPP_SOURCES ${PROJECT_SOURCE_DIR}/test/ test_*.cpp)

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -4,6 +4,7 @@
 #include <rclcpp/create_timer.hpp>
 #include <rclcpp/node_options.hpp>
 #include <rclcpp/node_interfaces/node_parameters_interface.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -27,10 +28,18 @@
 namespace modulo_components {
 
 template<class NodeT>
+class ComponentInterfacePublicInterface;
+
+template<class NodeT>
+class ComponentInterfaceParameterPublicInterface;
+
+template<class NodeT>
 class ComponentInterface : private NodeT {
 public:
-  friend class ComponentInterfacePublicInterface;
-  friend class ComponentInterfaceParameterPublicInterface;
+  friend class ComponentInterfacePublicInterface<rclcpp::Node>;
+  friend class ComponentInterfacePublicInterface<rclcpp_lifecycle::LifecycleNode>;
+  friend class ComponentInterfaceParameterPublicInterface<rclcpp::Node>;
+  friend class ComponentInterfaceParameterPublicInterface<rclcpp_lifecycle::LifecycleNode>;
 
   /**
    * @brief Constructor from node options.

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -722,4 +722,14 @@ inline void ComponentInterface<NodeT>::raise_error() {
   this->set_predicate("in_error_state", true);
 }
 
+template<class NodeT>
+inline rclcpp::QoS ComponentInterface<NodeT>::get_qos() const {
+  return this->qos_;
+}
+
+template<class NodeT>
+inline void ComponentInterface<NodeT>::set_qos(const rclcpp::QoS& qos) {
+  this->qos_ = qos;
+}
+
 }// namespace modulo_components

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -31,15 +31,10 @@ template<class NodeT>
 class ComponentInterfacePublicInterface;
 
 template<class NodeT>
-class ComponentInterfaceParameterPublicInterface;
-
-template<class NodeT>
 class ComponentInterface : private NodeT {
 public:
   friend class ComponentInterfacePublicInterface<rclcpp::Node>;
   friend class ComponentInterfacePublicInterface<rclcpp_lifecycle::LifecycleNode>;
-  friend class ComponentInterfaceParameterPublicInterface<rclcpp::Node>;
-  friend class ComponentInterfaceParameterPublicInterface<rclcpp_lifecycle::LifecycleNode>;
 
   /**
    * @brief Constructor from node options.

--- a/source/modulo_components/src/ComponentInterface.cpp
+++ b/source/modulo_components/src/ComponentInterface.cpp
@@ -2,14 +2,4 @@
 
 namespace modulo_components {
 
-template<class NodeT>
-rclcpp::QoS ComponentInterface<NodeT>::get_qos() const {
-  return this->qos_;
-}
-
-template<class NodeT>
-void ComponentInterface<NodeT>::set_qos(const rclcpp::QoS& qos) {
-  this->qos_ = qos;
-}
-
 }// namespace modulo_components

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "modulo_components/ComponentInterface.hpp"
+#include "modulo_components/Component.hpp"
+#include "modulo_components/LifecycleComponent.hpp"
+
+using namespace state_representation;
+
+namespace modulo_components {
+
+template<class NodeT>
+class ComponentInterfacePublicInterface : public ComponentInterface<NodeT> {
+public:
+  explicit ComponentInterfacePublicInterface(
+      const rclcpp::NodeOptions& node_options, modulo_new_core::communication::PublisherType publisher_type
+  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
+  using ComponentInterface<NodeT>::add_parameter;
+  using ComponentInterface<NodeT>::get_parameter;
+  using ComponentInterface<NodeT>::get_parameter_value;
+  using ComponentInterface<NodeT>::set_parameter_value;
+  using ComponentInterface<NodeT>::parameter_map_;
+  using ComponentInterface<NodeT>::add_predicate;
+  using ComponentInterface<NodeT>::get_predicate;
+  using ComponentInterface<NodeT>::set_predicate;
+  using ComponentInterface<NodeT>::predicates_;
+  using ComponentInterface<NodeT>::add_input;
+  using ComponentInterface<NodeT>::inputs_;
+  using ComponentInterface<NodeT>::create_output;
+  using ComponentInterface<NodeT>::outputs_;
+  using ComponentInterface<NodeT>::raise_error;
+  using ComponentInterface<NodeT>::get_qos;
+  using ComponentInterface<NodeT>::set_qos;
+
+  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) override {
+    validate_parameter_was_called = true;
+    return validate_parameter_return_value;
+  }
+
+  rclcpp::Parameter get_ros_parameter(const std::string& name) {
+    return NodeT::get_parameter(name);
+  }
+
+  rcl_interfaces::msg::SetParametersResult set_ros_parameter(const rclcpp::Parameter& parameter) {
+    return NodeT::set_parameter(parameter);
+  }
+
+  std::string get_parameter_description(const std::string& name) {
+    return NodeT::describe_parameter(name).description;
+  }
+
+  bool validate_parameter_was_called = false;
+  bool validate_parameter_return_value = true;
+};
+
+class ComponentPublicInterface : public Component {
+public:
+  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options, bool start_thread = true) :
+      Component(node_options, start_thread) {}
+  using Component::add_output;
+  using Component::outputs_;
+  using Component::get_clock;
+};
+
+class LifecycleComponentPublicInterface : public LifecycleComponent {
+public:
+  explicit LifecycleComponentPublicInterface(const rclcpp::NodeOptions& node_options) : LifecycleComponent(node_options) {}
+  using LifecycleComponent::add_output;
+  using LifecycleComponent::configure_outputs;
+  using LifecycleComponent::activate_outputs;
+  using LifecycleComponent::outputs_;
+  using LifecycleComponent::get_clock;
+};
+
+
+}

--- a/source/modulo_components/test/cpp/test_component.cpp
+++ b/source/modulo_components/test/cpp/test_component.cpp
@@ -11,7 +11,8 @@ namespace modulo_components {
 
 class ComponentPublicInterface : public Component {
 public:
-  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options) : Component(node_options) {}
+  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options, bool start_thread = true) :
+      Component(node_options, start_thread) {}
   using Component::add_output;
   using Component::outputs_;
   using Component::get_clock;
@@ -28,7 +29,7 @@ protected:
   }
 
   void SetUp() override {
-    component_ = std::make_shared<ComponentPublicInterface>(rclcpp::NodeOptions());
+    component_ = std::make_shared<ComponentPublicInterface>(rclcpp::NodeOptions(), false);
   }
 
   std::shared_ptr<ComponentPublicInterface> component_;
@@ -37,9 +38,13 @@ protected:
 TEST_F(ComponentTest, AddOutput) {
   std::shared_ptr<State> data = make_shared_state(CartesianState::Random("test"));
   component_->add_output("_tEsT_#1@3", data, true);
-  auto outputs_iterator = component_->outputs_.find("test_13");
-  EXPECT_TRUE(outputs_iterator != component_->outputs_.end());
+  EXPECT_TRUE(component_->outputs_.find("test_13") != component_->outputs_.end());
   EXPECT_NO_THROW(component_->outputs_.at("test_13")->publish());
+
+  auto new_data = std::make_shared<bool>(false);
+  component_->add_output("test_13", new_data, true);
+  EXPECT_EQ(component_->outputs_.at("test_13")->get_message_pair()->get_type(),
+            modulo_new_core::communication::MessageType::ENCODED_STATE);
 }
 
 } // namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component.cpp
+++ b/source/modulo_components/test/cpp/test_component.cpp
@@ -5,18 +5,11 @@
 #include "modulo_components/Component.hpp"
 #include "modulo_new_core/EncodedState.hpp"
 
+#include "test_modulo_components/component_public_interfaces.hpp"
+
 using namespace state_representation;
 
 namespace modulo_components {
-
-class ComponentPublicInterface : public Component {
-public:
-  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options, bool start_thread = true) :
-      Component(node_options, start_thread) {}
-  using Component::add_output;
-  using Component::outputs_;
-  using Component::get_clock;
-};
 
 class ComponentTest : public ::testing::Test {
 protected:

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -3,27 +3,9 @@
 #include "modulo_components/ComponentInterface.hpp"
 #include "modulo_new_core/EncodedState.hpp"
 
-namespace modulo_components {
+#include "test_modulo_components/component_public_interfaces.hpp"
 
-template<class NodeT>
-class ComponentInterfacePublicInterface : public ComponentInterface<NodeT> {
-public:
-  explicit ComponentInterfacePublicInterface(
-      const rclcpp::NodeOptions& node_options, modulo_new_core::communication::PublisherType publisher_type
-  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
-  using ComponentInterface<NodeT>::add_predicate;
-  using ComponentInterface<NodeT>::get_predicate;
-  using ComponentInterface<NodeT>::set_predicate;
-  using ComponentInterface<NodeT>::predicates_;
-  using ComponentInterface<NodeT>::get_parameter_value;
-  using ComponentInterface<NodeT>::add_input;
-  using ComponentInterface<NodeT>::inputs_;
-  using ComponentInterface<NodeT>::create_output;
-  using ComponentInterface<NodeT>::outputs_;
-  using ComponentInterface<NodeT>::raise_error;
-  using ComponentInterface<NodeT>::get_qos;
-  using ComponentInterface<NodeT>::set_qos;
-};
+namespace modulo_components {
 
 template<class NodeT>
 class ComponentInterfaceTest : public ::testing::Test {

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -1,26 +1,25 @@
 #include <gtest/gtest.h>
-#include <rclcpp/node.hpp>
-#include <rclcpp/publisher.hpp>
-#include <rclcpp/node_options.hpp>
 
 #include "modulo_components/ComponentInterface.hpp"
 #include "modulo_new_core/EncodedState.hpp"
 
 namespace modulo_components {
 
-class ComponentInterfacePublicInterface : public ComponentInterface<rclcpp::Node> {
+template<class NodeT>
+class ComponentInterfacePublicInterface : public ComponentInterface<NodeT> {
 public:
-  explicit ComponentInterfacePublicInterface(const rclcpp::NodeOptions& node_options) :
-      ComponentInterface<rclcpp::Node>(node_options, modulo_new_core::communication::PublisherType::PUBLISHER) {}
-  using ComponentInterface<rclcpp::Node>::add_predicate;
-  using ComponentInterface<rclcpp::Node>::get_predicate;
-  using ComponentInterface<rclcpp::Node>::set_predicate;
-  using ComponentInterface<rclcpp::Node>::predicates_;
-  using ComponentInterface<rclcpp::Node>::add_input;
-  using ComponentInterface<rclcpp::Node>::inputs_;
-  using ComponentInterface<rclcpp::Node>::raise_error;
+  explicit ComponentInterfacePublicInterface(
+      const rclcpp::NodeOptions& node_options, modulo_new_core::communication::PublisherType publisher_type
+  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
+  using ComponentInterface<NodeT>::add_predicate;
+  using ComponentInterface<NodeT>::get_predicate;
+  using ComponentInterface<NodeT>::set_predicate;
+  using ComponentInterface<NodeT>::predicates_;
+  using ComponentInterface<NodeT>::add_input;
+  using ComponentInterface<NodeT>::inputs_;
 };
 
+template<class NodeT>
 class ComponentInterfaceTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
@@ -32,13 +31,24 @@ protected:
   }
 
   void SetUp() override {
-    component_ = std::make_shared<ComponentInterfacePublicInterface>(rclcpp::NodeOptions());
+    if (std::is_same<NodeT, rclcpp::Node>::value) {
+      this->component_ = std::make_shared<ComponentInterfacePublicInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::PUBLISHER
+      );
+    } else if (std::is_same<NodeT, rclcpp_lifecycle::LifecycleNode>::value) {
+      this->component_ = std::make_shared<ComponentInterfacePublicInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::LIFECYCLE_PUBLISHER
+      );
+    }
   }
 
-  std::shared_ptr<ComponentInterfacePublicInterface> component_;
+  std::shared_ptr<ComponentInterfacePublicInterface<NodeT>> component_;
 };
 
-TEST_F(ComponentInterfaceTest, AddBoolPredicate) {
+using NodeTypes = ::testing::Types<rclcpp::Node, rclcpp_lifecycle::LifecycleNode>;
+TYPED_TEST_SUITE(ComponentInterfaceTest, NodeTypes);
+
+TYPED_TEST(ComponentInterfaceTest, AddBoolPredicate) {
   this->component_->add_predicate("foo", true);
   auto predicate_iterator = this->component_->predicates_.find("foo");
   EXPECT_TRUE(predicate_iterator != this->component_->predicates_.end());
@@ -46,15 +56,15 @@ TEST_F(ComponentInterfaceTest, AddBoolPredicate) {
   EXPECT_TRUE(value);
 }
 
-TEST_F(ComponentInterfaceTest, AddFunctionPredicate) {
+TYPED_TEST(ComponentInterfaceTest, AddFunctionPredicate) {
   this->component_->add_predicate("bar", [&]() { return false; });
-  auto predicate_iterator = component_->predicates_.find("bar");
-  EXPECT_TRUE(predicate_iterator != component_->predicates_.end());
+  auto predicate_iterator = this->component_->predicates_.find("bar");
+  EXPECT_TRUE(predicate_iterator != this->component_->predicates_.end());
   auto value_callback = std::get<std::function<bool(void)>>(predicate_iterator->second);
   EXPECT_FALSE((value_callback)());
 }
 
-TEST_F(ComponentInterfaceTest, GetPredicateValue) {
+TYPED_TEST(ComponentInterfaceTest, GetPredicateValue) {
   this->component_->add_predicate("foo", true);
   EXPECT_TRUE(this->component_->get_predicate("foo"));
   this->component_->add_predicate("bar", [&]() { return true; });
@@ -71,7 +81,7 @@ TEST_F(ComponentInterfaceTest, GetPredicateValue) {
   EXPECT_FALSE(this->component_->get_predicate("error"));
 }
 
-TEST_F(ComponentInterfaceTest, SetPredicateValue) {
+TYPED_TEST(ComponentInterfaceTest, SetPredicateValue) {
   this->component_->add_predicate("foo", true);
   this->component_->set_predicate("foo", false);
   EXPECT_FALSE(this->component_->get_predicate("foo"));
@@ -83,17 +93,15 @@ TEST_F(ComponentInterfaceTest, SetPredicateValue) {
   EXPECT_FALSE(this->component_->get_predicate("bar"));
 }
 
-TEST_F(ComponentInterfaceTest, AddInput) {
+TYPED_TEST(ComponentInterfaceTest, AddInput) {
   auto data = std::make_shared<bool>(true);
   EXPECT_NO_THROW(this->component_->add_input("_tEsT_#1@3", data, true));
-  auto inputs_iterator = component_->inputs_.find("test_13");
-  EXPECT_TRUE(inputs_iterator != component_->inputs_.end());
+  EXPECT_TRUE(this->component_->inputs_.find("test_13") != this->component_->inputs_.end());
 
   EXPECT_NO_THROW(this->component_->template add_input<std_msgs::msg::Bool>(
       "_tEsT_#1@5", [](const std::shared_ptr<std_msgs::msg::Bool>) {}
   ));
-  inputs_iterator = component_->inputs_.find("test_15");
-  EXPECT_TRUE(inputs_iterator != component_->inputs_.end());
+  EXPECT_TRUE(this->component_->inputs_.find("test_15") != this->component_->inputs_.end());
 
   this->component_->template add_input<std_msgs::msg::String>(
       "test_13", [](const std::shared_ptr<std_msgs::msg::String>) {}
@@ -107,4 +115,4 @@ TEST_F(ComponentInterfaceTest, RaiseError) {
   this->component_->raise_error();
   EXPECT_TRUE(this->component_->get_predicate("in_error_state"));
 }
-}
+}// namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -23,10 +23,6 @@ public:
   using ComponentInterface<NodeT>::raise_error;
   using ComponentInterface<NodeT>::get_qos;
   using ComponentInterface<NodeT>::set_qos;
-  using ComponentInterface<NodeT>::add_tf_broadcaster;
-  using ComponentInterface<NodeT>::add_tf_listener;
-  using ComponentInterface<NodeT>::send_transform;
-  using ComponentInterface<NodeT>::lookup_transform;
 };
 
 template<class NodeT>

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -5,40 +5,9 @@
 #include "modulo_components/ComponentInterface.hpp"
 #include "modulo_new_core/EncodedState.hpp"
 
+#include "test_modulo_components/component_public_interfaces.hpp"
+
 namespace modulo_components {
-
-template<class NodeT>
-class ComponentInterfaceParameterPublicInterface : public ComponentInterface<NodeT> {
-public:
-  explicit ComponentInterfaceParameterPublicInterface(
-      const rclcpp::NodeOptions& node_options, modulo_new_core::communication::PublisherType publisher_type
-  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
-  using ComponentInterface<NodeT>::add_parameter;
-  using ComponentInterface<NodeT>::get_parameter;
-  using ComponentInterface<NodeT>::get_parameter_value;
-  using ComponentInterface<NodeT>::set_parameter_value;
-  using ComponentInterface<NodeT>::parameter_map_;
-
-  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) override {
-    validate_was_called = true;
-    return validation_return_value;
-  }
-
-  rclcpp::Parameter get_ros_parameter(const std::string& name) {
-    return NodeT::get_parameter(name);
-  }
-
-  rcl_interfaces::msg::SetParametersResult set_ros_parameter(const rclcpp::Parameter& parameter) {
-    return NodeT::set_parameter(parameter);
-  }
-
-  std::string get_parameter_description(const std::string& name) {
-    return NodeT::describe_parameter(name).description;
-  }
-
-  bool validate_was_called = false;
-  bool validation_return_value = true;
-};
 
 template<class NodeT>
 class ComponentInterfaceParameterTest : public ::testing::Test {
@@ -53,11 +22,11 @@ protected:
 
   void SetUp() override {
     if (std::is_same<NodeT, rclcpp::Node>::value) {
-      this->component_ = std::make_shared<ComponentInterfaceParameterPublicInterface<NodeT>>(
+      this->component_ = std::make_shared<ComponentInterfacePublicInterface<NodeT>>(
           rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::PUBLISHER
       );
     } else if (std::is_same<NodeT, rclcpp_lifecycle::LifecycleNode>::value) {
-      this->component_ = std::make_shared<ComponentInterfaceParameterPublicInterface<NodeT>>(
+      this->component_ = std::make_shared<ComponentInterfacePublicInterface<NodeT>>(
           rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::LIFECYCLE_PUBLISHER
       );
     }
@@ -71,7 +40,7 @@ protected:
     EXPECT_EQ(this->component_->parameter_map_.template get_parameter_value<T>("test"), value);
   }
 
-  std::shared_ptr<ComponentInterfaceParameterPublicInterface<NodeT>> component_;
+  std::shared_ptr<ComponentInterfacePublicInterface<NodeT>> component_;
   std::shared_ptr<state_representation::Parameter<int>> param_;
 };
 using NodeTypes = ::testing::Types<rclcpp::Node, rclcpp_lifecycle::LifecycleNode>;
@@ -84,7 +53,7 @@ TYPED_TEST(ComponentInterfaceParameterTest, AddParameter) {
   this->component_->add_parameter(this->param_, "Test parameter");
 
   // Adding the parameter should declare and set the value and call the validation function
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   EXPECT_NO_THROW(auto discard = this->component_->get_parameter("test"));
   EXPECT_NO_THROW(this->component_->get_ros_parameter("test"));
   this->template expect_parameter_value<int>(1);
@@ -97,7 +66,7 @@ TYPED_TEST(ComponentInterfaceParameterTest, AddNameValueParameter) {
   this->component_->add_parameter("test", 1, "Test parameter");
 
   // Adding the parameter should declare and set the value and call the validation function
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   EXPECT_NO_THROW(auto discard = this->component_->get_parameter("test"));
   EXPECT_NO_THROW(this->component_->get_ros_parameter("test"));
   this->template expect_parameter_value<int>(1);
@@ -111,9 +80,9 @@ TYPED_TEST(ComponentInterfaceParameterTest, AddParameterAgain) {
   this->component_->add_parameter(this->param_, "Test parameter");
 
   // Adding an existing parameter again should just set the value
-  this->component_->validate_was_called = false;
+  this->component_->validate_parameter_was_called = false;
   EXPECT_NO_THROW(this->component_->add_parameter("test", 2, "foo"));
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   this->template expect_parameter_value<int>(2);
   EXPECT_EQ(this->param_->get_value(), 2);
 }
@@ -123,31 +92,31 @@ TYPED_TEST(ComponentInterfaceParameterTest, SetParameter) {
   EXPECT_THROW(this->component_->set_parameter_value("test", 1), rclcpp::exceptions::ParameterNotDeclaredException);
 
   // validation should not be invoked as the parameter did not exist
-  EXPECT_FALSE(this->component_->validate_was_called);
+  EXPECT_FALSE(this->component_->validate_parameter_was_called);
   EXPECT_THROW(this->component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
 
   this->component_->add_parameter(this->param_, "Test parameter");
 
   // Setting the parameter value should call the validation function and update the referenced value
-  this->component_->validate_was_called = false;
+  this->component_->validate_parameter_was_called = false;
   EXPECT_NO_THROW(this->component_->set_parameter_value("test", 2));
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   this->template expect_parameter_value<int>(2);
   EXPECT_EQ(this->param_->get_value(), 2);
 
   // If the validation function returns false, setting the parameter value should _not_ update the referenced value
-  this->component_->validate_was_called = false;
-  this->component_->validation_return_value = false;
+  this->component_->validate_parameter_was_called = false;
+  this->component_->validate_parameter_return_value = false;
   EXPECT_THROW(this->component_->set_parameter_value("test", 3),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   this->template expect_parameter_value<int>(2);
   EXPECT_EQ(this->param_->get_value(), 2);
 
   // Setting a value with an incompatible type should not update the parameter
   EXPECT_THROW(this->component_->template set_parameter_value<std::string>("test", "foo"),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   this->template expect_parameter_value<int>(2);
   EXPECT_EQ(this->param_->get_value(), 2);
 }
@@ -156,18 +125,18 @@ TYPED_TEST(ComponentInterfaceParameterTest, SetParameterROS) {
   this->component_->add_parameter(this->param_, "Test parameter");
 
   // Setting the parameter value should call the validation function and update the referenced value
-  this->component_->validate_was_called = false;
+  this->component_->validate_parameter_was_called = false;
   auto result = this->component_->set_ros_parameter({"test", 2});
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   EXPECT_TRUE(result.successful);
   this->template expect_parameter_value<int>(2);
   EXPECT_EQ(this->param_->get_value(), 2);
 
   // If the validation function returns false, setting the parameter value should _not_ update the referenced value
-  this->component_->validate_was_called = false;
-  this->component_->validation_return_value = false;
+  this->component_->validate_parameter_was_called = false;
+  this->component_->validate_parameter_return_value = false;
   result = this->component_->set_ros_parameter({"test", 3});
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   EXPECT_FALSE(result.successful);
   this->template expect_parameter_value<int>(2);
   EXPECT_EQ(this->param_->get_value(), 2);
@@ -183,23 +152,23 @@ TYPED_TEST(ComponentInterfaceParameterTest, GetParameterDescription) {
 TYPED_TEST(ComponentInterfaceParameterTest, ReadOnlyParameter) {
   // Adding a read-only parameter should behave normally
   this->component_->add_parameter(this->param_, "Test parameter", true);
-  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_TRUE(this->component_->validate_parameter_was_called);
   EXPECT_NO_THROW(auto discard = this->component_->get_parameter("test"));
   EXPECT_NO_THROW(this->component_->get_ros_parameter("test"));
   this->template expect_parameter_value<int>(1);
 
   // Trying to set the value of the read-only parameter should fail before the validation step
-  this->component_->validate_was_called = false;
+  this->component_->validate_parameter_was_called = false;
   EXPECT_THROW(this->component_->set_parameter_value("test", 2),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_FALSE(this->component_->validate_was_called);
+  EXPECT_FALSE(this->component_->validate_parameter_was_called);
   this->template expect_parameter_value<int>(1);
   EXPECT_EQ(this->param_->get_value(), 1);
 
   // Setting the value on the ROS interface should also fail
-  this->component_->validate_was_called = false;
+  this->component_->validate_parameter_was_called = false;
   auto result = this->component_->set_ros_parameter({"test", 2});
-  EXPECT_FALSE(this->component_->validate_was_called);
+  EXPECT_FALSE(this->component_->validate_parameter_was_called);
   EXPECT_FALSE(result.successful);
   this->template expect_parameter_value<int>(1);
   EXPECT_EQ(this->param_->get_value(), 1);

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -1,7 +1,4 @@
 #include <gtest/gtest.h>
-#include <rclcpp/node.hpp>
-#include <rclcpp/publisher.hpp>
-#include <rclcpp/node_options.hpp>
 
 #include <state_representation/exceptions/InvalidParameterException.hpp>
 
@@ -10,15 +7,17 @@
 
 namespace modulo_components {
 
-class ComponentInterfaceParameterPublicInterface : public ComponentInterface<rclcpp::Node> {
+template<class NodeT>
+class ComponentInterfaceParameterPublicInterface : public ComponentInterface<NodeT> {
 public:
-  explicit ComponentInterfaceParameterPublicInterface(const rclcpp::NodeOptions& node_options) :
-      ComponentInterface<rclcpp::Node>(node_options, modulo_new_core::communication::PublisherType::PUBLISHER) {}
-  using ComponentInterface<rclcpp::Node>::add_parameter;
-  using ComponentInterface<rclcpp::Node>::get_parameter;
-  using ComponentInterface<rclcpp::Node>::get_parameter_value;
-  using ComponentInterface<rclcpp::Node>::set_parameter_value;
-  using ComponentInterface<rclcpp::Node>::parameter_map_;
+  explicit ComponentInterfaceParameterPublicInterface(
+      const rclcpp::NodeOptions& node_options, modulo_new_core::communication::PublisherType publisher_type
+  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
+  using ComponentInterface<NodeT>::add_parameter;
+  using ComponentInterface<NodeT>::get_parameter;
+  using ComponentInterface<NodeT>::get_parameter_value;
+  using ComponentInterface<NodeT>::set_parameter_value;
+  using ComponentInterface<NodeT>::parameter_map_;
 
   bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) override {
     validate_was_called = true;
@@ -26,21 +25,22 @@ public:
   }
 
   rclcpp::Parameter get_ros_parameter(const std::string& name) {
-    return rclcpp::Node::get_parameter(name);
+    return NodeT::get_parameter(name);
   }
 
   rcl_interfaces::msg::SetParametersResult set_ros_parameter(const rclcpp::Parameter& parameter) {
-    return rclcpp::Node::set_parameter(parameter);
+    return NodeT::set_parameter(parameter);
   }
 
   std::string get_parameter_description(const std::string& name) {
-    return rclcpp::Node::describe_parameter(name).description;
+    return NodeT::describe_parameter(name).description;
   }
 
   bool validate_was_called = false;
   bool validation_return_value = true;
 };
 
+template<class NodeT>
 class ComponentInterfaceParameterTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
@@ -52,145 +52,157 @@ protected:
   }
 
   void SetUp() override {
-    component_ = std::make_shared<ComponentInterfaceParameterPublicInterface>(rclcpp::NodeOptions());
+    if (std::is_same<NodeT, rclcpp::Node>::value) {
+      this->component_ = std::make_shared<ComponentInterfaceParameterPublicInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::PUBLISHER
+      );
+    } else if (std::is_same<NodeT, rclcpp_lifecycle::LifecycleNode>::value) {
+      this->component_ = std::make_shared<ComponentInterfaceParameterPublicInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_new_core::communication::PublisherType::LIFECYCLE_PUBLISHER
+      );
+    }
     param_ = state_representation::make_shared_parameter("test", 1);
   }
 
   template<typename T>
   void expect_parameter_value(const T& value) {
-    EXPECT_STREQ(component_->get_ros_parameter("test").value_to_string().c_str(), std::to_string(value).c_str());
-    EXPECT_EQ(component_->get_parameter_value<T>("test"), value);
-    EXPECT_EQ(component_->parameter_map_.get_parameter_value<T>("test"), value);
+    EXPECT_STREQ(this->component_->get_ros_parameter("test").value_to_string().c_str(), std::to_string(value).c_str());
+    EXPECT_EQ(this->component_->template get_parameter_value<T>("test"), value);
+    EXPECT_EQ(this->component_->parameter_map_.template get_parameter_value<T>("test"), value);
   }
 
-  std::shared_ptr<ComponentInterfaceParameterPublicInterface> component_;
+  std::shared_ptr<ComponentInterfaceParameterPublicInterface<NodeT>> component_;
   std::shared_ptr<state_representation::Parameter<int>> param_;
 };
+using NodeTypes = ::testing::Types<rclcpp::Node, rclcpp_lifecycle::LifecycleNode>;
+TYPED_TEST_SUITE(ComponentInterfaceParameterTest, NodeTypes);
 
-TEST_F(ComponentInterfaceParameterTest, AddParameter) {
-  EXPECT_THROW(auto discard = component_->get_parameter("test"),
+TYPED_TEST(ComponentInterfaceParameterTest, AddParameter) {
+  EXPECT_THROW(auto discard = this->component_->get_parameter("test"),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
-  component_->add_parameter(param_, "Test parameter");
+  EXPECT_THROW(this->component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  this->component_->add_parameter(this->param_, "Test parameter");
 
   // Adding the parameter should declare and set the value and call the validation function
-  EXPECT_TRUE(component_->validate_was_called);
-  EXPECT_NO_THROW(auto discard = component_->get_parameter("test"));
-  EXPECT_NO_THROW(component_->get_ros_parameter("test"));
-  expect_parameter_value<int>(1);
+  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_NO_THROW(auto discard = this->component_->get_parameter("test"));
+  EXPECT_NO_THROW(this->component_->get_ros_parameter("test"));
+  this->template expect_parameter_value<int>(1);
 }
 
-TEST_F(ComponentInterfaceParameterTest, AddNameValueParameter) {
-  EXPECT_THROW(auto discard = component_->get_parameter("test"),
+TYPED_TEST(ComponentInterfaceParameterTest, AddNameValueParameter) {
+  EXPECT_THROW(auto discard = this->component_->get_parameter("test"),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
-  component_->add_parameter("test", 1, "Test parameter");
+  EXPECT_THROW(this->component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  this->component_->add_parameter("test", 1, "Test parameter");
 
   // Adding the parameter should declare and set the value and call the validation function
-  EXPECT_TRUE(component_->validate_was_called);
-  EXPECT_NO_THROW(auto discard = component_->get_parameter("test"));
-  EXPECT_NO_THROW(component_->get_ros_parameter("test"));
-  expect_parameter_value<int>(1);
+  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_NO_THROW(auto discard = this->component_->get_parameter("test"));
+  EXPECT_NO_THROW(this->component_->get_ros_parameter("test"));
+  this->template expect_parameter_value<int>(1);
 }
 
-TEST_F(ComponentInterfaceParameterTest, AddParameterAgain) {
+TYPED_TEST(ComponentInterfaceParameterTest, AddParameterAgain) {
   EXPECT_THROW(auto
-                   discard = component_->get_parameter("test"),
+                   discard = this->component_->get_parameter("test"),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
-  component_->add_parameter(param_, "Test parameter");
+  EXPECT_THROW(this->component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  this->component_->add_parameter(this->param_, "Test parameter");
 
   // Adding an existing parameter again should just set the value
-  component_->validate_was_called = false;
-  EXPECT_NO_THROW(component_->add_parameter("test", 2, "foo"));
-  EXPECT_TRUE(component_->validate_was_called);
-  expect_parameter_value<int>(2);
-  EXPECT_EQ(param_->get_value(), 2);
+  this->component_->validate_was_called = false;
+  EXPECT_NO_THROW(this->component_->add_parameter("test", 2, "foo"));
+  EXPECT_TRUE(this->component_->validate_was_called);
+  this->template expect_parameter_value<int>(2);
+  EXPECT_EQ(this->param_->get_value(), 2);
 }
 
-TEST_F(ComponentInterfaceParameterTest, SetParameter) {
+TYPED_TEST(ComponentInterfaceParameterTest, SetParameter) {
   // setting before adding should not work
-  EXPECT_THROW(component_->set_parameter_value("test", 1), rclcpp::exceptions::ParameterNotDeclaredException);
+  EXPECT_THROW(this->component_->set_parameter_value("test", 1), rclcpp::exceptions::ParameterNotDeclaredException);
 
   // validation should not be invoked as the parameter did not exist
-  EXPECT_FALSE(component_->validate_was_called);
-  EXPECT_THROW(component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
+  EXPECT_FALSE(this->component_->validate_was_called);
+  EXPECT_THROW(this->component_->get_ros_parameter("test"), rclcpp::exceptions::ParameterNotDeclaredException);
 
-  component_->add_parameter(param_, "Test parameter");
+  this->component_->add_parameter(this->param_, "Test parameter");
 
   // Setting the parameter value should call the validation function and update the referenced value
-  component_->validate_was_called = false;
-  EXPECT_NO_THROW(component_->set_parameter_value("test", 2));
-  EXPECT_TRUE(component_->validate_was_called);
-  expect_parameter_value<int>(2);
-  EXPECT_EQ(param_->get_value(), 2);
+  this->component_->validate_was_called = false;
+  EXPECT_NO_THROW(this->component_->set_parameter_value("test", 2));
+  EXPECT_TRUE(this->component_->validate_was_called);
+  this->template expect_parameter_value<int>(2);
+  EXPECT_EQ(this->param_->get_value(), 2);
 
   // If the validation function returns false, setting the parameter value should _not_ update the referenced value
-  component_->validate_was_called = false;
-  component_->validation_return_value = false;
-  EXPECT_THROW(component_->set_parameter_value("test", 3), state_representation::exceptions::InvalidParameterException);
-  EXPECT_TRUE(component_->validate_was_called);
-  expect_parameter_value<int>(2);
-  EXPECT_EQ(param_->get_value(), 2);
+  this->component_->validate_was_called = false;
+  this->component_->validation_return_value = false;
+  EXPECT_THROW(this->component_->set_parameter_value("test", 3),
+               state_representation::exceptions::InvalidParameterException);
+  EXPECT_TRUE(this->component_->validate_was_called);
+  this->template expect_parameter_value<int>(2);
+  EXPECT_EQ(this->param_->get_value(), 2);
 
   // Setting a value with an incompatible type should not update the parameter
-  EXPECT_THROW(component_->set_parameter_value<std::string>("test", "foo"),
+  EXPECT_THROW(this->component_->template set_parameter_value<std::string>("test", "foo"),
                state_representation::exceptions::InvalidParameterException);
-  EXPECT_TRUE(component_->validate_was_called);
-  expect_parameter_value<int>(2);
-  EXPECT_EQ(param_->get_value(), 2);
+  EXPECT_TRUE(this->component_->validate_was_called);
+  this->template expect_parameter_value<int>(2);
+  EXPECT_EQ(this->param_->get_value(), 2);
 }
 
-TEST_F(ComponentInterfaceParameterTest, SetParameterROS) {
-  component_->add_parameter(param_, "Test parameter");
+TYPED_TEST(ComponentInterfaceParameterTest, SetParameterROS) {
+  this->component_->add_parameter(this->param_, "Test parameter");
 
   // Setting the parameter value should call the validation function and update the referenced value
-  component_->validate_was_called = false;
-  auto result = component_->set_ros_parameter({"test", 2});
-  EXPECT_TRUE(component_->validate_was_called);
+  this->component_->validate_was_called = false;
+  auto result = this->component_->set_ros_parameter({"test", 2});
+  EXPECT_TRUE(this->component_->validate_was_called);
   EXPECT_TRUE(result.successful);
-  expect_parameter_value<int>(2);
-  EXPECT_EQ(param_->get_value(), 2);
+  this->template expect_parameter_value<int>(2);
+  EXPECT_EQ(this->param_->get_value(), 2);
 
   // If the validation function returns false, setting the parameter value should _not_ update the referenced value
-  component_->validate_was_called = false;
-  component_->validation_return_value = false;
-  result = component_->set_ros_parameter({"test", 3});
-  EXPECT_TRUE(component_->validate_was_called);
+  this->component_->validate_was_called = false;
+  this->component_->validation_return_value = false;
+  result = this->component_->set_ros_parameter({"test", 3});
+  EXPECT_TRUE(this->component_->validate_was_called);
   EXPECT_FALSE(result.successful);
-  expect_parameter_value<int>(2);
-  EXPECT_EQ(param_->get_value(), 2);
+  this->template expect_parameter_value<int>(2);
+  EXPECT_EQ(this->param_->get_value(), 2);
 }
 
-TEST_F(ComponentInterfaceParameterTest, GetParameterDescription) {
-  component_->add_parameter(param_, "Test parameter");
-  EXPECT_STREQ(component_->get_parameter_description("test").c_str(), "Test parameter");
+TYPED_TEST(ComponentInterfaceParameterTest, GetParameterDescription) {
+  this->component_->add_parameter(this->param_, "Test parameter");
+  EXPECT_STREQ(this->component_->get_parameter_description("test").c_str(), "Test parameter");
 
-  EXPECT_THROW(component_->get_parameter_description("foo"), rclcpp::exceptions::ParameterNotDeclaredException);
+  EXPECT_THROW(this->component_->get_parameter_description("foo"), rclcpp::exceptions::ParameterNotDeclaredException);
 }
 
-TEST_F(ComponentInterfaceParameterTest, ReadOnlyParameter) {
+TYPED_TEST(ComponentInterfaceParameterTest, ReadOnlyParameter) {
   // Adding a read-only parameter should behave normally
-  component_->add_parameter(param_, "Test parameter", true);
-  EXPECT_TRUE(component_->validate_was_called);
-  EXPECT_NO_THROW(auto discard = component_->get_parameter("test"));
-  EXPECT_NO_THROW(component_->get_ros_parameter("test"));
-  expect_parameter_value<int>(1);
+  this->component_->add_parameter(this->param_, "Test parameter", true);
+  EXPECT_TRUE(this->component_->validate_was_called);
+  EXPECT_NO_THROW(auto discard = this->component_->get_parameter("test"));
+  EXPECT_NO_THROW(this->component_->get_ros_parameter("test"));
+  this->template expect_parameter_value<int>(1);
 
   // Trying to set the value of the read-only parameter should fail before the validation step
-  component_->validate_was_called = false;
-  EXPECT_THROW(component_->set_parameter_value("test", 2), state_representation::exceptions::InvalidParameterException);
-  EXPECT_FALSE(component_->validate_was_called);
-  expect_parameter_value<int>(1);
-  EXPECT_EQ(param_->get_value(), 1);
+  this->component_->validate_was_called = false;
+  EXPECT_THROW(this->component_->set_parameter_value("test", 2),
+               state_representation::exceptions::InvalidParameterException);
+  EXPECT_FALSE(this->component_->validate_was_called);
+  this->template expect_parameter_value<int>(1);
+  EXPECT_EQ(this->param_->get_value(), 1);
 
   // Setting the value on the ROS interface should also fail
-  component_->validate_was_called = false;
-  auto result = component_->set_ros_parameter({"test", 2});
-  EXPECT_FALSE(component_->validate_was_called);
+  this->component_->validate_was_called = false;
+  auto result = this->component_->set_ros_parameter({"test", 2});
+  EXPECT_FALSE(this->component_->validate_was_called);
   EXPECT_FALSE(result.successful);
-  expect_parameter_value<int>(1);
-  EXPECT_EQ(param_->get_value(), 1);
+  this->template expect_parameter_value<int>(1);
+  EXPECT_EQ(this->param_->get_value(), 1);
 }
 
 } // namespace modulo_components

--- a/source/modulo_components/test/cpp/test_lifecycle_component.cpp
+++ b/source/modulo_components/test/cpp/test_lifecycle_component.cpp
@@ -44,6 +44,11 @@ TEST_F(LifecycleComponentTest, AddOutput) {
   EXPECT_NO_THROW(component_->configure_outputs());
   EXPECT_NO_THROW(component_->activate_outputs());
   EXPECT_NO_THROW(component_->outputs_.at("test")->publish());
+
+  auto new_data = std::make_shared<bool>(false);
+  component_->add_output("test", new_data, true);
+  EXPECT_EQ(component_->outputs_.at("test")->get_message_pair()->get_type(),
+            modulo_new_core::communication::MessageType::ENCODED_STATE);
 }
 
 } // namespace modulo_components

--- a/source/modulo_components/test/cpp/test_lifecycle_component.cpp
+++ b/source/modulo_components/test/cpp/test_lifecycle_component.cpp
@@ -5,19 +5,11 @@
 #include "modulo_components/LifecycleComponent.hpp"
 #include "modulo_new_core/EncodedState.hpp"
 
+#include "test_modulo_components/component_public_interfaces.hpp"
+
 using namespace state_representation;
 
 namespace modulo_components {
-
-class LifecycleComponentPublicInterface : public LifecycleComponent {
-public:
-  explicit LifecycleComponentPublicInterface(const rclcpp::NodeOptions& node_options) : LifecycleComponent(node_options) {}
-  using LifecycleComponent::add_output;
-  using LifecycleComponent::configure_outputs;
-  using LifecycleComponent::activate_outputs;
-  using LifecycleComponent::outputs_;
-  using LifecycleComponent::get_clock;
-};
 
 class LifecycleComponentTest : public ::testing::Test {
 protected:


### PR DESCRIPTION
With this PR, I'm forward declaring our friend test classes such that we can use `TYPED_TEST` with `NodeT` template test classes to test both lifecycle and normal component interface.

A consequence of this is that I needed to add `this->` in the parameter tests, which results in a big diff.

Also added a few more test cases