### PR TITLE
Minor improvements

### DIFF
--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -63,6 +63,7 @@ private:
    */
   void run();
 
+  using rclcpp::Node::create_publisher;
   using ComponentInterface<rclcpp::Node>::create_output;
   using ComponentInterface<rclcpp::Node>::outputs_;
   using ComponentInterface<rclcpp::Node>::qos_;

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -63,12 +63,6 @@ private:
    */
   void run();
 
-  /**
-   * @brief Put the component in error state by setting the
-   * 'in_error_state' predicate to true.
-   */
-  void raise_error() override;
-
   using ComponentInterface<rclcpp::Node>::create_output;
   using ComponentInterface<rclcpp::Node>::outputs_;
   using ComponentInterface<rclcpp::Node>::qos_;

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -74,7 +74,7 @@ private:
   using ComponentInterface<rclcpp::Node>::qos_;
   using ComponentInterface<rclcpp::Node>::publish_predicates;
   using ComponentInterface<rclcpp::Node>::publish_outputs;
-  using ComponentInterface<rclcpp::Node>::evaluate_daemon_callbacks;
+  using ComponentInterface<rclcpp::Node>::evaluate_periodic_callbacks;
 
   std::thread run_thread_; ///< The execution thread of the component
   bool started_; ///< Flag that indicates if execution has started or not

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -15,9 +15,14 @@ public:
 
   /**
    * @brief Constructor from node options.
-   * @param node_options node options as used in ROS2 Node
+   * @param node_options Node options as used in ROS2 Node
    */
   explicit Component(const rclcpp::NodeOptions& node_options, bool start_thread = true);
+
+  /**
+   * @brief Virtual default destructor.
+   */
+  virtual ~Component() = default;
 
 protected:
   /**

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -254,8 +254,8 @@ protected:
   void evaluate_periodic_callbacks();
 
   /**
-   * @brief Raise an error, or set the component into error state.
-   * To be redefined in derived classes.
+   * @brief Put the component in error state by setting the
+   * 'in_error_state' predicate to true.
    */
   virtual void raise_error();
 
@@ -318,6 +318,8 @@ ComponentInterface<NodeT>::ComponentInterface(
       }
   );
   this->add_parameter("period", 1.0, "The time interval in seconds for all periodic callbacks", true);
+
+  this->add_predicate("in_error_state", false);
 
   this->step_timer_ = this->create_wall_timer(
       std::chrono::nanoseconds(static_cast<int64_t>(this->get_parameter_value<double>("period") * 1e9)),
@@ -693,6 +695,8 @@ inline void ComponentInterface<NodeT>::create_output(
 }
 
 template<class NodeT>
-inline void ComponentInterface<NodeT>::raise_error() {}
+inline void ComponentInterface<NodeT>::raise_error() {
+  this->set_predicate("in_error_state", true);
+}
 
 }// namespace modulo_components

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -27,7 +27,7 @@
 namespace modulo_components {
 
 template<class NodeT>
-class ComponentInterface : public NodeT {
+class ComponentInterface : private NodeT {
 public:
   friend class ComponentInterfacePublicInterface;
   friend class ComponentInterfaceParameterPublicInterface;
@@ -44,6 +44,11 @@ public:
    * @brief Virtual default destructor.
    */
   virtual ~ComponentInterface() = default;
+
+  using NodeT::get_node_base_interface;
+  using NodeT::get_name;
+  using NodeT::get_clock;
+  using NodeT::get_logger;
 
 protected:
   /**
@@ -263,6 +268,8 @@ protected:
    */
   virtual void raise_error();
 
+  using NodeT::create_publisher;
+
   std::map<std::string, std::shared_ptr<modulo_new_core::communication::PublisherInterface>>
       outputs_; ///< Map of outputs
 
@@ -289,22 +296,6 @@ private:
    * @param predicate The predicate variant
    */
   void set_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate);
-
-  using NodeT::declare_parameter;
-  using NodeT::declare_parameters;
-  using NodeT::undeclare_parameter;
-  using NodeT::get_parameter_or;
-  using NodeT::get_parameter_types;
-  using NodeT::get_parameters;
-  using NodeT::set_parameter;
-  using NodeT::set_parameters;
-  using NodeT::set_parameters_atomically;
-  using NodeT::list_parameters;
-  using NodeT::has_parameter;
-  using NodeT::describe_parameter;
-  using NodeT::describe_parameters;
-  using NodeT::add_on_set_parameters_callback;
-  using NodeT::remove_on_set_parameters_callback;
 
   modulo_new_core::communication::PublisherType
       publisher_type_; ///< Type of the output publishers (one of PUBLISHER, LIFECYCLE_PUBLISHER)

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -34,7 +34,7 @@ public:
 
   /**
    * @brief Constructor from node options.
-   * @param node_options node options as used in ROS2 Node
+   * @param node_options Node options as used in ROS2 Node / LifecycleNode
    */
   explicit ComponentInterface(
       const rclcpp::NodeOptions& node_options, modulo_new_core::communication::PublisherType publisher_type

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -286,6 +286,22 @@ private:
    */
   void set_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate);
 
+  using NodeT::declare_parameter;
+  using NodeT::declare_parameters;
+  using NodeT::undeclare_parameter;
+  using NodeT::get_parameter_or;
+  using NodeT::get_parameter_types;
+  using NodeT::get_parameters;
+  using NodeT::set_parameter;
+  using NodeT::set_parameters;
+  using NodeT::set_parameters_atomically;
+  using NodeT::list_parameters;
+  using NodeT::has_parameter;
+  using NodeT::describe_parameter;
+  using NodeT::describe_parameters;
+  using NodeT::add_on_set_parameters_callback;
+  using NodeT::remove_on_set_parameters_callback;
+
   modulo_new_core::communication::PublisherType
       publisher_type_; ///< Type of the output publishers (one of PUBLISHER, LIFECYCLE_PUBLISHER)
 

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -68,7 +68,7 @@ private:
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::qos_;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::publish_predicates;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::publish_outputs;
-  using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::evaluate_daemon_callbacks;
+  using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::evaluate_periodic_callbacks;
 };
 
 template<typename DataT>

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -63,6 +63,7 @@ private:
    */
   bool deactivate_outputs();
 
+  using rclcpp_lifecycle::LifecycleNode::create_publisher;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::create_output;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::outputs_;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::qos_;

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -15,10 +15,15 @@ public:
   friend class LifecycleComponentPublicInterface;
 
   /**
-   * @brief Constructor from node options
-   * @param node_options node options as used in ROS2 Node
+   * @brief Constructor from node options.
+   * @param node_options Node options as used in ROS2 LifecycleNode
    */
   explicit LifecycleComponent(const rclcpp::NodeOptions& node_options);
+
+  /**
+   * @brief Virtual default destructor.
+   */
+  virtual ~LifecycleComponent() = default;
 
 protected:
   /**

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -47,19 +47,19 @@ private:
 
   /**
    * @brief Configure all outputs.
-   * @return True configuration was successful
+   * @return True if configuration was successful
    */
   bool configure_outputs();
 
   /**
    * @brief Activate all outputs.
-   * @return True activation was successful
+   * @return True if activation was successful
    */
   bool activate_outputs();
 
   /**
    * @brief Deactivate all outputs.
-   * @return True deactivation was successful
+   * @return True if deactivation was successful
    */
   bool deactivate_outputs();
 

--- a/source/modulo_components/src/Component.cpp
+++ b/source/modulo_components/src/Component.cpp
@@ -17,7 +17,7 @@ Component::Component(const rclcpp::NodeOptions& node_options, bool start_thread)
 void Component::step() {
   this->publish_predicates();
   this->publish_outputs();
-  this->evaluate_daemon_callbacks();
+  this->evaluate_periodic_callbacks();
 }
 
 void Component::start_thread() {

--- a/source/modulo_components/src/Component.cpp
+++ b/source/modulo_components/src/Component.cpp
@@ -6,7 +6,6 @@ namespace modulo_components {
 
 Component::Component(const rclcpp::NodeOptions& node_options, bool start_thread) :
     ComponentInterface<rclcpp::Node>(node_options, PublisherType::PUBLISHER), started_(false) {
-  this->add_predicate("in_error_state", false);
   this->add_predicate("is_finished", false);
 
   if (start_thread) {
@@ -47,10 +46,6 @@ void Component::run() {
 
 bool Component::execute() {
   return true;
-}
-
-void Component::raise_error() {
-  this->set_predicate("in_error_state", true);
 }
 
 }// namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -18,6 +18,7 @@ public:
   using ComponentInterface<rclcpp::Node>::predicates_;
   using ComponentInterface<rclcpp::Node>::add_input;
   using ComponentInterface<rclcpp::Node>::inputs_;
+  using ComponentInterface<rclcpp::Node>::raise_error;
 };
 
 class ComponentInterfaceTest : public ::testing::Test {
@@ -99,5 +100,11 @@ TEST_F(ComponentInterfaceTest, AddInput) {
   );
   EXPECT_EQ(this->component_->inputs_.at("test_13")->get_message_pair()->get_type(),
             modulo_new_core::communication::MessageType::BOOL);
+}
+
+TEST_F(ComponentInterfaceTest, RaiseError) {
+  EXPECT_FALSE(this->component_->get_predicate("in_error_state"));
+  this->component_->raise_error();
+  EXPECT_TRUE(this->component_->get_predicate("in_error_state"));
 }
 }


### PR DESCRIPTION
A few small things that came up during our discussion yesterday that I wanted to fix in the C++ components before I dig deeper into the bigger topics (namely exception handling and lifecycle transitions).

One important thing to take away from this PR is that we hide all of NodeT methods except a small set that is actually required (name, clock, logger, node_base_interface)

Review by commit, they are small and easy.