### PR TITLE
Add inputs and outputs to python component interface

### DIFF
--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -87,11 +87,10 @@ inline void Component::add_output(
 ) {
   using namespace modulo_new_core::communication;
   try {
-    std::string parsed_signal_name = utilities::parse_signal_name(signal_name);
-    this->create_output(parsed_signal_name, data, fixed_topic, default_topic);
+    auto parsed_signal_name = this->create_output(signal_name, data, fixed_topic, default_topic);
     auto topic_name = this->get_parameter_value<std::string>(parsed_signal_name + "_topic");
     RCLCPP_DEBUG_STREAM(this->get_logger(),
-                        "Adding output '" << signal_name << "' with topic name '" << topic_name << "'.");
+                        "Adding output '" << parsed_signal_name << "' with topic name '" << topic_name << "'.");
     auto message_pair = this->outputs_.at(parsed_signal_name)->get_message_pair();
     switch (message_pair->get_type()) {
       case MessageType::BOOL: {
@@ -146,6 +145,7 @@ inline void Component::add_output(
       }
     }
   } catch (const std::exception& ex) {
+    // TODO if modulo::communication had a base exception, could catch that
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
   }
 }

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -180,6 +180,8 @@ protected:
    * @param fixed_topic If true, the topic name of the input signal is fixed
    * @param default_topic If set, the default value for the topic name to use
    */
+   // TODO could be nice to add an optional callback here that would be executed from within the subscription callback
+   // in order to manipulate the data pointer upon reception of a message
   template<typename DataT>
   void add_input(
       const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false,

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -227,9 +227,9 @@ protected:
    * @throws AddSignalException if the output could not be created (empty name, already registered)
    */
   template<typename DataT>
-  void create_output(
-      const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic = false,
-      const std::string& default_topic = ""
+  std::string create_output(
+      const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic,
+      const std::string& default_topic
   );
 
   /**
@@ -777,24 +777,38 @@ inline void ComponentInterface<NodeT>::evaluate_periodic_callbacks() {
 
 template<class NodeT>
 template<typename DataT>
-inline void ComponentInterface<NodeT>::create_output(
+inline std::string ComponentInterface<NodeT>::create_output(
     const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic,
     const std::string& default_topic
 ) {
   using namespace modulo_new_core::communication;
-  if (signal_name.empty()) {
-    throw exceptions::AddSignalException("Failed to add output: Provide a non empty string as a name.");
+  try {
+    auto parsed_signal_name = utilities::parse_signal_name(signal_name);
+    if (parsed_signal_name.empty()) {
+      throw exceptions::AddSignalException(
+          "The parsed signal name for signal '" + signal_name
+              + "'is empty. Provide a string with valid characters for the signal name ([a-zA-Z0-9_])."
+      );
+    }
+    RCLCPP_DEBUG_STREAM(this->get_logger(),
+                        "Creating output '" << parsed_signal_name << "' (provided signal name was '" << signal_name
+                                            << "'.");
+    if (this->outputs_.find(parsed_signal_name) != this->outputs_.end()) {
+      throw exceptions::AddSignalException("Output with name '" + signal_name + "' already exists.");
+    }
+    auto message_pair = make_shared_message_pair(data, this->get_clock());
+    this->outputs_.insert_or_assign(
+        parsed_signal_name, std::make_shared<PublisherInterface>(this->publisher_type_, message_pair));
+    std::string topic_name = default_topic.empty() ? "~/" + parsed_signal_name : default_topic;
+    this->add_parameter(
+        parsed_signal_name + "_topic", topic_name, "Output topic name of signal '" + parsed_signal_name + "'",
+        fixed_topic
+    );
+    return parsed_signal_name;
+  } catch (const std::exception& ex) {
+    // TODO if modulo::communication had a base exception, could catch that
+    throw exceptions::AddSignalException(std::string(ex.what()));
   }
-  if (this->outputs_.find(signal_name) != this->outputs_.end()) {
-    throw exceptions::AddSignalException("Output with name '" + signal_name + "' already exists");
-  }
-  auto message_pair = make_shared_message_pair(data, this->get_clock());
-  this->outputs_.insert_or_assign(
-      signal_name, std::make_shared<PublisherInterface>(this->publisher_type_, message_pair));
-  std::string topic_name = default_topic.empty() ? "~/" + signal_name : default_topic;
-  this->add_parameter(
-      signal_name + "_topic", topic_name, "Output topic name of signal '" + signal_name + "'", fixed_topic
-  );
 }
 
 template<class NodeT>

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -224,7 +224,9 @@ protected:
    * @param signal_name Name of the output signal
    * @param data Data to transmit on the output signal
    * @param fixed_topic If true, the topic name of the output signal is fixed
+   * @param default_topic If set, the default value for the topic name to use
    * @throws AddSignalException if the output could not be created (empty name, already registered)
+   * @return The parsed signal name
    */
   template<typename DataT>
   std::string create_output(

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -258,9 +258,9 @@ inline void LifecycleComponent::add_output(
     const std::string& default_topic
 ) {
   try {
-    std::string parsed_signal_name = utilities::parse_signal_name(signal_name);
-    this->create_output(parsed_signal_name, data, fixed_topic, default_topic);
+    this->create_output(signal_name, data, fixed_topic, default_topic);
   } catch (const std::exception& ex) {
+    // TODO if modulo::communication had a base exception, could catch that
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
   }
 }

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -4,7 +4,6 @@ from typing import TypeVar
 import clproto
 from modulo_components.component_interface import ComponentInterface
 
-DataT = TypeVar('DataT')
 MsgT = TypeVar('MsgT')
 
 
@@ -87,13 +86,13 @@ class Component(ComponentInterface):
         """
         self.set_predicate("in_error_state", True)
 
-    def add_output(self, signal_name: str, data: DataT, message_type: MsgT,
+    def add_output(self, signal_name: str, data: str, message_type: MsgT,
                    clproto_message_type=clproto.MessageType.UNKNOWN_MESSAGE, fixed_topic=False, default_topic=""):
         """
         Add and configure an output signal of the component.
 
         :param signal_name: Name of the output signal
-        :param data: Data to transmit on the output signal
+        :param data: Name of the attribute to transmit over the channel
         :param message_type: The ROS message type of the output
         :param clproto_message_type: The clproto message type, if applicable
         :param fixed_topic: If true, the topic name of the output signal is fixed

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -1,6 +1,11 @@
 from threading import Thread
+from typing import TypeVar
 
+import clproto
 from modulo_components.component_interface import ComponentInterface
+
+DataT = TypeVar('DataT')
+MsgT = TypeVar('MsgT')
 
 
 class Component(ComponentInterface):
@@ -73,3 +78,32 @@ class Component(ComponentInterface):
         :return: True, if the execution was successful, false otherwise
         """
         return True
+
+    def _raise_error(self):
+        """
+        Put the component in error state by setting the 'in_error_state'
+        predicate to true.
+        """
+        self.set_predicate("in_error_state", True)
+
+    def add_output(self, signal_name: str, data: DataT, message_type: MsgT,
+                   clproto_message_type=clproto.MessageType.UNKNOWN_MESSAGE, fixed_topic=False, default_topic=""):
+        """
+        Add and configure an output signal of the component.
+
+        :param signal_name: Name of the output signal
+        :param data: Data to transmit on the output signal
+        :param message_type: The ROS message type of the output
+        :param clproto_message_type: The clproto message type, if applicable
+        :param fixed_topic: If true, the topic name of the output signal is fixed
+        :param default_topic: If set, the default value for the topic name to use
+        """
+        try:
+            parsed_signal_name = self._create_output(signal_name, data, message_type, clproto_message_type, fixed_topic,
+                                                     default_topic)
+            topic_name = self.get_parameter_value(parsed_signal_name + "_topic")
+            self.get_logger().debug(f"Adding output '{parsed_signal_name}' with topic name '{topic_name}'.")
+            publisher = self.create_publisher(message_type, topic_name, self._qos)
+            self._outputs[parsed_signal_name]["publisher"] = publisher
+        except Exception as e:
+            self.get_logger().error(f"Failed to add output '{signal_name}: {e}")

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -40,6 +40,7 @@ class Component(ComponentInterface):
         try:
             # TODO catch here or in helpers...? (or re raise with ComponentError)
             self._publish_predicates()
+            self._publish_outputs()
             self._evaluate_periodic_callbacks()
         except Exception as e:
             self.get_logger().error(f"Failed to execute step function: {e}", throttle_duration_sec=1.0)

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -28,7 +28,6 @@ from tf2_ros import TransformBroadcaster
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
-DataT = TypeVar('DataT')
 MsgT = TypeVar('MsgT')
 T = TypeVar('T')
 
@@ -285,13 +284,13 @@ class ComponentInterface(Node):
             return
         self._predicates[name] = value
 
-    def _create_output(self, signal_name: str, data: DataT, message_type: MsgT,
+    def _create_output(self, signal_name: str, data: str, message_type: MsgT,
                        clproto_message_type: clproto.MessageType, fixed_topic: bool, default_topic: str) -> str:
         """
         Helper function to parse the signal name and add an output without Publisher to the dict of outputs.
 
         :param signal_name: Name of the output signal
-        :param data: Data to transmit on the output signal
+        :param data: Name of the attribute to transmit over the channel
         :param message_type: The ROS message type of the output
         :param clproto_message_type: The clproto message type, if applicable
         :param fixed_topic: If true, the topic name of the output signal is fixed
@@ -341,6 +340,8 @@ class ComponentInterface(Node):
 
     def add_input(self, signal_name: str, subscription: Union[str, Callable], message_type: MsgT, fixed_topic=False,
                   default_topic=""):
+        # TODO could be nice to add an optional callback here that would be executed from within the subscription
+        #  callback in order to manipulate the data pointer upon reception of a message
         """
         Add and configure an input signal of the component.
 

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -1,12 +1,18 @@
 import sys
+from functools import partial
 from typing import Callable, Dict, List, Optional, TypeVar, Union
 
+import clproto
+import modulo_new_core.translators.message_readers as modulo_readers
+import modulo_new_core.translators.message_writers as modulo_writers
 import rclpy
 import state_representation as sr
 import tf2_py
 from geometry_msgs.msg import TransformStamped
-from modulo_components.exceptions.component_exceptions import ComponentParameterError, LookupTransformError
-from modulo_components.utilities.utilities import generate_predicate_topic
+from modulo_components.exceptions.component_exceptions import AddSignalError, ComponentParameterError, \
+    LookupTransformError
+from modulo_components.utilities.utilities import generate_predicate_topic, parse_signal_name
+from modulo_new_core.encoded_state import EncodedState
 from modulo_new_core.translators.message_readers import read_stamped_message
 from modulo_new_core.translators.message_writers import write_stamped_message
 from modulo_new_core.translators.parameter_translators import write_parameter, read_parameter_const
@@ -17,11 +23,13 @@ from rclpy.node import Node
 from rclpy.publisher import Publisher
 from rclpy.qos import QoSProfile
 from rclpy.time import Time
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, Int32, Float64, Float64MultiArray, String
 from tf2_ros import TransformBroadcaster
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
+DataT = TypeVar('DataT')
+MsgT = TypeVar('MsgT')
 T = TypeVar('T')
 
 
@@ -37,6 +45,8 @@ class ComponentInterface(Node):
         parameter_dict (dict(Publisher)): dict of parameters
         periodic_callbacks (dict(Callable): dict of periodic callback functions
         qos (rclpy.qos.QoSProfile: the Quality of Service for publishers and subscribers
+        inputs: dict of inputs
+        outputs: dict of output
         tf_buffer (tf2_ros.Buffer): the buffer to lookup transforms published on tf2.
         tf_listener (tf2_ros.TransformListener): the listener to lookup transforms published on tf2.
         tf_broadcaster (tf2_ros.TransformBroadcaster): the broadcaster to publish transforms on tf2
@@ -55,6 +65,8 @@ class ComponentInterface(Node):
         self._predicates: Dict[str, Union[bool, Callable[[], bool]]] = {}
         self._predicate_publishers: Dict[str, Publisher] = {}
         self._periodic_callbacks: Dict[str, Callable[[], None]] = {}
+        self._inputs = {}
+        self._outputs = {}
         self.__tf_buffer: Optional[Buffer] = None
         self.__tf_listener: Optional[TransformListener] = None
         self.__tf_broadcaster: Optional[TransformBroadcaster] = None
@@ -273,6 +285,106 @@ class ComponentInterface(Node):
             return
         self._predicates[name] = value
 
+    def _create_output(self, signal_name: str, data: DataT, message_type: MsgT,
+                       clproto_message_type: clproto.MessageType, fixed_topic: bool, default_topic: str) -> str:
+        """
+        Helper function to parse the signal name and add an output without Publisher to the dict of outputs.
+
+        :param signal_name: Name of the output signal
+        :param data: Data to transmit on the output signal
+        :param message_type: The ROS message type of the output
+        :param clproto_message_type: The clproto message type, if applicable
+        :param fixed_topic: If true, the topic name of the output signal is fixed
+        :param default_topic: If set, the default value for the topic name to use
+        :raises AddSignalError if there is a problem adding the output
+        :return: The parsed signal name
+        """
+        try:
+            if message_type == EncodedState and clproto_message_type == clproto.MessageType.UNKNOWN_MESSAGE:
+                raise AddSignalError(f"Provide a valid clproto message type for outputs of type EncodedState.")
+            parsed_signal_name = parse_signal_name(signal_name)
+            if not parsed_signal_name:
+                raise AddSignalError("The parsed signal name is empty. Provide a string with valid "
+                                     "characters for the signal name ([a-zA-Z0-9_]).")
+            if parsed_signal_name in self._outputs.keys():
+                raise AddSignalError(f"Output with parsed name '{parsed_signal_name}' already exists.")
+            topic_name = default_topic if default_topic else "~/" + parsed_signal_name
+            self.add_parameter(sr.Parameter(parsed_signal_name + "_topic", topic_name, sr.ParameterType.STRING),
+                               f"Output topic name of signal '{parsed_signal_name}'", fixed_topic)
+            translator = None
+            if message_type == Bool or message_type == Float64 or \
+                    message_type == Float64MultiArray or message_type == Int32 or message_type == String:
+                translator = modulo_writers.write_std_message
+            elif message_type == EncodedState:
+                translator = partial(modulo_writers.write_clproto_message,
+                                     clproto_message_type=clproto_message_type)
+            else:
+                raise AddSignalError("The provided message type is not supported to create a component output")
+            self._outputs[parsed_signal_name] = {"attribute": data, "message_type": message_type,
+                                                 "translator": translator}
+            return parsed_signal_name
+        except Exception as e:
+            raise AddSignalError(f"{e}")
+
+    def __subscription_callback(self, message: MsgT, attribute_name: str, reader: Callable):
+        """
+        Subscription callback for the ROS subscriptions.
+
+        :param message: The message from the ROS network
+        :param attribute_name: The name of the attribute that is updated by the subscription
+        :param reader: A callable that can read the ROS message and translate to the desired type
+        """
+        try:
+            self.__setattr__(attribute_name, reader(message))
+        except Exception as e:
+            self.get_logger().error(f"Failed to read message for attribute {attribute_name}", throttle_duration_sec=1.0)
+
+    def add_input(self, signal_name: str, subscription: Union[str, Callable], message_type: MsgT, fixed_topic=False,
+                  default_topic=""):
+        """
+        Add and configure an input signal of the component.
+
+        :param signal_name: Name of the output signal
+        :param subscription: The callback to use for the subscription
+        :param message_type: ROS message type of the subscription
+        :param fixed_topic: If true, the topic name of the output signal is fixed
+        :param default_topic: If set, the default value for the topic name to use
+        """
+        try:
+            parsed_signal_name = parse_signal_name(signal_name)
+            if not parsed_signal_name:
+                raise AddSignalError(f"Failed to add input '{signal_name}': Parsed signal name is empty.")
+            if parsed_signal_name in self._inputs.keys():
+                raise AddSignalError(f"Failed to add input '{parsed_signal_name}': Input already exists")
+            topic_name = default_topic if default_topic else "~/" + parsed_signal_name
+            self.add_parameter(sr.Parameter(parsed_signal_name + "_topic", topic_name, sr.ParameterType.STRING),
+                               f"Output topic name of signal '{parsed_signal_name}'", fixed_topic)
+            topic_name = self.get_parameter_value(parsed_signal_name + "_topic")
+            self.get_logger().debug(f"Adding input '{parsed_signal_name}' with topic name '{topic_name}'.")
+            if isinstance(subscription, Callable):
+                self._inputs[parsed_signal_name] = self.create_subscription(message_type, topic_name, subscription,
+                                                                            self._qos)
+            elif isinstance(subscription, str):
+                if message_type == Bool or message_type == Float64 or \
+                        message_type == Float64MultiArray or message_type == Int32 or message_type == String:
+                    self._inputs[parsed_signal_name] = self.create_subscription(message_type, topic_name,
+                                                                                partial(self.__subscription_callback,
+                                                                                        attribute_name=subscription,
+                                                                                        reader=modulo_readers.read_std_message),
+                                                                                self._qos)
+                elif message_type == EncodedState:
+                    self._inputs[parsed_signal_name] = self.create_subscription(message_type, topic_name,
+                                                                                partial(self.__subscription_callback,
+                                                                                        attribute_name=subscription,
+                                                                                        reader=modulo_readers.read_clproto_message),
+                                                                                self._qos)
+                else:
+                    raise TypeError("The provided message type is not supported to create a component input")
+            else:
+                raise TypeError("Provide either a string containing the name of an attribute or a callable.")
+        except Exception as e:
+            self.get_logger().error(f"Failed to add input '{signal_name}': {e}")
+
     def add_tf_broadcaster(self):
         """
         Configure a transform broadcaster.
@@ -306,7 +418,7 @@ class ComponentInterface(Node):
             return
         try:
             transform_message = TransformStamped()
-            write_stamped_message(transform_message, transform, self.get_clock().now())
+            modulo_writers.write_stamped_message(transform_message, transform, self.get_clock().now())
             self.__tf_broadcaster.sendTransform(transform_message)
         except tf2_py.TransformException as e:
             self.get_logger().error(f"Failed to send transform: {e}", throttle_duration_sec=1.0)
@@ -327,7 +439,7 @@ class ComponentInterface(Node):
         try:
             result = sr.CartesianPose(frame_name, reference_frame_name)
             transform = self.__tf_buffer.lookup_transform(reference_frame_name, frame_name, time_point, duration)
-            read_stamped_message(result, transform)
+            modulo_readers.read_stamped_message(result, transform)
             return result
         except tf2_py.TransformException as e:
             raise LookupTransformError(f"Failed to lookup transform: {e}")
@@ -379,6 +491,18 @@ class ComponentInterface(Node):
                 self.get_logger().error(f"No publisher for predicate '{name}' found.", throttle_duration_sec=1.0)
                 continue
             self._predicate_publishers[name].publish(message)
+
+    def _publish_outputs(self):
+        """
+        Helper function to publish all outputs.
+        """
+        for signal, output_dict in self._outputs.items():
+            try:
+                message = output_dict["message_type"]()
+                output_dict["translator"](message, self.__getattribute__(output_dict["attribute"]))
+                output_dict["publisher"].publish(message)
+            except Exception as e:
+                self.get_logger().error(f"{e}")
 
     def _evaluate_periodic_callbacks(self):
         """

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -359,7 +359,7 @@ class ComponentInterface(Node):
                 raise AddSignalError(f"Failed to add input '{parsed_signal_name}': Input already exists")
             topic_name = default_topic if default_topic else "~/" + parsed_signal_name
             self.add_parameter(sr.Parameter(parsed_signal_name + "_topic", topic_name, sr.ParameterType.STRING),
-                               f"Output topic name of signal '{parsed_signal_name}'", fixed_topic)
+                               f"Input topic name of signal '{parsed_signal_name}'", fixed_topic)
             topic_name = self.get_parameter_value(parsed_signal_name + "_topic")
             self.get_logger().debug(f"Adding input '{parsed_signal_name}' with topic name '{topic_name}'.")
             if isinstance(subscription, Callable):

--- a/source/modulo_components/modulo_components/exceptions/component_exceptions.py
+++ b/source/modulo_components/modulo_components/exceptions/component_exceptions.py
@@ -2,6 +2,17 @@ class ComponentError(Exception):
     """
     A base class for all component exceptions.
     """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class AddSignalError(ComponentError):
+    """
+    An exception class to notify errors when adding a signal. This is an exception class to be thrown if there is a
+    problem while adding a signal to the component.
+    """
+
     def __init__(self, message: str):
         super().__init__(message)
 
@@ -11,6 +22,7 @@ class ComponentParameterError(ComponentError):
     An exception class to notify errors with component parameters. This is an exception class to be thrown if there is a
     problem with component parameters (overriding, inconsistent types, undeclared, ...).
     """
+
     def __init__(self, message: str):
         super().__init__(message)
 
@@ -20,5 +32,6 @@ class LookupTransformError(ComponentError):
     An exception class to notify an error while looking up TF transforms. This is an exception class to be thrown if
     there is a problem with looking up a TF transform (unconfigured buffer/listener, TF2 exception).
     """
+
     def __init__(self, message: str):
         super().__init__(message)

--- a/source/modulo_components/modulo_components/utilities/utilities.py
+++ b/source/modulo_components/modulo_components/utilities/utilities.py
@@ -1,3 +1,6 @@
+import re
+
+
 def generate_predicate_topic(node_name: str, predicate_name: str) -> str:
     """
     Generate a topic name from the name of node and the predicate.
@@ -7,3 +10,16 @@ def generate_predicate_topic(node_name: str, predicate_name: str) -> str:
     :return: The name of the topic
     """
     return f'/predicates/{node_name}/{predicate_name}'
+
+
+def parse_signal_name(signal_name: str) -> str:
+    """
+    Parse a string signal name from a user-provided input.
+    This functions removes all characters different from a-z, A-Z, 0-9, and _ from a string.
+
+    :param signal_name: The input string
+    :return: The sanitized string
+    """
+    sanitized_string = re.sub("\W", "", signal_name, flags=re.ASCII).lower()
+    sanitized_string = sanitized_string.lstrip("_")
+    return sanitized_string

--- a/source/modulo_components/src/LifecycleComponent.cpp
+++ b/source/modulo_components/src/LifecycleComponent.cpp
@@ -286,6 +286,7 @@ bool LifecycleComponent::configure_outputs() {
         }
       }
     } catch (const std::exception& ex) {
+      // TODO if modulo::communication had a base exception, could catch that
       success = false;
       RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to configure output '" << name << "': " << ex.what());
     }
@@ -306,10 +307,12 @@ bool LifecycleComponent::activate_outputs() {
     try {
       interface->activate();
     } catch (const std::exception& ex) {
+      // TODO if modulo::communication had a base exception, could catch that
       success = false;
       RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to activate output '" << name << "': " << ex.what());
     }
   }
+  RCLCPP_DEBUG(this->get_logger(), "All outputs activated.");
   return success;
 }
 
@@ -319,10 +322,12 @@ bool LifecycleComponent::deactivate_outputs() {
     try {
       interface->deactivate();
     } catch (const std::exception& ex) {
+      // TODO if modulo::communication had a base exception, could catch that
       success = false;
       RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to deactivate output '" << name << "': " << ex.what());
     }
   }
+  RCLCPP_DEBUG(this->get_logger(), "All outputs deactivated.");
   return success;
 }
 }// namespace modulo_components

--- a/source/modulo_components/test/python/test_component.py
+++ b/source/modulo_components/test/python/test_component.py
@@ -1,0 +1,21 @@
+import pytest
+from modulo_components.component import Component
+from std_msgs.msg import Bool, String
+
+
+@pytest.fixture()
+def component(ros_context):
+    yield Component('component')
+
+
+def test_add_output(component):
+    component.add_output("_tEsT_#1@3", "test", Bool)
+    assert "test_13" in component._outputs.keys()
+    assert component.get_parameter_value("test_13_topic") == "~/test_13"
+
+    component.add_output("_tEsT_#1@5", "test", Bool, default_topic="/topic")
+    assert "test_15" in component._outputs.keys()
+    assert component.get_parameter_value("test_15_topic") == "/topic"
+
+    component.add_output("test_13", "test", String)
+    assert component._outputs["test_13"]["message_type"] == Bool

--- a/source/modulo_components/test/python/test_component_interface.py
+++ b/source/modulo_components/test/python/test_component_interface.py
@@ -4,6 +4,7 @@ import rclpy
 import state_representation as sr
 from modulo_components.component_interface import ComponentInterface
 from modulo_components.exceptions.component_exceptions import LookupTransformError
+from std_msgs.msg import Bool, String
 
 
 def raise_(ex):
@@ -49,6 +50,19 @@ def test_set_predicate(component_interface):
     component_interface.add_predicate('bar', True)
     component_interface.set_predicate('bar', lambda: False)
     assert not component_interface.get_predicate('bar')
+
+
+def test_add_input(component_interface):
+    component_interface.add_input("_tEsT_#1@3", "test", Bool)
+    assert "test_13" in component_interface._inputs.keys()
+    assert component_interface.get_parameter_value("test_13_topic") == "~/test_13"
+
+    component_interface.add_input("_tEsT_#1@5", "test", Bool, default_topic="/topic")
+    assert "test_15" in component_interface._inputs.keys()
+    assert component_interface.get_parameter_value("test_15_topic") == "/topic"
+
+    component_interface.add_input("test_13", "test", String)
+    assert component_interface._inputs["test_13"].msg_type == Bool
 
 
 def test_tf(component_interface):

--- a/source/modulo_new_core/modulo_new_core/translators/message_readers.py
+++ b/source/modulo_new_core/modulo_new_core/translators/message_readers.py
@@ -6,6 +6,7 @@ import state_representation as sr
 from modulo_new_core.encoded_state import EncodedState
 from sensor_msgs.msg import JointState
 
+DataT = TypeVar('DataT')
 MsgT = TypeVar('MsgT')
 StateT = TypeVar('StateT')
 
@@ -91,6 +92,16 @@ def read_stamped_message(state: StateT, message: MsgT):
     else:
         raise RuntimeError("The provided combination of state type and message type is not supported")
     state.set_reference_frame(message.header.frame_id)
+    return state
+
+
+def read_std_message(message: MsgT) -> DataT:
+    """
+    Read the data field of a std_msg.msg message.
+
+    :param message: The message to read from
+    """
+    return message.data
 
 
 def read_clproto_message(message: EncodedState) -> StateT:

--- a/source/modulo_new_core/modulo_new_core/translators/message_readers.py
+++ b/source/modulo_new_core/modulo_new_core/translators/message_readers.py
@@ -16,6 +16,7 @@ def read_xyz(message: Union[geometry.Point, geometry.Vector3]) -> List[float]:
     Helper function to read a list from a Point or Vector3 message.
 
     :param message: The message to read from
+    :return: The vector coefficients as a list
     """
     return [message.x, message.y, message.z]
 
@@ -25,17 +26,19 @@ def read_quaternion(message: geometry.Quaternion) -> List[float]:
     Helper function to read a list of quaternion coefficients (w,x,y,z) from a Quaternion message.
 
     :param message: The message to read from
+    :return: The quaternion coefficients as a list
     """
     return [message.w, message.x, message.y, message.z]
 
 
-def read_message(state: StateT, message: MsgT):
+def read_message(state: StateT, message: MsgT) -> StateT:
     """
     Convert a ROS message to a state_representation State type.
 
     :param state: The state to populate
     :param message: The ROS message to read from
     :raises Exception if the message could not be read
+    :return: The populated state
     """
     if not isinstance(state, sr.State):
         raise RuntimeError("This state type is not supported.")
@@ -70,13 +73,14 @@ def read_message(state: StateT, message: MsgT):
     return state
 
 
-def read_stamped_message(state: StateT, message: MsgT):
+def read_stamped_message(state: StateT, message: MsgT) -> StateT:
     """
     Convert a stamped ROS message to a state_representation State type.
 
     :param state: The state to populate
     :param message: The ROS message to read from
     :raises Exception if the message could not be read
+    :return: The populated state
     """
     if isinstance(message, geometry.AccelStamped):
         read_message(state, message.accel)
@@ -100,6 +104,7 @@ def read_std_message(message: MsgT) -> DataT:
     Read the data field of a std_msg.msg message.
 
     :param message: The message to read from
+    :return: The data field of the message
     """
     return message.data
 
@@ -109,6 +114,7 @@ def read_clproto_message(message: EncodedState) -> StateT:
     Convert an EncodedState message to a state_representation State type.
 
     :param message: The EncodedState message to read from
-    :raises Exception if the message could not be read
+    :raises Exception if the message could not be read:
+    :return: The decoded clproto message
     """
     return clproto.decode(message.data.tobytes())

--- a/source/modulo_new_core/modulo_new_core/translators/message_writers.py
+++ b/source/modulo_new_core/modulo_new_core/translators/message_writers.py
@@ -8,6 +8,7 @@ import state_representation as sr
 from modulo_new_core.encoded_state import EncodedState
 from sensor_msgs.msg import JointState
 
+DataT = TypeVar('DataT')
 MsgT = TypeVar('MsgT')
 StateT = TypeVar('StateT')
 
@@ -108,17 +109,25 @@ def write_stamped_message(message: MsgT, state: StateT, time: rclpy.time.Time):
     message.header.frame_id = state.get_reference_frame()
 
 
-def write_clproto_message(state: StateT, clproto_message_type: clproto.MessageType) -> EncodedState():
+def write_std_message(message: MsgT, data: DataT):
     """
-    Convert a state_representation State type to an EncodedState message.
+    Convert to a std_msgs.msg message.
 
+    :param message: The std_msgs.msg message to populate
+    :param data: The data to read from
+    """
+    message.data = data
+
+
+def write_clproto_message(message: EncodedState, state: StateT, clproto_message_type: clproto.MessageType):
+    """
+    Convert a state_representation State to an EncodedState message.
+
+    :param message: The EncodedState message to populate
     :param state: The state to read from
     :param clproto_message_type: The clproto message type to encode the state
     :raises Exception if the message could not be written
-    :return: The populated message
     """
     if not isinstance(state, sr.State):
         raise RuntimeError("This state type is not supported.")
-    message = EncodedState()
     message.data = clproto.encode(state, clproto_message_type)
-    return message

--- a/source/modulo_new_core/test/python_tests/translators/test_messages.py
+++ b/source/modulo_new_core/test/python_tests/translators/test_messages.py
@@ -1,13 +1,13 @@
 import clproto
 import geometry_msgs.msg
-import numpy as np
-import pytest
-import sensor_msgs.msg
-import state_representation as sr
-from rclpy.clock import Clock
-
 import modulo_new_core.translators.message_readers as modulo_readers
 import modulo_new_core.translators.message_writers as modulo_writers
+import numpy as np
+import pytest
+import state_representation as sr
+from modulo_new_core.encoded_state import EncodedState
+from rclpy.clock import Clock
+from sensor_msgs.msg import JointState
 
 
 def read_xyz(message):
@@ -143,7 +143,7 @@ def test_wrench(cart_state: sr.CartesianState, clock: Clock):
 
 
 def test_joint_state(joint_state: sr.JointState):
-    message = sensor_msgs.msg.JointState()
+    message = JointState()
     modulo_writers.write_message(message, joint_state)
     for i in range(joint_state.get_size()):
         assert message.name[i] == joint_state.get_names()[i]
@@ -163,7 +163,8 @@ def test_joint_state(joint_state: sr.JointState):
 
 
 def test_encoded_state(cart_state: sr.CartesianState):
-    message = modulo_writers.write_clproto_message(cart_state, clproto.MessageType.CARTESIAN_STATE_MESSAGE)
+    message = EncodedState()
+    modulo_writers.write_clproto_message(message, cart_state, clproto.MessageType.CARTESIAN_STATE_MESSAGE)
 
     new_state = modulo_readers.read_clproto_message(message)
     assert_np_array_equal(new_state.data(), cart_state.data())


### PR DESCRIPTION
Let's try this again. This PR adds the input and output signals to the python component interface. As with the parameters, it takes a name of a class attribute that should be used to publish messages and receive messages.