### PR TITLE
Build and test packages in CI

### DIFF
--- a/.github/actions/build-test-galactic/Dockerfile
+++ b/.github/actions/build-test-galactic/Dockerfile
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions
+FROM ghcr.io/aica-technology/ros2-control-libraries:galactic
+
+# Copy and set the entrypoint commands to execute when the container starts,
+# explicilty invoking as ros2 user and with bash interpreter.
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["sudo", "su", "-", "ros2", "-c", "/bin/bash", "-c", "/entrypoint.sh"]

--- a/.github/actions/build-test-galactic/action.yml
+++ b/.github/actions/build-test-galactic/action.yml
@@ -1,0 +1,5 @@
+name: 'Build and Test (Galactic)'
+description: 'Build the source packages and run all unit tests'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/build-test-galactic/entrypoint.sh
+++ b/.github/actions/build-test-galactic/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+STEP=1
+build_and_test() {
+  PACKAGE=$1
+
+  echo ">>> ${STEP}: Building ${PACKAGE}..."
+  cp -r /github/workspace/source/"${PACKAGE}" ./src/"${PACKAGE}"
+  if ! colcon build --packages-select "${PACKAGE}"; then
+    echo ">>> [ERROR] Build stage ${STEP} failed!"
+    exit "${STEP}"
+  fi
+  echo ">>> Build stage ${STEP} completed successfully!"
+  STEP=$((STEP+1))
+
+  echo ">>> ${STEP}: Testing ${PACKAGE}..."
+  if ! colcon test --packages-select "${PACKAGE}" --return-code-on-test-failure; then
+    colcon test-result --verbose
+    echo ">>> [ERROR] Test stage ${STEP} failed!"
+    exit "${STEP}"
+  fi
+  echo ">>> Test stage ${STEP} completed successfully!"
+  STEP=$((STEP+1))
+}
+
+source /opt/ros/"${ROS_DISTRO}"/setup.bash
+cd /home/ros2/ros2_ws
+
+build_and_test modulo_new_core
+build_and_test modulo_core
+build_and_test modulo_components
+
+echo ">>> All build and test stages completed successfully!"
+exit 0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,23 @@
+name: Build and Test
+
+# Run workflow on pushes to main and develop branches, on any pull request, or by manual dispatch
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+# Define the build test jobs
+jobs:
+  build-test-galactic:
+    runs-on: ubuntu-latest
+    name: Galactic build and test
+    steps:
+      # First check out the repository
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Load the repository build-test action
+      - name: Build and Test
+        uses: ./.github/actions/build-test-galactic

--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 5.1.0 REQUIRED COMPONENTS state_representation)
+find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
 find_library(clproto REQUIRED)
 
 include_directories(include)

--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(ament_cmake_python REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
-find_library(clproto REQUIRED)
+find_package(clproto 6.0.0 REQUIRED)
 
 include_directories(include)
 

--- a/source/modulo_new_core/CMakeLists.txt
+++ b/source/modulo_new_core/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 5.0.0 REQUIRED COMPONENTS state_representation)
+find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
 find_library(clproto REQUIRED)
 
 include_directories(include)

--- a/source/modulo_new_core/CMakeLists.txt
+++ b/source/modulo_new_core/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(ament_cmake_python REQUIRED)
 ament_auto_find_build_dependencies()
 
 find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
-find_library(clproto REQUIRED)
+find_package(clproto 6.0.0 REQUIRED)
 
 include_directories(include)
 


### PR DESCRIPTION
Now that the refactored packages have meaningful and passing tests, we can iterate and close on this refactor more effectively if the CI informs us of any issues with the build or test stages.

I used a custom [docker action](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions) to run a build and test script. Unfortunately with the limitations of the action syntax I am stuck with hard-coding the base image. In other repos we use a different build-push action which supports build args, but for now I didn't want to spend too long on this feature. Mainly something to help us move on the PRs with more confidence.

@domire8 @buschbapti 