### PR TITLE
Refactor 'msg' to 'message' for readability

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -748,7 +748,7 @@ inline void ComponentInterface<NodeT>::send_transform(const state_representation
   }
   try {
     geometry_msgs::msg::TransformStamped transform_message;
-    modulo_new_core::translators::write_msg(transform_message, transform, this->get_clock()->now());
+    modulo_new_core::translators::write_message(transform_message, transform, this->get_clock()->now());
     tf2_msgs::msg::TFMessage tf_message;
     tf_message.transforms.emplace_back(transform_message);
     this->tf_broadcaster_->publish(tf_message);
@@ -769,7 +769,7 @@ inline state_representation::CartesianPose ComponentInterface<NodeT>::lookup_tra
   try {
     state_representation::CartesianPose result(frame_name, reference_frame_name);
     auto transform = this->tf_buffer_->lookupTransform(reference_frame_name, frame_name, time_point, duration);
-    modulo_new_core::translators::read_msg(result, transform);
+    modulo_new_core::translators::read_message(result, transform);
     return result;
   } catch (const tf2::TransformException& ex) {
     throw exceptions::LookupTransformException(std::string("Failed to lookup transform: ").append(ex.what()));
@@ -779,14 +779,14 @@ inline state_representation::CartesianPose ComponentInterface<NodeT>::lookup_tra
 template<class NodeT>
 inline void ComponentInterface<NodeT>::publish_predicates() {
   for (const auto& predicate: this->predicates_) {
-    std_msgs::msg::Bool msg;
-    msg.data = this->get_predicate(predicate.first);
+    std_msgs::msg::Bool message;
+    message.data = this->get_predicate(predicate.first);
     if (this->predicate_publishers_.find(predicate.first) == this->predicate_publishers_.end()) {
       RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                    "No publisher for predicate " << predicate.first << " found.");
       return;
     }
-    predicate_publishers_.at(predicate.first)->publish(msg);
+    predicate_publishers_.at(predicate.first)->publish(message);
   }
 }
 

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -6,8 +6,8 @@ import state_representation as sr
 import tf2_py
 from geometry_msgs.msg import TransformStamped
 from modulo_components.exceptions.component_exceptions import ComponentParameterError, LookupTransformError
-from modulo_new_core.translators.message_readers import read_stamped_msg
-from modulo_new_core.translators.message_writers import write_stamped_msg
+from modulo_new_core.translators.message_readers import read_stamped_message
+from modulo_new_core.translators.message_writers import write_stamped_message
 from modulo_new_core.translators.parameter_translators import write_parameter, read_parameter_const
 from rcl_interfaces.msg import ParameterDescriptor
 from rcl_interfaces.msg import SetParametersResult
@@ -63,13 +63,13 @@ class ComponentInterface(Node):
         Step function that is called periodically.
         """
         for predicate_name in self._predicates.keys():
-            msg = Bool()
-            msg.data = self.get_predicate(predicate_name)
+            message = Bool()
+            message.data = self.get_predicate(predicate_name)
             if predicate_name not in self._predicate_publishers.keys():
                 self.get_logger().error(f"No publisher for predicate {predicate_name} found.",
                                         throttle_duration_sec=1.0)
                 return
-            self._predicate_publishers[predicate_name].publish(msg)
+            self._predicate_publishers[predicate_name].publish(message)
 
     def __generate_predicate_topic(self, predicate_name: str) -> str:
         """
@@ -311,7 +311,7 @@ class ComponentInterface(Node):
             return
         try:
             transform_message = TransformStamped()
-            write_stamped_msg(transform_message, transform, self.get_clock().now())
+            write_stamped_message(transform_message, transform, self.get_clock().now())
             self.__tf_broadcaster.sendTransform(transform_message)
         except tf2_py.TransformException as e:
             self.get_logger().error(f"Failed to send transform: {e}", throttle_duration_sec=1.0)
@@ -332,7 +332,7 @@ class ComponentInterface(Node):
         try:
             result = sr.CartesianPose(frame_name, reference_frame_name)
             transform = self.__tf_buffer.lookup_transform(reference_frame_name, frame_name, time_point, duration)
-            read_stamped_msg(result, transform)
+            read_stamped_message(result, transform)
             return result
         except tf2_py.TransformException as e:
             raise LookupTransformError(f"Failed to lookup transform: {e}")

--- a/source/modulo_core/include/modulo_core/communication/message_passing/PublisherHandler.hpp
+++ b/source/modulo_core/include/modulo_core/communication/message_passing/PublisherHandler.hpp
@@ -99,7 +99,7 @@ PublisherHandler<RecT, MsgT>::PublisherHandler(const std::shared_ptr<rclcpp::Clo
 template <class RecT, typename MsgT>
 void PublisherHandler<RecT, MsgT>::publish(const RecT& recipient) {
   auto out_msg = std::make_unique<MsgT>();
-  modulo_new_core::translators::write_msg(*out_msg, recipient, this->get_clock().now());
+  modulo_new_core::translators::write_message(*out_msg, recipient, this->get_clock().now());
   this->publisher_->publish(std::move(out_msg));
 }
 

--- a/source/modulo_core/include/modulo_core/communication/message_passing/SubscriptionHandler.hpp
+++ b/source/modulo_core/include/modulo_core/communication/message_passing/SubscriptionHandler.hpp
@@ -62,7 +62,7 @@ SubscriptionHandler<RecT, MsgT>::SubscriptionHandler(const std::shared_ptr<state
 
 template <class RecT, typename MsgT>
 void SubscriptionHandler<RecT, MsgT>::subscription_callback(const std::shared_ptr<MsgT> msg) {
-  modulo_new_core::translators::read_msg(static_cast<RecT&>(this->get_recipient()), *msg);
+  modulo_new_core::translators::read_message(static_cast<RecT&>(this->get_recipient()), *msg);
 }
 
 template <class RecT, typename MsgT>

--- a/source/modulo_core/src/communication/message_passing/TransformListenerHandler.cpp
+++ b/source/modulo_core/src/communication/message_passing/TransformListenerHandler.cpp
@@ -9,7 +9,7 @@ const state_representation::CartesianPose TransformListenerHandler::lookup_trans
                                                    frame_name,
                                                    tf2::TimePoint(std::chrono::milliseconds(0)),
                                                    tf2::Duration(this->get_timeout()));
-  modulo_new_core::translators::read_msg(result, transformStamped);
+  modulo_new_core::translators::read_message(result, transformStamped);
   return result;
 }
 }// namespace modulo::core::communication

--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
@@ -59,9 +59,9 @@ inline MsgT MessagePair<MsgT, DataT>::write_message() const {
   if (this->data_ == nullptr) {
     throw exceptions::NullPointerException("The message pair data is not set, nothing to write");
   }
-  auto msg = MsgT();
-  translators::write_msg(msg, *this->data_, clock_->now());
-  return msg;
+  auto message = MsgT();
+  translators::write_message(message, *this->data_, clock_->now());
+  return message;
 }
 
 template<>
@@ -69,9 +69,9 @@ inline EncodedState MessagePair<EncodedState, state_representation::State>::writ
   if (this->data_ == nullptr) {
     throw exceptions::NullPointerException("The message pair data is not set, nothing to write");
   }
-  auto msg = EncodedState();
-  translators::write_msg(msg, this->data_, clock_->now());
-  return msg;
+  auto message = EncodedState();
+  translators::write_message(message, this->data_, clock_->now());
+  return message;
 }
 
 template<typename MsgT, typename DataT>
@@ -79,7 +79,7 @@ inline void MessagePair<MsgT, DataT>::read_message(const MsgT& message) {
   if (this->data_ == nullptr) {
     throw exceptions::NullPointerException("The message pair data is not set, nothing to read");
   }
-  translators::read_msg(*this->data_, message);
+  translators::read_message(*this->data_, message);
 }
 
 template<>
@@ -87,7 +87,7 @@ inline void MessagePair<EncodedState, state_representation::State>::read_message
   if (this->data_ == nullptr) {
     throw exceptions::NullPointerException("The message pair data is not set, nothing to read");
   }
-  translators::read_msg(this->data_, message);
+  translators::read_message(this->data_, message);
 }
 
 template<typename MsgT, typename DataT>

--- a/source/modulo_new_core/include/modulo_new_core/translators/message_readers.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/message_readers.hpp
@@ -25,143 +25,143 @@ namespace modulo_new_core::translators {
 /**
  * @brief Convert a ROS geometry_msgs::msg::Accel to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS msg to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Accel& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Accel& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::AccelStamped to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS msg to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::AccelStamped& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::AccelStamped& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::Pose to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Pose& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Pose& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::PoseStamped to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::PoseStamped& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::PoseStamped& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::Transform to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Transform& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Transform& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::TransformStamped to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::TransformStamped& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::TransformStamped& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::Twist to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Twist& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Twist& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::TwistStamped to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::TwistStamped& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::TwistStamped& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::Wrench to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Wrench& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Wrench& message);
 
 /**
  * @brief Convert a ROS geometry_msgs::msg::WrenchStamped to a CartesianState
  * @param state The CartesianState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::WrenchStamped& msg);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::WrenchStamped& message);
 
 /**
  * @brief Convert a ROS sensor_msgs::msg::JointState to a JointState
  * @param state The JointState to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(state_representation::JointState& state, const sensor_msgs::msg::JointState& msg);
+void read_message(state_representation::JointState& state, const sensor_msgs::msg::JointState& message);
 
 /**
  * @brief Template function to convert a ROS std_msgs::msg::T to a Parameter<T>
- * @tparam T all types of parameters supported in ROS std messages
- * @tparam U all types of parameters supported in ROS std messages
+ * @tparam T All types of parameters supported in ROS std messages
+ * @tparam U All types of parameters supported in ROS std messages
  * @param state The Parameter<T> to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
 template<typename T, typename U>
-void read_msg(state_representation::Parameter<T>& state, const U& msg) {
-  state.set_value(msg.data);
+void read_message(state_representation::Parameter<T>& state, const U& message) {
+  state.set_value(message.data);
 }
 
 /**
  * @brief Convert a ROS std_msgs::msg::Bool to a boolean
  * @param state The state to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(bool& state, const std_msgs::msg::Bool& msg);
+void read_message(bool& state, const std_msgs::msg::Bool& message);
 
 /**
  * @brief Convert a ROS std_msgs::msg::Float64 to a double
  * @param state The state to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(double& state, const std_msgs::msg::Float64& msg);
+void read_message(double& state, const std_msgs::msg::Float64& message);
 
 /**
  * @brief Convert a ROS std_msgs::msg::Float64MultiArray to a vector of double
  * @param state The state to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(std::vector<double>& state, const std_msgs::msg::Float64MultiArray& msg);
+void read_message(std::vector<double>& state, const std_msgs::msg::Float64MultiArray& message);
 
 /**
  * @brief Convert a ROS std_msgs::msg::Int32 to an integer
  * @param state The state to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(int& state, const std_msgs::msg::Int32& msg);
+void read_message(int& state, const std_msgs::msg::Int32& message);
 
 /**
  * @brief Convert a ROS std_msgs::msg::String to a string
  * @param state The state to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
-void read_msg(std::string& state, const std_msgs::msg::String& msg);
+void read_message(std::string& state, const std_msgs::msg::String& message);
 
 /**
  * @brief Convert a ROS std_msgs::msg::UInt8MultiArray message to a State using protobuf decoding
- * @tparam a state_representation::State type object
+ * @tparam T A state_representation::State type
  * @param state The state to populate
- * @param msg The ROS message to read from
+ * @param message The ROS message to read from
  */
 template<typename T>
-inline void read_msg(T& state, const EncodedState& msg) {
-  std::string tmp(msg.data.begin(), msg.data.end());
+inline void read_message(T& state, const EncodedState& message) {
+  std::string tmp(message.data.begin(), message.data.end());
   state = clproto::decode<T>(tmp);
 }
 
 template<>
-inline void read_msg(std::shared_ptr<state_representation::State>& state, const EncodedState& msg) {
+inline void read_message(std::shared_ptr<state_representation::State>& state, const EncodedState& message) {
   using namespace state_representation;
-  std::string tmp(msg.data.begin(), msg.data.end());
+  std::string tmp(message.data.begin(), message.data.end());
   auto new_state = clproto::decode<std::shared_ptr<State>>(tmp);
   switch (new_state->get_type()) {
     case StateType::STATE:

--- a/source/modulo_new_core/include/modulo_new_core/translators/message_writers.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/translators/message_writers.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <rclcpp/time.hpp>
 #include <geometry_msgs/msg/accel_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
+#include <rclcpp/time.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/float64.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
 #include <std_msgs/msg/int32.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <sensor_msgs/msg/joint_state.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include <clproto.h>
@@ -25,161 +25,191 @@ namespace modulo_new_core::translators {
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Accel
- * @param msg The ROS msg to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::Accel& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::Accel& message, const state_representation::CartesianState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::AccelStamped
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::AccelStamped& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::AccelStamped& message, const state_representation::CartesianState& state,
+    const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Pose
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::Pose& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::Pose& message, const state_representation::CartesianState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::PoseStamped
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::PoseStamped& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::PoseStamped& message, const state_representation::CartesianState& state,
+    const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Transform
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::Transform& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::Transform& message, const state_representation::CartesianState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::TransformStamped
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::TransformStamped& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::TransformStamped& message, const state_representation::CartesianState& state,
+    const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Twist
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::Twist& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::Twist& message, const state_representation::CartesianState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::TwistStamped
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::TwistStamped& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::TwistStamped& message, const state_representation::CartesianState& state,
+    const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::Wrench
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::Wrench& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::Wrench& message, const state_representation::CartesianState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS geometry_msgs::msg::WrenchStamped
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(geometry_msgs::msg::WrenchStamped& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    geometry_msgs::msg::WrenchStamped& message, const state_representation::CartesianState& state,
+    const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a JointState to a ROS sensor_msgs::msg::JointState
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(sensor_msgs::msg::JointState& msg, const state_representation::JointState& state, const rclcpp::Time& time);
+void write_message(
+    sensor_msgs::msg::JointState& message, const state_representation::JointState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a CartesianState to a ROS tf2_msgs::msg::TFMessage
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(tf2_msgs::msg::TFMessage& msg, const state_representation::CartesianState& state, const rclcpp::Time& time);
+void write_message(
+    tf2_msgs::msg::TFMessage& message, const state_representation::CartesianState& state, const rclcpp::Time& time
+);
 
 /**
  * @brief Convert a Parameter<T> to a ROS equivalent representation
- * @tparam T all types of parameters supported in ROS std messages
- * @tparam U all types of parameters supported in ROS std messages
- * @param msg The ROS message to populate
+ * @tparam T All types of parameters supported in ROS std messages
+ * @tparam U All types of parameters supported in ROS std messages
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-template <typename U, typename T>
-void write_msg(U& msg, const state_representation::Parameter<T>& state, const rclcpp::Time&);
+template<typename U, typename T>
+void write_message(U& message, const state_representation::Parameter<T>& state, const rclcpp::Time&);
 
 /**
  * @brief Convert a boolean to a ROS std_msgs::msg::Bool
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(std_msgs::msg::Bool& msg, const bool& state, const rclcpp::Time& time);
+void write_message(std_msgs::msg::Bool& message, const bool& state, const rclcpp::Time& time);
 
 /**
  * @brief Convert a double to a ROS std_msgs::msg::Float64
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(std_msgs::msg::Float64& msg, const double& state, const rclcpp::Time& time);
+void write_message(std_msgs::msg::Float64& message, const double& state, const rclcpp::Time& time);
 
 /**
  * @brief Convert a vector of double to a ROS std_msgs::msg::Float64MultiArray
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(std_msgs::msg::Float64MultiArray& msg, const std::vector<double>& state, const rclcpp::Time& time);
+void
+write_message(std_msgs::msg::Float64MultiArray& message, const std::vector<double>& state, const rclcpp::Time& time);
 
 /**
  * @brief Convert an integer to a ROS std_msgs::msg::Int32
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(std_msgs::msg::Int32& msg, const int& state, const rclcpp::Time& time);
+void write_message(std_msgs::msg::Int32& message, const int& state, const rclcpp::Time& time);
 
 /**
  * @brief Convert a string to a ROS std_msgs::msg::String
- * @param msg The ROS message to populate
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
-void write_msg(std_msgs::msg::String& msg, const std::string& state, const rclcpp::Time& time);
+void write_message(std_msgs::msg::String& message, const std::string& state, const rclcpp::Time& time);
 
 /**
- * @brief Convert a state to a ROS std_msgs::msg::UInt8MultiArray message using protobuf encoding
- * @tparam a state_representation::State type object
- * @param msg The ROS msg to populate
+ * @brief Convert a state to an EncodedState (std_msgs::msg::UInt8MultiArray) message using protobuf encoding
+ * @tparam T A state_representation::State type
+ * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
  */
 template<typename T>
-inline void write_msg(EncodedState& msg, const T& state, const rclcpp::Time&) {
+inline void write_message(EncodedState& message, const T& state, const rclcpp::Time&) {
   std::string tmp = clproto::encode<T>(state);
-  msg.data = std::vector<unsigned char>(tmp.begin(), tmp.end());
+  message.data = std::vector<unsigned char>(tmp.begin(), tmp.end());
 }
 }// namespace modulo_new_core::translators

--- a/source/modulo_new_core/modulo_new_core/translators/message_readers.py
+++ b/source/modulo_new_core/modulo_new_core/translators/message_readers.py
@@ -12,91 +12,91 @@ MsgT = TypeVar('MsgT')
 StateT = TypeVar('StateT')
 
 
-def read_xyz(msg: Union[geometry.Point, geometry.Vector3]) -> List[float]:
+def read_xyz(message: Union[geometry.Point, geometry.Vector3]) -> List[float]:
     """
     Helper function to read a list from a Point or Vector3 message.
 
-    :param msg: The message to read from
+    :param message: The message to read from
     """
-    return [msg.x, msg.y, msg.z]
+    return [message.x, message.y, message.z]
 
 
-def read_quaternion(msg: geometry.Quaternion) -> List[float]:
+def read_quaternion(message: geometry.Quaternion) -> List[float]:
     """
     Helper function to read a list of quaternion coefficients (w,x,y,z) from a Quaternion message.
 
-    :param msg: The message to read from
+    :param message: The message to read from
     """
-    return [msg.w, msg.x, msg.y, msg.z]
+    return [message.w, message.x, message.y, message.z]
 
 
-def read_msg(state: StateT, msg: MsgT):
+def read_message(state: StateT, message: MsgT):
     """
     Convert a ROS message to a state_representation State.
 
     :param state: The state to populate
-    :param msg: The ROS message to read from
+    :param message: The ROS message to read from
     """
     if not isinstance(state, sr.State):
         raise RuntimeError("This state type is not supported.")
     if isinstance(state, sr.CartesianState):
-        if isinstance(msg, geometry.Accel):
-            state.set_linear_acceleration(read_xyz(msg.linear))
-            state.set_angular_acceleration(read_xyz(msg.angular))
-        elif isinstance(msg, geometry.Pose):
-            state.set_position(read_xyz(msg.position))
-            state.set_orientation(read_quaternion(msg.orientation))
-        elif isinstance(msg, geometry.Transform):
-            state.set_position(read_xyz(msg.translation))
-            state.set_orientation(read_quaternion(msg.rotation))
-        elif isinstance(msg, geometry.Twist):
-            state.set_linear_velocity(read_xyz(msg.linear))
-            state.set_angular_velocity(read_xyz(msg.angular))
-        elif isinstance(msg, geometry.Wrench):
-            state.set_force(read_xyz(msg.force))
-            state.set_torque(read_xyz(msg.torque))
+        if isinstance(message, geometry.Accel):
+            state.set_linear_acceleration(read_xyz(message.linear))
+            state.set_angular_acceleration(read_xyz(message.angular))
+        elif isinstance(message, geometry.Pose):
+            state.set_position(read_xyz(message.position))
+            state.set_orientation(read_quaternion(message.orientation))
+        elif isinstance(message, geometry.Transform):
+            state.set_position(read_xyz(message.translation))
+            state.set_orientation(read_quaternion(message.rotation))
+        elif isinstance(message, geometry.Twist):
+            state.set_linear_velocity(read_xyz(message.linear))
+            state.set_angular_velocity(read_xyz(message.angular))
+        elif isinstance(message, geometry.Wrench):
+            state.set_force(read_xyz(message.force))
+            state.set_torque(read_xyz(message.torque))
         else:
             raise RuntimeError("The provided combination of state type and message type is not supported")
-    elif isinstance(msg, sensor_msgs.msg.JointState) and isinstance(state, sr.JointState):
-        state.set_names(msg.name)
-        if len(msg.position):
-            state.set_positions(msg.position)
-        if len(msg.velocity):
-            state.set_velocities(msg.velocity)
-        if len(msg.effort):
-            state.set_torques(msg.effort)
+    elif isinstance(message, sensor_msgs.msg.JointState) and isinstance(state, sr.JointState):
+        state.set_names(message.name)
+        if len(message.position):
+            state.set_positions(message.position)
+        if len(message.velocity):
+            state.set_velocities(message.velocity)
+        if len(message.effort):
+            state.set_torques(message.effort)
     else:
         raise RuntimeError("The provided combination of state type and message type is not supported")
     return state
 
 
-def read_stamped_msg(state: StateT, msg: MsgT):
+def read_stamped_message(state: StateT, message: MsgT):
     """
     Convert a stamped ROS message to a state_representation State.
 
     :param state: The state to populate
-    :param msg: The ROS message to read from
+    :param message: The ROS message to read from
     """
-    if isinstance(msg, geometry.AccelStamped):
-        read_msg(state, msg.accel)
-    elif isinstance(msg, geometry.PoseStamped):
-        read_msg(state, msg.pose)
-    elif isinstance(msg, geometry.TransformStamped):
-        read_msg(state, msg.transform)
-        state.set_name(msg.child_frame_id)
-    elif isinstance(msg, geometry.TwistStamped):
-        read_msg(state, msg.twist)
-    elif isinstance(msg, geometry.WrenchStamped):
-        read_msg(state, msg.wrench)
+    if isinstance(message, geometry.AccelStamped):
+        read_message(state, message.accel)
+    elif isinstance(message, geometry.PoseStamped):
+        read_message(state, message.pose)
+    elif isinstance(message, geometry.TransformStamped):
+        read_message(state, message.transform)
+        state.set_name(message.child_frame_id)
+    elif isinstance(message, geometry.TwistStamped):
+        read_message(state, message.twist)
+    elif isinstance(message, geometry.WrenchStamped):
+        read_message(state, message.wrench)
     else:
         raise RuntimeError("The provided combination of state type and message type is not supported")
-    state.set_reference_frame(msg.header.frame_id)
+    state.set_reference_frame(message.header.frame_id)
 
 
-def read_clproto_msg(msg: EncodedState) -> StateT:
+def read_clproto_message(message: EncodedState) -> StateT:
     """
     Convert an EncodedState message to a state_representation State.
 
-    :param msg: The EncodedState msg to read from
+    :param message: The EncodedState message to read from
     """
-    return clproto.decode(msg.data.tobytes())
+    return clproto.decode(message.data.tobytes())

--- a/source/modulo_new_core/modulo_new_core/translators/message_writers.py
+++ b/source/modulo_new_core/modulo_new_core/translators/message_writers.py
@@ -12,40 +12,40 @@ MsgT = TypeVar('MsgT')
 StateT = TypeVar('StateT')
 
 
-def write_xyz(msg: Union[geometry.Point, geometry.Vector3], vector: np.array):
+def write_xyz(message: Union[geometry.Point, geometry.Vector3], vector: np.array):
     """
     Helper function to write a vector to a Point or Vector3 message.
 
-    :param msg: The message to populate
+    :param message: The message to populate
     :param vector: The vector to read from
     """
     if vector.size != 3:
         raise RuntimeError("Provide a vector of size 3 to transform to a Point or Vector3 message.")
-    msg.x = vector[0]
-    msg.y = vector[1]
-    msg.z = vector[2]
+    message.x = vector[0]
+    message.y = vector[1]
+    message.z = vector[2]
 
 
-def write_quaternion(msg: geometry.Quaternion, quat: np.array):
+def write_quaternion(message: geometry.Quaternion, quat: np.array):
     """
     Helper function to write a vector of quaternion coefficients (w,x,y,z) to a Quaternion message.
 
-    :param msg: The message to populate
+    :param message: The message to populate
     :param quat: The vector to read from
     """
     if quat.size != 4:
         raise RuntimeError("Provide a vector of size 4 to transform to a Quaternion message.")
-    msg.w = quat[0]
-    msg.x = quat[1]
-    msg.y = quat[2]
-    msg.z = quat[3]
+    message.w = quat[0]
+    message.x = quat[1]
+    message.y = quat[2]
+    message.z = quat[3]
 
 
-def write_msg(msg: MsgT, state: StateT):
+def write_message(message: MsgT, state: StateT):
     """
     Convert a state_representation State to a ROS message.
 
-    :param msg: The ROS message to populate
+    :param message: The ROS message to populate
     :param state: The state to read from
     """
     if not isinstance(state, sr.State):
@@ -53,58 +53,58 @@ def write_msg(msg: MsgT, state: StateT):
     if state.is_empty():
         raise RuntimeError(f"{state.get_name()} state is empty while attempting to write it to message.")
     if isinstance(state, sr.CartesianState):
-        if isinstance(msg, geometry.Accel):
-            write_xyz(msg.linear, state.get_linear_acceleration())
-            write_xyz(msg.angular, state.get_angular_acceleration())
-        elif isinstance(msg, geometry.Pose):
-            write_xyz(msg.position, state.get_position())
-            write_quaternion(msg.orientation, state.get_orientation_coefficients())
-        elif isinstance(msg, geometry.Transform):
-            write_xyz(msg.translation, state.get_position())
-            write_quaternion(msg.rotation, state.get_orientation_coefficients())
-        elif isinstance(msg, geometry.Twist):
-            write_xyz(msg.linear, state.get_linear_velocity())
-            write_xyz(msg.angular, state.get_angular_velocity())
-        elif isinstance(msg, geometry.Wrench):
-            write_xyz(msg.force, state.get_force())
-            write_xyz(msg.torque, state.get_torque())
+        if isinstance(message, geometry.Accel):
+            write_xyz(message.linear, state.get_linear_acceleration())
+            write_xyz(message.angular, state.get_angular_acceleration())
+        elif isinstance(message, geometry.Pose):
+            write_xyz(message.position, state.get_position())
+            write_quaternion(message.orientation, state.get_orientation_coefficients())
+        elif isinstance(message, geometry.Transform):
+            write_xyz(message.translation, state.get_position())
+            write_quaternion(message.rotation, state.get_orientation_coefficients())
+        elif isinstance(message, geometry.Twist):
+            write_xyz(message.linear, state.get_linear_velocity())
+            write_xyz(message.angular, state.get_angular_velocity())
+        elif isinstance(message, geometry.Wrench):
+            write_xyz(message.force, state.get_force())
+            write_xyz(message.torque, state.get_torque())
         else:
             raise RuntimeError("The provided combination of state type and message type is not supported")
-    elif isinstance(msg, sensor_msgs.msg.JointState) and isinstance(state, sr.JointState):
-        msg.name = state.get_names()
-        msg.position = state.get_positions().tolist()
-        msg.velocity = state.get_velocities().tolist()
-        msg.effort = state.get_torques().tolist()
+    elif isinstance(message, sensor_msgs.msg.JointState) and isinstance(state, sr.JointState):
+        message.name = state.get_names()
+        message.position = state.get_positions().tolist()
+        message.velocity = state.get_velocities().tolist()
+        message.effort = state.get_torques().tolist()
     else:
         raise RuntimeError("The provided combination of state type and message type is not supported")
 
 
-def write_stamped_msg(msg: MsgT, state: StateT, time: rclpy.time.Time):
+def write_stamped_message(message: MsgT, state: StateT, time: rclpy.time.Time):
     """
     Convert a state_representation State to a stamped ROS message.
 
-    :param msg: The ROS message to populate
+    :param message: The ROS message to populate
     :param state: The state to read from
     :param time: The time of the message
     """
-    if isinstance(msg, geometry.AccelStamped):
-        write_msg(msg.accel, state)
-    elif isinstance(msg, geometry.PoseStamped):
-        write_msg(msg.pose, state)
-    elif isinstance(msg, geometry.TransformStamped):
-        write_msg(msg.transform, state)
-        msg.child_frame_id = state.get_name()
-    elif isinstance(msg, geometry.TwistStamped):
-        write_msg(msg.twist, state)
-    elif isinstance(msg, geometry.WrenchStamped):
-        write_msg(msg.wrench, state)
+    if isinstance(message, geometry.AccelStamped):
+        write_message(message.accel, state)
+    elif isinstance(message, geometry.PoseStamped):
+        write_message(message.pose, state)
+    elif isinstance(message, geometry.TransformStamped):
+        write_message(message.transform, state)
+        message.child_frame_id = state.get_name()
+    elif isinstance(message, geometry.TwistStamped):
+        write_message(message.twist, state)
+    elif isinstance(message, geometry.WrenchStamped):
+        write_message(message.wrench, state)
     else:
         raise RuntimeError("The provided combination of state type and message type is not supported")
-    msg.header.stamp = time.to_msg()
-    msg.header.frame_id = state.get_reference_frame()
+    message.header.stamp = time.to_msg()
+    message.header.frame_id = state.get_reference_frame()
 
 
-def write_clproto_msg(state: StateT, clproto_message_type: clproto.MessageType) -> EncodedState():
+def write_clproto_message(state: StateT, clproto_message_type: clproto.MessageType) -> EncodedState():
     """
     Convert a state_representation State to an EncodedState message.
 
@@ -113,6 +113,6 @@ def write_clproto_msg(state: StateT, clproto_message_type: clproto.MessageType) 
     """
     if not isinstance(state, sr.State):
         raise RuntimeError("This state type is not supported.")
-    msg = EncodedState()
-    msg.data = clproto.encode(state, clproto_message_type)
-    return msg
+    message = EncodedState()
+    message.data = clproto.encode(state, clproto_message_type)
+    return message

--- a/source/modulo_new_core/src/translators/message_readers.cpp
+++ b/source/modulo_new_core/src/translators/message_readers.cpp
@@ -2,99 +2,99 @@
 
 namespace modulo_new_core::translators {
 
-static Eigen::Vector3d read_point(const geometry_msgs::msg::Point& msg) {
-  return {msg.x, msg.y, msg.z};
+static Eigen::Vector3d read_point(const geometry_msgs::msg::Point& message) {
+  return {message.x, message.y, message.z};
 }
 
-static Eigen::Vector3d read_vector3(const geometry_msgs::msg::Vector3& msg) {
-  return {msg.x, msg.y, msg.z};
+static Eigen::Vector3d read_vector3(const geometry_msgs::msg::Vector3& message) {
+  return {message.x, message.y, message.z};
 }
 
-static Eigen::Quaterniond read_quaternion(const geometry_msgs::msg::Quaternion& msg) {
-  return {msg.w, msg.x, msg.y, msg.z};
+static Eigen::Quaterniond read_quaternion(const geometry_msgs::msg::Quaternion& message) {
+  return {message.w, message.x, message.y, message.z};
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Accel& msg) {
-  state.set_linear_acceleration(read_vector3(msg.linear));
-  state.set_angular_acceleration(read_vector3(msg.angular));
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Accel& message) {
+  state.set_linear_acceleration(read_vector3(message.linear));
+  state.set_angular_acceleration(read_vector3(message.angular));
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::AccelStamped& msg) {
-  state.set_reference_frame(msg.header.frame_id);
-  read_msg(state, msg.accel);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::AccelStamped& message) {
+  state.set_reference_frame(message.header.frame_id);
+  read_message(state, message.accel);
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Pose& msg) {
-  state.set_position(read_point(msg.position));
-  state.set_orientation(read_quaternion(msg.orientation));
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Pose& message) {
+  state.set_position(read_point(message.position));
+  state.set_orientation(read_quaternion(message.orientation));
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::PoseStamped& msg) {
-  state.set_reference_frame(msg.header.frame_id);
-  read_msg(state, msg.pose);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::PoseStamped& message) {
+  state.set_reference_frame(message.header.frame_id);
+  read_message(state, message.pose);
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Transform& msg) {
-  state.set_position(read_vector3(msg.translation));
-  state.set_orientation(read_quaternion(msg.rotation));
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Transform& message) {
+  state.set_position(read_vector3(message.translation));
+  state.set_orientation(read_quaternion(message.rotation));
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::TransformStamped& msg) {
-  state.set_reference_frame(msg.header.frame_id);
-  state.set_name(msg.child_frame_id);
-  read_msg(state, msg.transform);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::TransformStamped& message) {
+  state.set_reference_frame(message.header.frame_id);
+  state.set_name(message.child_frame_id);
+  read_message(state, message.transform);
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Twist& msg) {
-  state.set_linear_velocity(read_vector3(msg.linear));
-  state.set_angular_velocity(read_vector3(msg.angular));
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Twist& message) {
+  state.set_linear_velocity(read_vector3(message.linear));
+  state.set_angular_velocity(read_vector3(message.angular));
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::TwistStamped& msg) {
-  state.set_reference_frame(msg.header.frame_id);
-  read_msg(state, msg.twist);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::TwistStamped& message) {
+  state.set_reference_frame(message.header.frame_id);
+  read_message(state, message.twist);
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::Wrench& msg) {
-  state.set_force(read_vector3(msg.force));
-  state.set_torque(read_vector3(msg.torque));
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::Wrench& message) {
+  state.set_force(read_vector3(message.force));
+  state.set_torque(read_vector3(message.torque));
 }
 
-void read_msg(state_representation::CartesianState& state, const geometry_msgs::msg::WrenchStamped& msg) {
-  state.set_reference_frame(msg.header.frame_id);
-  read_msg(state, msg.wrench);
+void read_message(state_representation::CartesianState& state, const geometry_msgs::msg::WrenchStamped& message) {
+  state.set_reference_frame(message.header.frame_id);
+  read_message(state, message.wrench);
 }
 
-void read_msg(state_representation::JointState& state, const sensor_msgs::msg::JointState& msg) {
-  state.set_names(msg.name);
-  if (!msg.position.empty()) {
-    state.set_positions(Eigen::VectorXd::Map(msg.position.data(), msg.position.size()));
+void read_message(state_representation::JointState& state, const sensor_msgs::msg::JointState& message) {
+  state.set_names(message.name);
+  if (!message.position.empty()) {
+    state.set_positions(Eigen::VectorXd::Map(message.position.data(), message.position.size()));
   }
-  if (!msg.velocity.empty()) {
-    state.set_velocities(Eigen::VectorXd::Map(msg.velocity.data(), msg.velocity.size()));
+  if (!message.velocity.empty()) {
+    state.set_velocities(Eigen::VectorXd::Map(message.velocity.data(), message.velocity.size()));
   }
-  if (!msg.effort.empty()) {
-    state.set_torques(Eigen::VectorXd::Map(msg.effort.data(), msg.effort.size()));
+  if (!message.effort.empty()) {
+    state.set_torques(Eigen::VectorXd::Map(message.effort.data(), message.effort.size()));
   }
 }
 
-void read_msg(bool& state, const std_msgs::msg::Bool& msg) {
-  state = msg.data;
+void read_message(bool& state, const std_msgs::msg::Bool& message) {
+  state = message.data;
 }
 
-void read_msg(double& state, const std_msgs::msg::Float64& msg) {
-  state = msg.data;
+void read_message(double& state, const std_msgs::msg::Float64& message) {
+  state = message.data;
 }
 
-void read_msg(std::vector<double>& state, const std_msgs::msg::Float64MultiArray& msg) {
-  state = msg.data;
+void read_message(std::vector<double>& state, const std_msgs::msg::Float64MultiArray& message) {
+  state = message.data;
 }
 
-void read_msg(int& state, const std_msgs::msg::Int32& msg) {
-  state = msg.data;
+void read_message(int& state, const std_msgs::msg::Int32& message) {
+  state = message.data;
 }
 
-void read_msg(std::string& state, const std_msgs::msg::String& msg) {
-  state = msg.data;
+void read_message(std::string& state, const std_msgs::msg::String& message) {
+  state = message.data;
 }
 }// namespace modulo_new_core::translators

--- a/source/modulo_new_core/src/translators/message_writers.cpp
+++ b/source/modulo_new_core/src/translators/message_writers.cpp
@@ -7,164 +7,179 @@ using namespace state_representation;
 
 namespace modulo_new_core::translators {
 
-static void write_point(geometry_msgs::msg::Point& msg, const Eigen::Vector3d& vector) {
-  msg.x = vector.x();
-  msg.y = vector.y();
-  msg.z = vector.z();
+static void write_point(geometry_msgs::msg::Point& message, const Eigen::Vector3d& vector) {
+  message.x = vector.x();
+  message.y = vector.y();
+  message.z = vector.z();
 }
 
-static void write_vector3(geometry_msgs::msg::Vector3& msg, const Eigen::Vector3d& vector) {
-  msg.x = vector.x();
-  msg.y = vector.y();
-  msg.z = vector.z();
+static void write_vector3(geometry_msgs::msg::Vector3& message, const Eigen::Vector3d& vector) {
+  message.x = vector.x();
+  message.y = vector.y();
+  message.z = vector.z();
 }
 
-static void write_quaternion(geometry_msgs::msg::Quaternion& msg, const Eigen::Quaterniond& quat) {
-  msg.w = quat.w();
-  msg.x = quat.x();
-  msg.y = quat.y();
-  msg.z = quat.z();
+static void write_quaternion(geometry_msgs::msg::Quaternion& message, const Eigen::Quaterniond& quat) {
+  message.w = quat.w();
+  message.x = quat.x();
+  message.y = quat.y();
+  message.z = quat.z();
 }
 
-void write_msg(geometry_msgs::msg::Accel& msg, const CartesianState& state, const rclcpp::Time&) {
+void write_message(geometry_msgs::msg::Accel& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  write_vector3(msg.linear, state.get_linear_acceleration());
-  write_vector3(msg.angular, state.get_angular_acceleration());
+  write_vector3(message.linear, state.get_linear_acceleration());
+  write_vector3(message.angular, state.get_angular_acceleration());
 }
 
-void write_msg(geometry_msgs::msg::AccelStamped& msg, const CartesianState& state, const rclcpp::Time& time) {
-  write_msg(msg.accel, state, time);
-  msg.header.stamp = time;
-  msg.header.frame_id = state.get_reference_frame();
+void write_message(geometry_msgs::msg::AccelStamped& message, const CartesianState& state, const rclcpp::Time& time) {
+  write_message(message.accel, state, time);
+  message.header.stamp = time;
+  message.header.frame_id = state.get_reference_frame();
 }
 
-void write_msg(geometry_msgs::msg::Pose& msg, const CartesianState& state, const rclcpp::Time&) {
+void write_message(geometry_msgs::msg::Pose& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  write_point(msg.position, state.get_position());
-  write_quaternion(msg.orientation, state.get_orientation());
+  write_point(message.position, state.get_position());
+  write_quaternion(message.orientation, state.get_orientation());
 }
 
-void write_msg(geometry_msgs::msg::PoseStamped& msg, const CartesianState& state, const rclcpp::Time& time) {
-  write_msg(msg.pose, state, time);
-  msg.header.stamp = time;
-  msg.header.frame_id = state.get_reference_frame();
+void write_message(geometry_msgs::msg::PoseStamped& message, const CartesianState& state, const rclcpp::Time& time) {
+  write_message(message.pose, state, time);
+  message.header.stamp = time;
+  message.header.frame_id = state.get_reference_frame();
 }
 
-void write_msg(geometry_msgs::msg::Transform& msg, const CartesianState& state, const rclcpp::Time&) {
+void write_message(geometry_msgs::msg::Transform& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  write_vector3(msg.translation, state.get_position());
-  write_quaternion(msg.rotation, state.get_orientation());
+  write_vector3(message.translation, state.get_position());
+  write_quaternion(message.rotation, state.get_orientation());
 }
 
-void write_msg(geometry_msgs::msg::TransformStamped& msg, const CartesianState& state, const rclcpp::Time& time) {
-  write_msg(msg.transform, state, time);
-  msg.header.stamp = time;
-  msg.header.frame_id = state.get_reference_frame();
-  msg.child_frame_id = state.get_name();
+void
+write_message(geometry_msgs::msg::TransformStamped& message, const CartesianState& state, const rclcpp::Time& time) {
+  write_message(message.transform, state, time);
+  message.header.stamp = time;
+  message.header.frame_id = state.get_reference_frame();
+  message.child_frame_id = state.get_name();
 }
 
-void write_msg(geometry_msgs::msg::Twist& msg, const CartesianState& state, const rclcpp::Time&) {
+void write_message(geometry_msgs::msg::Twist& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  write_vector3(msg.linear, state.get_linear_velocity());
-  write_vector3(msg.angular, state.get_angular_velocity());
+  write_vector3(message.linear, state.get_linear_velocity());
+  write_vector3(message.angular, state.get_angular_velocity());
 }
 
-void write_msg(geometry_msgs::msg::TwistStamped& msg, const CartesianState& state, const rclcpp::Time& time) {
-  write_msg(msg.twist, state, time);
-  msg.header.stamp = time;
-  msg.header.frame_id = state.get_reference_frame();
+void write_message(geometry_msgs::msg::TwistStamped& message, const CartesianState& state, const rclcpp::Time& time) {
+  write_message(message.twist, state, time);
+  message.header.stamp = time;
+  message.header.frame_id = state.get_reference_frame();
 }
 
-void write_msg(geometry_msgs::msg::Wrench& msg, const CartesianState& state, const rclcpp::Time&) {
+void write_message(geometry_msgs::msg::Wrench& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  write_vector3(msg.force, state.get_force());
-  write_vector3(msg.torque, state.get_torque());
+  write_vector3(message.force, state.get_force());
+  write_vector3(message.torque, state.get_torque());
 }
 
-void write_msg(geometry_msgs::msg::WrenchStamped& msg, const CartesianState& state, const rclcpp::Time& time) {
-  write_msg(msg.wrench, state, time);
-  msg.header.stamp = time;
-  msg.header.frame_id = state.get_reference_frame();
+void write_message(geometry_msgs::msg::WrenchStamped& message, const CartesianState& state, const rclcpp::Time& time) {
+  write_message(message.wrench, state, time);
+  message.header.stamp = time;
+  message.header.frame_id = state.get_reference_frame();
 }
 
-void write_msg(sensor_msgs::msg::JointState& msg, const JointState& state, const rclcpp::Time& time) {
+void write_message(sensor_msgs::msg::JointState& message, const JointState& state, const rclcpp::Time& time) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  msg.header.stamp = time;
-  msg.name = state.get_names();
-  msg.position = std::vector<double>(state.get_positions().data(), state.get_positions().data() + state.get_positions().size());
-  msg.velocity = std::vector<double>(state.get_velocities().data(), state.get_velocities().data() + state.get_velocities().size());
-  msg.effort = std::vector<double>(state.get_torques().data(), state.get_torques().data() + state.get_torques().size());
+  message.header.stamp = time;
+  message.name = state.get_names();
+  message.position =
+      std::vector<double>(state.get_positions().data(), state.get_positions().data() + state.get_positions().size());
+  message.velocity =
+      std::vector<double>(state.get_velocities().data(), state.get_velocities().data() + state.get_velocities().size());
+  message.effort =
+      std::vector<double>(state.get_torques().data(), state.get_torques().data() + state.get_torques().size());
 }
 
-void write_msg(tf2_msgs::msg::TFMessage& msg, const CartesianState& state, const rclcpp::Time& time) {
+void write_message(tf2_msgs::msg::TFMessage& message, const CartesianState& state, const rclcpp::Time& time) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
   geometry_msgs::msg::TransformStamped transform;
-  write_msg(transform, state, time);
-  msg.transforms.push_back(transform);
+  write_message(transform, state, time);
+  message.transforms.push_back(transform);
 }
 
 template<typename U, typename T>
-void write_msg(U& msg, const Parameter<T>& state, const rclcpp::Time&) {
+void write_message(U& message, const Parameter<T>& state, const rclcpp::Time&) {
   if (state.is_empty()) {
     throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
   }
-  msg.data = state.get_value();
+  message.data = state.get_value();
 }
 
-template void write_msg<std_msgs::msg::Float64, double>(std_msgs::msg::Float64& msg, const Parameter<double>& state, const rclcpp::Time&);
+template void write_message<std_msgs::msg::Float64, double>(
+    std_msgs::msg::Float64& message, const Parameter<double>& state, const rclcpp::Time&
+);
 
-template void write_msg<std_msgs::msg::Float64MultiArray, std::vector<double>>(std_msgs::msg::Float64MultiArray& msg, const Parameter<std::vector<double>>& state, const rclcpp::Time&);
+template void write_message<std_msgs::msg::Float64MultiArray, std::vector<double>>(
+    std_msgs::msg::Float64MultiArray& message, const Parameter<std::vector<double>>& state, const rclcpp::Time&
+);
 
-template void write_msg<std_msgs::msg::Bool, bool>(std_msgs::msg::Bool& msg, const Parameter<bool>& state, const rclcpp::Time&);
+template void write_message<std_msgs::msg::Bool, bool>(
+    std_msgs::msg::Bool& message, const Parameter<bool>& state, const rclcpp::Time&
+);
 
-template void write_msg<std_msgs::msg::String, std::string>(std_msgs::msg::String& msg, const Parameter<std::string>& state, const rclcpp::Time&);
+template void write_message<std_msgs::msg::String, std::string>(
+    std_msgs::msg::String& message, const Parameter<std::string>& state, const rclcpp::Time&
+);
 
 template<>
-void write_msg(geometry_msgs::msg::Transform& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
-  write_msg(msg, state.get_value(), time);
+void
+write_message(geometry_msgs::msg::Transform& message, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
+  write_message(message, state.get_value(), time);
 }
 
 template<>
-void write_msg(geometry_msgs::msg::TransformStamped& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
-  write_msg(msg, state.get_value(), time);
+void write_message(
+    geometry_msgs::msg::TransformStamped& message, const Parameter<CartesianPose>& state, const rclcpp::Time& time
+) {
+  write_message(message, state.get_value(), time);
 }
 
 template<>
-void write_msg(tf2_msgs::msg::TFMessage& msg, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
-  write_msg(msg, state.get_value(), time);
+void write_message(tf2_msgs::msg::TFMessage& message, const Parameter<CartesianPose>& state, const rclcpp::Time& time) {
+  write_message(message, state.get_value(), time);
 }
 
-void write_msg(std_msgs::msg::Bool& msg, const bool& state, const rclcpp::Time&) {
-  msg.data = state;
+void write_message(std_msgs::msg::Bool& message, const bool& state, const rclcpp::Time&) {
+  message.data = state;
 }
 
-void write_msg(std_msgs::msg::Float64& msg, const double& state, const rclcpp::Time&) {
-  msg.data = state;
+void write_message(std_msgs::msg::Float64& message, const double& state, const rclcpp::Time&) {
+  message.data = state;
 }
 
-void write_msg(std_msgs::msg::Float64MultiArray& msg, const std::vector<double>& state, const rclcpp::Time&) {
-  msg.data = state;
+void write_message(std_msgs::msg::Float64MultiArray& message, const std::vector<double>& state, const rclcpp::Time&) {
+  message.data = state;
 }
 
-void write_msg(std_msgs::msg::Int32& msg, const int& state, const rclcpp::Time&) {
-  msg.data = state;
+void write_message(std_msgs::msg::Int32& message, const int& state, const rclcpp::Time&) {
+  message.data = state;
 }
 
-void write_msg(std_msgs::msg::String& msg, const std::string& state, const rclcpp::Time&) {
-  msg.data = state;
+void write_message(std_msgs::msg::String& message, const std::string& state, const rclcpp::Time&) {
+  message.data = state;
 }
 }// namespace modulo_new_core::translators

--- a/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
@@ -34,8 +34,8 @@ public:
     this->received_future = this->received_.get_future();
     this->subscription_interface_ = std::make_shared<SubscriptionHandler<MsgT>>(message_pair);
     auto subscription = this->create_subscription<MsgT>(
-        topic_name, 10, [this](const std::shared_ptr<MsgT> msg) {
-          this->subscription_interface_->template get_handler<MsgT>()->get_callback()(msg);
+        topic_name, 10, [this](const std::shared_ptr<MsgT> message) {
+          this->subscription_interface_->template get_handler<MsgT>()->get_callback()(message);
           this->received_.set_value();
         }
     );

--- a/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_message_pair.cpp
@@ -9,24 +9,24 @@ static void test_message_interface(
     const DataT& initial_value, const DataT& new_value, const std::shared_ptr<rclcpp::Clock> clock
 ) {
   auto data = std::make_shared<DataT>(initial_value);
-  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, clock);
-  EXPECT_EQ(initial_value, *msg_pair->get_data());
-  EXPECT_EQ(initial_value, msg_pair->write_message().data);
+  auto message_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, clock);
+  EXPECT_EQ(initial_value, *message_pair->get_data());
+  EXPECT_EQ(initial_value, message_pair->write_message().data);
 
-  std::shared_ptr<MessagePairInterface> msg_pair_interface(msg_pair);
-  auto msg = msg_pair_interface->template write<MsgT, DataT>();
-  EXPECT_EQ(initial_value, msg.data);
+  std::shared_ptr<MessagePairInterface> message_pair_interface(message_pair);
+  auto message = message_pair_interface->template write<MsgT, DataT>();
+  EXPECT_EQ(initial_value, message.data);
 
   *data = new_value;
-  EXPECT_EQ(new_value, *msg_pair->get_data());
-  EXPECT_EQ(new_value, msg_pair->write_message().data);
-  msg = msg_pair_interface->template write<MsgT, DataT>();
-  EXPECT_EQ(new_value, msg.data);
+  EXPECT_EQ(new_value, *message_pair->get_data());
+  EXPECT_EQ(new_value, message_pair->write_message().data);
+  message = message_pair_interface->template write<MsgT, DataT>();
+  EXPECT_EQ(new_value, message.data);
 
-  msg = MsgT();
-  msg.data = initial_value;
-  msg_pair_interface->template read<MsgT, DataT>(msg);
-  EXPECT_EQ(initial_value, *msg_pair->get_data());
+  message = MsgT();
+  message.data = initial_value;
+  message_pair_interface->template read<MsgT, DataT>(message);
+  EXPECT_EQ(initial_value, *message_pair->get_data());
 }
 
 class MessagePairTest : public ::testing::Test {
@@ -51,29 +51,29 @@ TEST_F(MessagePairTest, BasicTypes) {
 TEST_F(MessagePairTest, EncodedState) {
   auto initial_value = state_representation::CartesianState::Random("test");
   auto data = state_representation::make_shared_state(initial_value);
-  auto msg_pair =
+  auto message_pair =
       std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(data, clock_);
   EXPECT_TRUE(initial_value.data().isApprox(
-      std::dynamic_pointer_cast<state_representation::CartesianState>(msg_pair->get_data())->data()));
+      std::dynamic_pointer_cast<state_representation::CartesianState>(message_pair->get_data())->data()));
 
-  std::shared_ptr<MessagePairInterface> msg_pair_interface(msg_pair);
-  auto msg = msg_pair_interface->write<modulo_new_core::EncodedState, state_representation::State>();
-  std::string tmp(msg.data.begin(), msg.data.end());
+  std::shared_ptr<MessagePairInterface> message_pair_interface(message_pair);
+  auto message = message_pair_interface->write<modulo_new_core::EncodedState, state_representation::State>();
+  std::string tmp(message.data.begin(), message.data.end());
   auto decoded = clproto::decode<state_representation::CartesianState>(tmp);
   EXPECT_TRUE(initial_value.data().isApprox(decoded.data()));
 
   auto new_value = state_representation::CartesianState::Identity("world");
-  msg_pair->set_data(state_representation::make_shared_state(new_value));
-  msg = msg_pair_interface->write<modulo_new_core::EncodedState, state_representation::State>();
-  tmp = std::string(msg.data.begin(), msg.data.end());
+  message_pair->set_data(state_representation::make_shared_state(new_value));
+  message = message_pair_interface->write<modulo_new_core::EncodedState, state_representation::State>();
+  tmp = std::string(message.data.begin(), message.data.end());
   decoded = clproto::decode<state_representation::CartesianState>(tmp);
   EXPECT_TRUE(new_value.data().isApprox(decoded.data()));
 
   data = state_representation::make_shared_state(initial_value);
-  msg_pair->set_data(data);
-  msg = modulo_new_core::EncodedState();
-  modulo_new_core::translators::write_msg(msg, data, clock_->now());
-  msg_pair_interface->read<modulo_new_core::EncodedState, state_representation::State>(msg);
+  message_pair->set_data(data);
+  message = modulo_new_core::EncodedState();
+  modulo_new_core::translators::write_message(message, data, clock_->now());
+  message_pair_interface->read<modulo_new_core::EncodedState, state_representation::State>(message);
   EXPECT_TRUE(initial_value.data().isApprox(
-      std::dynamic_pointer_cast<state_representation::CartesianState>(msg_pair->get_data())->data()));
+      std::dynamic_pointer_cast<state_representation::CartesianState>(message_pair->get_data())->data()));
 }

--- a/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_publisher_handler.cpp
@@ -12,7 +12,7 @@ template<typename MsgT, typename DataT>
 static void test_publisher_interface(const std::shared_ptr<rclcpp::Node>& node, const DataT& value) {
   // create message pair
   auto data = std::make_shared<DataT>(value);
-  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, node->get_clock());
+  auto message_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, node->get_clock());
 
   // create publisher handler
   auto publisher = node->create_publisher<MsgT>("topic", 10);
@@ -22,10 +22,10 @@ static void test_publisher_interface(const std::shared_ptr<rclcpp::Node>& node, 
   // use in publisher interface
   std::shared_ptr<PublisherInterface> publisher_interface(publisher_handler);
   EXPECT_THROW(publisher_interface->publish(), modulo_new_core::exceptions::NullPointerException);
-  publisher_interface->set_message_pair(msg_pair);
+  publisher_interface->set_message_pair(message_pair);
   EXPECT_NO_THROW(publisher_interface->publish());
 
-  auto publisher_interface_ptr = publisher_handler->create_publisher_interface(msg_pair);
+  auto publisher_interface_ptr = publisher_handler->create_publisher_interface(message_pair);
   EXPECT_NO_THROW(publisher_interface->publish());
 }
 
@@ -59,7 +59,7 @@ TEST_F(PublisherTest, EncodedState) {
   // create message pair
   auto data =
       std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));
-  auto msg_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
+  auto message_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
       data, node->get_clock());
 
   // create publisher handler
@@ -72,9 +72,9 @@ TEST_F(PublisherTest, EncodedState) {
   // use in publisher interface
   std::shared_ptr<PublisherInterface> publisher_interface(publisher_handler);
   EXPECT_THROW(publisher_interface->publish(), modulo_new_core::exceptions::NullPointerException);
-  publisher_interface->set_message_pair(msg_pair);
+  publisher_interface->set_message_pair(message_pair);
   EXPECT_NO_THROW(publisher_interface->publish());
 
-  publisher_interface = publisher_handler->create_publisher_interface(msg_pair);
+  publisher_interface = publisher_handler->create_publisher_interface(message_pair);
   EXPECT_NO_THROW(publisher_interface->publish());
 }

--- a/source/modulo_new_core/test/cpp_tests/communication/test_subscription_handler.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_subscription_handler.cpp
@@ -11,10 +11,10 @@ template<typename MsgT, typename DataT>
 static void test_subscription_interface(const std::shared_ptr<rclcpp::Node>& node, const DataT& value) {
   // create message pair
   auto data = std::make_shared<DataT>(value);
-  auto msg_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, node->get_clock());
+  auto message_pair = std::make_shared<MessagePair<MsgT, DataT>>(data, node->get_clock());
 
   // create subscription handler
-  auto subscription_handler = std::make_shared<SubscriptionHandler<MsgT>>(msg_pair);
+  auto subscription_handler = std::make_shared<SubscriptionHandler<MsgT>>(message_pair);
   auto subscription = node->template create_subscription<MsgT>(
       "topic", 10, subscription_handler->get_callback());
 
@@ -52,11 +52,11 @@ TEST_F(SubscriptionTest, EncodedState) {
   // create message pair
   auto data =
       std::make_shared<state_representation::CartesianState>(state_representation::CartesianState::Random("test"));
-  auto msg_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
+  auto message_pair = std::make_shared<MessagePair<modulo_new_core::EncodedState, state_representation::State>>(
       data, node->get_clock());
 
   // create subscription handler
-  auto subscription_handler = std::make_shared<SubscriptionHandler<modulo_new_core::EncodedState>>(msg_pair);
+  auto subscription_handler = std::make_shared<SubscriptionHandler<modulo_new_core::EncodedState>>(message_pair);
   auto subscription = node->create_subscription<modulo_new_core::EncodedState>(
       "topic", 10, subscription_handler->get_callback());
 

--- a/source/modulo_new_core/test/cpp_tests/translators/test_messages.cpp
+++ b/source/modulo_new_core/test/cpp_tests/translators/test_messages.cpp
@@ -10,11 +10,11 @@ using namespace modulo_new_core::translators;
 
 template<typename MsgT, typename DataT>
 static void test_std_messages(const DataT& state, const rclcpp::Time& time) {
-  auto msg = MsgT();
-  write_msg(msg, state, time);
-  EXPECT_EQ(msg.data, state);
+  auto message = MsgT();
+  write_message(message, state, time);
+  EXPECT_EQ(message.data, state);
   DataT new_state;
-  read_msg(new_state, msg);
+  read_message(new_state, message);
   EXPECT_EQ(state, new_state);
 }
 
@@ -50,67 +50,67 @@ protected:
 
 TEST_F(MessageTranslatorsTest, TestAccel) {
   auto accel = geometry_msgs::msg::Accel();
-  write_msg(accel, state_, clock_.now());
+  write_message(accel, state_, clock_.now());
   expect_vector_equal(state_.get_linear_acceleration(), accel.linear);
   expect_vector_equal(state_.get_angular_acceleration(), accel.angular);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_msg(accel, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
-  read_msg(new_state, accel);
+  EXPECT_THROW(write_message(accel, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  read_message(new_state, accel);
   EXPECT_TRUE(new_state.get_acceleration().isApprox(state_.get_acceleration()));
 
   auto accel_stamped = geometry_msgs::msg::AccelStamped();
-  write_msg(accel_stamped, state_, clock_.now());
+  write_message(accel_stamped, state_, clock_.now());
   EXPECT_EQ(state_.get_reference_frame(), accel_stamped.header.frame_id);
   expect_vector_equal(state_.get_linear_acceleration(), accel_stamped.accel.linear);
   expect_vector_equal(state_.get_angular_acceleration(), accel_stamped.accel.angular);
   new_state = state_representation::CartesianState("new");
-  read_msg(new_state, accel_stamped);
+  read_message(new_state, accel_stamped);
   EXPECT_EQ(new_state.get_reference_frame(), state_.get_reference_frame());
   EXPECT_TRUE(new_state.get_acceleration().isApprox(state_.get_acceleration()));
 }
 
 TEST_F(MessageTranslatorsTest, TestPose) {
   auto pose = geometry_msgs::msg::Pose();
-  write_msg(pose, state_, clock_.now());
+  write_message(pose, state_, clock_.now());
   expect_point_equal(state_.get_position(), pose.position);
   expect_quaternion_equal(state_.get_orientation(), pose.orientation);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_msg(pose, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
-  read_msg(new_state, pose);
+  EXPECT_THROW(write_message(pose, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  read_message(new_state, pose);
   EXPECT_TRUE(new_state.get_pose().isApprox(state_.get_pose()));
 
   auto pose_stamped = geometry_msgs::msg::PoseStamped();
-  write_msg(pose_stamped, state_, clock_.now());
+  write_message(pose_stamped, state_, clock_.now());
   EXPECT_EQ(state_.get_reference_frame(), pose_stamped.header.frame_id);
   expect_point_equal(state_.get_position(), pose_stamped.pose.position);
   expect_quaternion_equal(state_.get_orientation(), pose_stamped.pose.orientation);
   new_state = state_representation::CartesianState("new");
-  read_msg(new_state, pose_stamped);
+  read_message(new_state, pose_stamped);
   EXPECT_EQ(new_state.get_reference_frame(), state_.get_reference_frame());
   EXPECT_TRUE(new_state.get_pose().isApprox(state_.get_pose()));
 }
 
 TEST_F(MessageTranslatorsTest, TestTransform) {
   auto tf = geometry_msgs::msg::Transform();
-  write_msg(tf, state_, clock_.now());
+  write_message(tf, state_, clock_.now());
   expect_vector_equal(state_.get_position(), tf.translation);
   expect_quaternion_equal(state_.get_orientation(), tf.rotation);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_msg(tf, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
-  read_msg(new_state, tf);
+  EXPECT_THROW(write_message(tf, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  read_message(new_state, tf);
   EXPECT_TRUE(new_state.get_pose().isApprox(state_.get_pose()));
 
   auto tf_stamped = geometry_msgs::msg::TransformStamped();
-  write_msg(tf_stamped, state_, clock_.now());
+  write_message(tf_stamped, state_, clock_.now());
   EXPECT_EQ(state_.get_name(), tf_stamped.child_frame_id);
   EXPECT_EQ(state_.get_reference_frame(), tf_stamped.header.frame_id);
   expect_vector_equal(state_.get_position(), tf_stamped.transform.translation);
   expect_quaternion_equal(state_.get_orientation(), tf_stamped.transform.rotation);
   new_state = state_representation::CartesianState("new");
-  read_msg(new_state, tf_stamped);
+  read_message(new_state, tf_stamped);
   EXPECT_EQ(new_state.get_name(), state_.get_name());
   EXPECT_EQ(new_state.get_reference_frame(), state_.get_reference_frame());
   EXPECT_TRUE(new_state.get_pose().isApprox(state_.get_pose()));
@@ -118,61 +118,61 @@ TEST_F(MessageTranslatorsTest, TestTransform) {
 
 TEST_F(MessageTranslatorsTest, TestTwist) {
   auto twist = geometry_msgs::msg::Twist();
-  write_msg(twist, state_, clock_.now());
+  write_message(twist, state_, clock_.now());
   expect_vector_equal(state_.get_linear_velocity(), twist.linear);
   expect_vector_equal(state_.get_angular_velocity(), twist.angular);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_msg(twist, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
-  read_msg(new_state, twist);
+  EXPECT_THROW(write_message(twist, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  read_message(new_state, twist);
   EXPECT_TRUE(new_state.get_twist().isApprox(state_.get_twist()));
 
   auto twist_stamped = geometry_msgs::msg::TwistStamped();
-  write_msg(twist_stamped, state_, clock_.now());
+  write_message(twist_stamped, state_, clock_.now());
   EXPECT_EQ(state_.get_reference_frame(), twist_stamped.header.frame_id);
   expect_vector_equal(state_.get_linear_velocity(), twist_stamped.twist.linear);
   expect_vector_equal(state_.get_angular_velocity(), twist_stamped.twist.angular);
   new_state = state_representation::CartesianState("new");
-  read_msg(new_state, twist_stamped);
+  read_message(new_state, twist_stamped);
   EXPECT_EQ(new_state.get_reference_frame(), state_.get_reference_frame());
   EXPECT_TRUE(new_state.get_twist().isApprox(state_.get_twist()));
 }
 
 TEST_F(MessageTranslatorsTest, TestWrench) {
   auto wrench = geometry_msgs::msg::Wrench();
-  write_msg(wrench, state_, clock_.now());
+  write_message(wrench, state_, clock_.now());
   expect_vector_equal(state_.get_force(), wrench.force);
   expect_vector_equal(state_.get_torque(), wrench.torque);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_msg(wrench, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
-  read_msg(new_state, wrench);
+  EXPECT_THROW(write_message(wrench, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  read_message(new_state, wrench);
   EXPECT_TRUE(new_state.get_wrench().isApprox(state_.get_wrench()));
 
   auto wrench_stamped = geometry_msgs::msg::WrenchStamped();
-  write_msg(wrench_stamped, state_, clock_.now());
+  write_message(wrench_stamped, state_, clock_.now());
   EXPECT_EQ(state_.get_reference_frame(), wrench_stamped.header.frame_id);
   expect_vector_equal(state_.get_force(), wrench_stamped.wrench.force);
   expect_vector_equal(state_.get_torque(), wrench_stamped.wrench.torque);
   new_state = state_representation::CartesianState("new");
-  read_msg(new_state, wrench_stamped);
+  read_message(new_state, wrench_stamped);
   EXPECT_EQ(new_state.get_reference_frame(), state_.get_reference_frame());
   EXPECT_TRUE(new_state.get_wrench().isApprox(state_.get_wrench()));
 }
 
 TEST_F(MessageTranslatorsTest, TestJointState) {
-  auto msg = sensor_msgs::msg::JointState();
-  write_msg(msg, joint_state_, clock_.now());
+  auto message = sensor_msgs::msg::JointState();
+  write_message(message, joint_state_, clock_.now());
   for (unsigned int i = 0; i < joint_state_.get_size(); ++i) {
-    EXPECT_EQ(msg.name.at(i), joint_state_.get_names().at(i));
-    EXPECT_NEAR(msg.position.at(i), joint_state_.get_position(i), 1e-5);
-    EXPECT_NEAR(msg.velocity.at(i), joint_state_.get_velocity(i), 1e-5);
-    EXPECT_NEAR(msg.effort.at(i), joint_state_.get_torque(i), 1e-5);
+    EXPECT_EQ(message.name.at(i), joint_state_.get_names().at(i));
+    EXPECT_NEAR(message.position.at(i), joint_state_.get_position(i), 1e-5);
+    EXPECT_NEAR(message.velocity.at(i), joint_state_.get_velocity(i), 1e-5);
+    EXPECT_NEAR(message.effort.at(i), joint_state_.get_torque(i), 1e-5);
   }
 
   auto new_state = state_representation::JointState("test", {"1", "2", "3"});
-  EXPECT_THROW(write_msg(msg, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
-  read_msg(new_state, msg);
+  EXPECT_THROW(write_message(message, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  read_message(new_state, message);
   EXPECT_TRUE(new_state.get_positions().isApprox(joint_state_.get_positions()));
   EXPECT_TRUE(new_state.get_velocities().isApprox(joint_state_.get_velocities()));
   EXPECT_TRUE(new_state.get_torques().isApprox(joint_state_.get_torques()));
@@ -187,22 +187,22 @@ TEST_F(MessageTranslatorsTest, TestStdMsgs) {
   test_std_messages<std_msgs::msg::Int32, int>(2, clock_.now());
   test_std_messages<std_msgs::msg::String, std::string>("test", clock_.now());
 
-  auto msg = std_msgs::msg::Float64MultiArray();
+  auto message = std_msgs::msg::Float64MultiArray();
   std::vector<double> state = {0.3, 0.6};
-  write_msg(msg, state, clock_.now());
+  write_message(message, state, clock_.now());
   std::vector<double> new_state;
-  read_msg(new_state, msg);
+  read_message(new_state, message);
   for (std::size_t i = 0; i < state.size(); ++i) {
-    EXPECT_EQ(msg.data.at(i), state.at(i));
+    EXPECT_EQ(message.data.at(i), state.at(i));
     EXPECT_EQ(state.at(i), new_state.at(i));
   }
 }
 
 TEST_F(MessageTranslatorsTest, TestEncodedState) {
-  auto msg = modulo_new_core::EncodedState();
-  write_msg(msg, state_, clock_.now());
+  auto message = modulo_new_core::EncodedState();
+  write_message(message, state_, clock_.now());
   state_representation::CartesianState new_state;
-  read_msg(new_state, msg);
+  read_message(new_state, message);
   EXPECT_TRUE(state_.data().isApprox(new_state.data()));
   EXPECT_EQ(state_.get_name(), new_state.get_name());
   EXPECT_EQ(state_.get_reference_frame(), new_state.get_reference_frame());
@@ -210,10 +210,10 @@ TEST_F(MessageTranslatorsTest, TestEncodedState) {
 
 TEST_F(MessageTranslatorsTest, TestEncodedStatePointer) {
   auto state_ptr = state_representation::make_shared_state(state_);
-  auto msg = modulo_new_core::EncodedState();
-  write_msg(msg, state_ptr, clock_.now());
+  auto message = modulo_new_core::EncodedState();
+  write_message(message, state_ptr, clock_.now());
   auto new_state_ptr = state_representation::make_shared_state(state_representation::CartesianState());
-  read_msg(new_state_ptr, msg);
+  read_message(new_state_ptr, message);
   auto new_state = *std::dynamic_pointer_cast<state_representation::CartesianState>(new_state_ptr);
   EXPECT_TRUE(state_.data().isApprox(new_state.data()));
   EXPECT_EQ(state_.get_name(), new_state.get_name());

--- a/source/modulo_new_core/test/python_tests/translators/test_messages.py
+++ b/source/modulo_new_core/test/python_tests/translators/test_messages.py
@@ -10,12 +10,12 @@ import modulo_new_core.translators.message_readers as modulo_readers
 import modulo_new_core.translators.message_writers as modulo_writers
 
 
-def read_xyz(msg):
-    return [msg.x, msg.y, msg.z]
+def read_xyz(message):
+    return [message.x, message.y, message.z]
 
 
-def read_quaternion(msg):
-    return [msg.w, msg.x, msg.y, msg.z]
+def read_quaternion(message):
+    return [message.w, message.x, message.y, message.z]
 
 
 def assert_np_array_equal(a: np.array, b: np.array, places=3):
@@ -26,135 +26,135 @@ def assert_np_array_equal(a: np.array, b: np.array, places=3):
 
 
 def test_accel(cart_state: sr.CartesianState, clock: Clock):
-    msg = geometry_msgs.msg.Accel()
-    modulo_writers.write_msg(msg, cart_state)
-    assert_np_array_equal(read_xyz(msg.linear), cart_state.get_linear_acceleration())
-    assert_np_array_equal(read_xyz(msg.angular), cart_state.get_angular_acceleration())
+    message = geometry_msgs.msg.Accel()
+    modulo_writers.write_message(message, cart_state)
+    assert_np_array_equal(read_xyz(message.linear), cart_state.get_linear_acceleration())
+    assert_np_array_equal(read_xyz(message.angular), cart_state.get_angular_acceleration())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
-        modulo_writers.write_msg(new_state, msg)
-    modulo_readers.read_msg(new_state, msg)
+        modulo_writers.write_message(new_state, message)
+    modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_acceleration(), new_state.get_acceleration())
 
-    msg_stamped = geometry_msgs.msg.AccelStamped()
-    modulo_writers.write_stamped_msg(msg_stamped, cart_state, clock.now())
-    assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
-    assert_np_array_equal(read_xyz(msg.linear), cart_state.get_linear_acceleration())
-    assert_np_array_equal(read_xyz(msg.angular), cart_state.get_angular_acceleration())
+    message_stamped = geometry_msgs.msg.AccelStamped()
+    modulo_writers.write_stamped_message(message_stamped, cart_state, clock.now())
+    assert message_stamped.header.frame_id == cart_state.get_reference_frame()
+    assert_np_array_equal(read_xyz(message.linear), cart_state.get_linear_acceleration())
+    assert_np_array_equal(read_xyz(message.angular), cart_state.get_angular_acceleration())
     new_state = sr.CartesianState("new")
-    modulo_readers.read_stamped_msg(new_state, msg_stamped)
+    modulo_readers.read_stamped_message(new_state, message_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()
     assert_np_array_equal(cart_state.get_acceleration(), new_state.get_acceleration())
 
 
 def test_pose(cart_state: sr.CartesianState, clock: Clock):
-    msg = geometry_msgs.msg.Pose()
-    modulo_writers.write_msg(msg, cart_state)
-    assert_np_array_equal(read_xyz(msg.position), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.orientation), cart_state.get_orientation_coefficients())
+    message = geometry_msgs.msg.Pose()
+    modulo_writers.write_message(message, cart_state)
+    assert_np_array_equal(read_xyz(message.position), cart_state.get_position())
+    assert_np_array_equal(read_quaternion(message.orientation), cart_state.get_orientation_coefficients())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
-        modulo_writers.write_msg(new_state, msg)
-    modulo_readers.read_msg(new_state, msg)
+        modulo_writers.write_message(new_state, message)
+    modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_pose(), new_state.get_pose())
 
-    msg_stamped = geometry_msgs.msg.PoseStamped()
-    modulo_writers.write_stamped_msg(msg_stamped, cart_state, clock.now())
-    assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
-    assert_np_array_equal(read_xyz(msg.position), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.orientation), cart_state.get_orientation_coefficients())
+    message_stamped = geometry_msgs.msg.PoseStamped()
+    modulo_writers.write_stamped_message(message_stamped, cart_state, clock.now())
+    assert message_stamped.header.frame_id == cart_state.get_reference_frame()
+    assert_np_array_equal(read_xyz(message.position), cart_state.get_position())
+    assert_np_array_equal(read_quaternion(message.orientation), cart_state.get_orientation_coefficients())
     new_state = sr.CartesianState("new")
-    modulo_readers.read_stamped_msg(new_state, msg_stamped)
+    modulo_readers.read_stamped_message(new_state, message_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()
     assert_np_array_equal(cart_state.get_pose(), new_state.get_pose())
 
 
 def test_transform(cart_state: sr.CartesianState, clock: Clock):
-    msg = geometry_msgs.msg.Transform()
-    modulo_writers.write_msg(msg, cart_state)
-    assert_np_array_equal(read_xyz(msg.translation), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.rotation), cart_state.get_orientation_coefficients())
+    message = geometry_msgs.msg.Transform()
+    modulo_writers.write_message(message, cart_state)
+    assert_np_array_equal(read_xyz(message.translation), cart_state.get_position())
+    assert_np_array_equal(read_quaternion(message.rotation), cart_state.get_orientation_coefficients())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
-        modulo_writers.write_msg(new_state, msg)
-    modulo_readers.read_msg(new_state, msg)
+        modulo_writers.write_message(new_state, message)
+    modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_pose(), new_state.get_pose())
 
-    msg_stamped = geometry_msgs.msg.TransformStamped()
-    modulo_writers.write_stamped_msg(msg_stamped, cart_state, clock.now())
-    assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
-    assert msg_stamped.child_frame_id == cart_state.get_name()
-    assert_np_array_equal(read_xyz(msg.translation), cart_state.get_position())
-    assert_np_array_equal(read_quaternion(msg.rotation), cart_state.get_orientation_coefficients())
+    message_stamped = geometry_msgs.msg.TransformStamped()
+    modulo_writers.write_stamped_message(message_stamped, cart_state, clock.now())
+    assert message_stamped.header.frame_id == cart_state.get_reference_frame()
+    assert message_stamped.child_frame_id == cart_state.get_name()
+    assert_np_array_equal(read_xyz(message.translation), cart_state.get_position())
+    assert_np_array_equal(read_quaternion(message.rotation), cart_state.get_orientation_coefficients())
     new_state = sr.CartesianState("new")
-    modulo_readers.read_stamped_msg(new_state, msg_stamped)
+    modulo_readers.read_stamped_message(new_state, message_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()
     assert cart_state.get_name() == new_state.get_name()
     assert_np_array_equal(cart_state.get_pose(), new_state.get_pose())
 
 
 def test_twist(cart_state: sr.CartesianState, clock: Clock):
-    msg = geometry_msgs.msg.Twist()
-    modulo_writers.write_msg(msg, cart_state)
-    assert_np_array_equal(read_xyz(msg.linear), cart_state.get_linear_velocity())
-    assert_np_array_equal(read_xyz(msg.angular), cart_state.get_angular_velocity())
+    message = geometry_msgs.msg.Twist()
+    modulo_writers.write_message(message, cart_state)
+    assert_np_array_equal(read_xyz(message.linear), cart_state.get_linear_velocity())
+    assert_np_array_equal(read_xyz(message.angular), cart_state.get_angular_velocity())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
-        modulo_writers.write_msg(new_state, msg)
-    modulo_readers.read_msg(new_state, msg)
+        modulo_writers.write_message(new_state, message)
+    modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_twist(), new_state.get_twist())
 
-    msg_stamped = geometry_msgs.msg.TwistStamped()
-    modulo_writers.write_stamped_msg(msg_stamped, cart_state, clock.now())
-    assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
-    assert_np_array_equal(read_xyz(msg.linear), cart_state.get_linear_velocity())
-    assert_np_array_equal(read_xyz(msg.angular), cart_state.get_angular_velocity())
+    message_stamped = geometry_msgs.msg.TwistStamped()
+    modulo_writers.write_stamped_message(message_stamped, cart_state, clock.now())
+    assert message_stamped.header.frame_id == cart_state.get_reference_frame()
+    assert_np_array_equal(read_xyz(message.linear), cart_state.get_linear_velocity())
+    assert_np_array_equal(read_xyz(message.angular), cart_state.get_angular_velocity())
     new_state = sr.CartesianState("new")
-    modulo_readers.read_stamped_msg(new_state, msg_stamped)
+    modulo_readers.read_stamped_message(new_state, message_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()
     assert_np_array_equal(cart_state.get_twist(), new_state.get_twist())
 
 
 def test_wrench(cart_state: sr.CartesianState, clock: Clock):
-    msg = geometry_msgs.msg.Wrench()
-    modulo_writers.write_msg(msg, cart_state)
-    assert_np_array_equal(read_xyz(msg.force), cart_state.get_force())
-    assert_np_array_equal(read_xyz(msg.torque), cart_state.get_torque())
+    message = geometry_msgs.msg.Wrench()
+    modulo_writers.write_message(message, cart_state)
+    assert_np_array_equal(read_xyz(message.force), cart_state.get_force())
+    assert_np_array_equal(read_xyz(message.torque), cart_state.get_torque())
 
     new_state = sr.CartesianState("new")
     with pytest.raises(RuntimeError):
-        modulo_writers.write_msg(new_state, msg)
-    modulo_readers.read_msg(new_state, msg)
+        modulo_writers.write_message(new_state, message)
+    modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_wrench(), new_state.get_wrench())
 
-    msg_stamped = geometry_msgs.msg.WrenchStamped()
-    modulo_writers.write_stamped_msg(msg_stamped, cart_state, clock.now())
-    assert msg_stamped.header.frame_id == cart_state.get_reference_frame()
-    assert_np_array_equal(read_xyz(msg.force), cart_state.get_force())
-    assert_np_array_equal(read_xyz(msg.torque), cart_state.get_torque())
+    message_stamped = geometry_msgs.msg.WrenchStamped()
+    modulo_writers.write_stamped_message(message_stamped, cart_state, clock.now())
+    assert message_stamped.header.frame_id == cart_state.get_reference_frame()
+    assert_np_array_equal(read_xyz(message.force), cart_state.get_force())
+    assert_np_array_equal(read_xyz(message.torque), cart_state.get_torque())
     new_state = sr.CartesianState("new")
-    modulo_readers.read_stamped_msg(new_state, msg_stamped)
+    modulo_readers.read_stamped_message(new_state, message_stamped)
     assert cart_state.get_reference_frame() == new_state.get_reference_frame()
     assert_np_array_equal(cart_state.get_wrench(), new_state.get_wrench())
 
 
 def test_joint_state(joint_state: sr.JointState):
-    msg = sensor_msgs.msg.JointState()
-    modulo_writers.write_msg(msg, joint_state)
+    message = sensor_msgs.msg.JointState()
+    modulo_writers.write_message(message, joint_state)
     for i in range(joint_state.get_size()):
-        assert msg.name[i] == joint_state.get_names()[i]
-    assert_np_array_equal(msg.position, joint_state.get_positions())
-    assert_np_array_equal(msg.velocity, joint_state.get_velocities())
-    assert_np_array_equal(msg.effort, joint_state.get_torques())
+        assert message.name[i] == joint_state.get_names()[i]
+    assert_np_array_equal(message.position, joint_state.get_positions())
+    assert_np_array_equal(message.velocity, joint_state.get_velocities())
+    assert_np_array_equal(message.effort, joint_state.get_torques())
 
     new_state = sr.JointState("test", ["1", "2", "3"])
     with pytest.raises(RuntimeError):
-        modulo_writers.write_msg(new_state, msg)
-    modulo_readers.read_msg(new_state, msg)
+        modulo_writers.write_message(new_state, message)
+    modulo_readers.read_message(new_state, message)
     for i in range(joint_state.get_size()):
         assert new_state.get_names()[i] == joint_state.get_names()[i]
     assert_np_array_equal(new_state.get_positions(), joint_state.get_positions())
@@ -163,9 +163,9 @@ def test_joint_state(joint_state: sr.JointState):
 
 
 def test_encoded_state(cart_state: sr.CartesianState):
-    msg = modulo_writers.write_clproto_msg(cart_state, clproto.MessageType.CARTESIAN_STATE_MESSAGE)
+    message = modulo_writers.write_clproto_message(cart_state, clproto.MessageType.CARTESIAN_STATE_MESSAGE)
 
-    new_state = modulo_readers.read_clproto_msg(msg)
+    new_state = modulo_readers.read_clproto_message(message)
     assert_np_array_equal(new_state.data(), cart_state.data())
     assert new_state.get_name() == cart_state.get_name()
     assert new_state.get_reference_frame() == cart_state.get_reference_frame()


### PR DESCRIPTION
Looks like a big change but I just refactored all the occurrences of 'msg' to 'message' because I like it better. Will take an executive decision and merge without review if the tests pass as there was nothing changed with the logic of the code