### PR TITLE
Fix MessagePair to enable creating from any SR type

### DIFF
--- a/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
+++ b/source/modulo_new_core/include/modulo_new_core/communication/MessagePair.hpp
@@ -106,7 +106,41 @@ inline void MessagePair<MsgT, DataT>::set_data(const std::shared_ptr<DataT>& dat
 }
 
 template<typename DataT>
-std::shared_ptr<MessagePairInterface>
-make_shared_message_pair(const std::shared_ptr<DataT>& data, const std::shared_ptr<rclcpp::Clock>& clock);
+inline std::shared_ptr<MessagePairInterface>
+make_shared_message_pair(const std::shared_ptr<DataT>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
+  return std::make_shared<MessagePair<EncodedState, state_representation::State>>(
+      std::dynamic_pointer_cast<state_representation::State>(data), clock
+  );
+}
 
+template<>
+inline std::shared_ptr<MessagePairInterface>
+make_shared_message_pair(const std::shared_ptr<bool>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
+  return std::make_shared<MessagePair<std_msgs::msg::Bool, bool>>(data, clock);
+}
+
+template<>
+inline std::shared_ptr<MessagePairInterface>
+make_shared_message_pair(const std::shared_ptr<double>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
+  return std::make_shared<MessagePair<std_msgs::msg::Float64, double>>(data, clock);
+}
+
+template<>
+inline std::shared_ptr<MessagePairInterface> make_shared_message_pair(
+    const std::shared_ptr<std::vector<double>>& data, const std::shared_ptr<rclcpp::Clock>& clock
+) {
+  return std::make_shared<MessagePair<std_msgs::msg::Float64MultiArray, std::vector<double>>>(data, clock);
+}
+
+template<>
+inline std::shared_ptr<MessagePairInterface>
+make_shared_message_pair(const std::shared_ptr<int>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
+  return std::make_shared<MessagePair<std_msgs::msg::Int32, int>>(data, clock);
+}
+
+template<>
+inline std::shared_ptr<MessagePairInterface>
+make_shared_message_pair(const std::shared_ptr<std::string>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
+  return std::make_shared<MessagePair<std_msgs::msg::String, std::string>>(data, clock);
+}
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/src/communication/MessagePair.cpp
+++ b/source/modulo_new_core/src/communication/MessagePair.cpp
@@ -40,41 +40,4 @@ MessagePair<EncodedState, state_representation::State>::MessagePair(
 ) :
     MessagePairInterface(MessageType::ENCODED_STATE), data_(std::move(data)), clock_(std::move(clock)) {}
 
-template<>
-std::shared_ptr<MessagePairInterface>
-make_shared_message_pair(const std::shared_ptr<bool>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
-  return std::make_shared<MessagePair<std_msgs::msg::Bool, bool>>(data, clock);
-}
-
-template<>
-std::shared_ptr<MessagePairInterface>
-make_shared_message_pair(const std::shared_ptr<double>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
-  return std::make_shared<MessagePair<std_msgs::msg::Float64, double>>(data, clock);
-}
-
-template<>
-std::shared_ptr<MessagePairInterface> make_shared_message_pair(
-    const std::shared_ptr<std::vector<double>>& data, const std::shared_ptr<rclcpp::Clock>& clock
-) {
-  return std::make_shared<MessagePair<std_msgs::msg::Float64MultiArray, std::vector<double>>>(data, clock);
-}
-
-template<>
-std::shared_ptr<MessagePairInterface>
-make_shared_message_pair(const std::shared_ptr<int>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
-  return std::make_shared<MessagePair<std_msgs::msg::Int32, int>>(data, clock);
-}
-
-template<>
-std::shared_ptr<MessagePairInterface>
-make_shared_message_pair(const std::shared_ptr<std::string>& data, const std::shared_ptr<rclcpp::Clock>& clock) {
-  return std::make_shared<MessagePair<std_msgs::msg::String, std::string>>(data, clock);
-}
-
-template<>
-std::shared_ptr<MessagePairInterface> make_shared_message_pair(
-    const std::shared_ptr<state_representation::State>& data, const std::shared_ptr<rclcpp::Clock>& clock
-) {
-  return std::make_shared<MessagePair<EncodedState, state_representation::State>>(data, clock);
-}
 }// namespace modulo_new_core::communication

--- a/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
+++ b/source/modulo_new_core/test/cpp_tests/communication/test_communication.cpp
@@ -112,11 +112,9 @@ TEST_F(CommunicationTest, BasicTypes) {
 TEST_F(CommunicationTest, EncodedState) {
   using namespace state_representation;
   auto pub_state = std::make_shared<CartesianState>(CartesianState::Random("this", "world"));
-  std::shared_ptr<State> pub_data = pub_state;
-  auto pub_message = make_shared_message_pair(pub_data, this->clock_);
+  auto pub_message = make_shared_message_pair(pub_state, this->clock_);
   auto sub_state = std::make_shared<CartesianState>(CartesianState::Identity("that", "base"));
-  std::shared_ptr<State> sub_data = sub_state;
-  auto sub_message = make_shared_message_pair(sub_data, this->clock_);
+  auto sub_message = make_shared_message_pair(sub_state, this->clock_);
   this->add_nodes<modulo_new_core::EncodedState>("/test_topic", pub_message, sub_message);
   this->exec_->template spin_until_future_complete(
       std::dynamic_pointer_cast<MinimalSubscriber<modulo_new_core::EncodedState>>(this->sub_node_)->received_future,
@@ -125,6 +123,5 @@ TEST_F(CommunicationTest, EncodedState) {
 
   EXPECT_EQ(pub_state->get_name(), sub_state->get_name());
   EXPECT_EQ(pub_state->get_reference_frame(), sub_state->get_reference_frame());
-  EXPECT_TRUE(std::dynamic_pointer_cast<CartesianState>(pub_data)->data().isApprox(
-      std::dynamic_pointer_cast<CartesianState>(sub_data)->data()));
+  EXPECT_TRUE(pub_state->data().isApprox(sub_state->data()));
 }


### PR DESCRIPTION
There was a rather big issue in the current MessagePair implementation: Due to the fact that all 6 `make_shared_message_pair<MsgT, Data>` were specialized in the source file, it was not possible to create message pairs with
```
make_shared_message_pair<state_representation::State, EncodedState>(std::shared_ptr<CartesianTwist> data)
```
(i.e. you could only make a pair if the input data pointer was also a `State` and not one of its derived classes). This is fixed now by keeping one `make_shared_message_pair` templated (props to @buschbapti the templating guru).

Note that without the `inline` keywords in the header, this solution wouldn't work (just for future reference, the `inline` keyword can actually be really important)