### PR TITLE
Inherit from NodeT with public keyword

### DIFF
--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -67,7 +67,7 @@ private:
    */
   void run();
 
-  using rclcpp::Node::create_publisher;
+  // TODO hide ROS methods
   using ComponentInterface<rclcpp::Node>::create_output;
   using ComponentInterface<rclcpp::Node>::inputs_;
   using ComponentInterface<rclcpp::Node>::outputs_;

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -75,8 +75,6 @@ private:
   using ComponentInterface<rclcpp::Node>::publish_predicates;
   using ComponentInterface<rclcpp::Node>::publish_outputs;
   using ComponentInterface<rclcpp::Node>::evaluate_periodic_callbacks;
-  using ComponentInterface<rclcpp::Node>::activate_tf_broadcaster;
-  using ComponentInterface<rclcpp::Node>::deactivate_tf_broadcaster;
 
   std::thread run_thread_; ///< The execution thread of the component
   bool started_; ///< Flag that indicates if execution has started or not

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -43,7 +43,7 @@ class ComponentInterfacePublicInterface;
  * @tparam NodeT
  */
 template<class NodeT>
-class ComponentInterface : private NodeT {
+class ComponentInterface : public NodeT {
 public:
   friend class ComponentInterfacePublicInterface<rclcpp::Node>;
   friend class ComponentInterfacePublicInterface<rclcpp_lifecycle::LifecycleNode>;
@@ -61,10 +61,7 @@ public:
    */
   virtual ~ComponentInterface() = default;
 
-  using NodeT::get_node_base_interface;
-  using NodeT::get_name;
-  using NodeT::get_clock;
-  using NodeT::get_logger;
+  // TODO hide ROS methods
 
 protected:
   /**
@@ -296,8 +293,6 @@ protected:
    * @brief Put the component in error state by setting the 'in_error_state' predicate to true.
    */
   virtual void raise_error();
-
-  using NodeT::create_publisher;
 
   std::map<std::string, std::shared_ptr<modulo_new_core::communication::SubscriptionInterface>>
       inputs_; ///< Map of inputs

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -491,11 +491,10 @@ inline void ComponentInterface<NodeT>::add_variant_predicate(
     RCLCPP_WARN_STREAM(this->get_logger(), "Predicate '" << name << "' already exists, overwriting.");
   } else {
     RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding predicate '" << name << "'.");
-    auto publisher = this->template create_publisher<std_msgs::msg::Bool>(
-        utilities::generate_predicate_topic(this->get_name(), name), this->qos_
+    auto publisher = rclcpp::create_publisher<std_msgs::msg::Bool>(
+        *this, utilities::generate_predicate_topic(this->get_name(), name), this->qos_
     );
-    this->predicate_publishers_.insert_or_assign(
-        name, std::static_pointer_cast<rclcpp::Publisher<std_msgs::msg::Bool>>(publisher));
+    this->predicate_publishers_.insert_or_assign(name, publisher);
   }
   this->predicates_.insert_or_assign(name, predicate);
 }

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -3,12 +3,12 @@
 // TODO sort includes
 #include <rclcpp/parameter.hpp>
 #include <rclcpp/create_timer.hpp>
-#include <rclcpp/node_options.hpp>
-#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
+#include <rclcpp/node.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #include <console_bridge/console.h>
 #include <tf2_msgs/msg/tf_message.hpp>
+#include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -219,16 +219,6 @@ protected:
   void add_tf_listener();
 
   /**
-   * @brief Activate the transform broadcaster (for LifecycleComponents).
-   */
-  void activate_tf_broadcaster();
-
-  /**
-   * @brief Deactivate the transform broadcaster (for LifecycleComponents).
-   */
-  void deactivate_tf_broadcaster();
-
-  /**
    * @brief Helper function to parse the signal name and add an unconfigured PublisherInterface to the map of outputs.
    * @tparam DataT Type of the data pointer
    * @param signal_name Name of the output signal
@@ -339,7 +329,7 @@ private:
   std::shared_ptr<rclcpp::TimerBase> step_timer_; ///< Timer for the step function
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_; ///< TF buffer
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_; ///< TF listener
-  std::shared_ptr<rclcpp::Publisher<tf2_msgs::msg::TFMessage>> tf_broadcaster_; ///< TF broadcaster
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_; ///< TF broadcaster
   // TODO maybe add a static tf broadcaster
 };
 
@@ -454,6 +444,9 @@ ComponentInterface<NodeT>::on_set_parameters_callback(const std::vector<rclcpp::
   result.successful = true;
   for (const auto& ros_parameter: parameters) {
     try {
+      if (ros_parameter.get_name().substr(0, 27) == "qos_overrides./tf.publisher") {
+        continue;
+      }
       // get the associated parameter interface by name
       auto parameter = parameter_map_.get_parameter(ros_parameter.get_name());
 
@@ -692,7 +685,7 @@ inline void ComponentInterface<NodeT>::add_tf_broadcaster() {
   if (this->tf_broadcaster_ == nullptr) {
     RCLCPP_DEBUG(this->get_logger(), "Adding TF broadcaster.");
     console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_NONE);
-    this->tf_broadcaster_ = this->template create_publisher<tf2_msgs::msg::TFMessage>("tf", this->qos_);
+    this->tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*this);
   } else {
     RCLCPP_DEBUG(this->get_logger(), "TF broadcaster already exists.");
   }
@@ -711,38 +704,6 @@ inline void ComponentInterface<NodeT>::add_tf_listener() {
 }
 
 template<class NodeT>
-inline void ComponentInterface<NodeT>::activate_tf_broadcaster() {
-  if (this->publisher_type_ != modulo_new_core::communication::PublisherType::LIFECYCLE_PUBLISHER) {
-    return;
-  }
-  try {
-    RCLCPP_DEBUG(this->get_logger(), "Activating TF broadcaster.");
-    auto publisher = std::dynamic_pointer_cast<rclcpp_lifecycle::LifecyclePublisher<tf2_msgs::msg::TFMessage>>(
-        this->tf_broadcaster_
-    );
-    publisher->on_activate();
-  } catch (const std::exception& ex) {
-    RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to activate TF broadcaster: " << ex.what());
-  }
-}
-
-template<class NodeT>
-inline void ComponentInterface<NodeT>::deactivate_tf_broadcaster() {
-  if (this->publisher_type_ == modulo_new_core::communication::PublisherType::PUBLISHER) {
-    return;
-  }
-  try {
-    RCLCPP_DEBUG(this->get_logger(), "Deactivating TF broadcaster.");
-    auto publisher = std::dynamic_pointer_cast<rclcpp_lifecycle::LifecyclePublisher<tf2_msgs::msg::TFMessage>>(
-        this->tf_broadcaster_
-    );
-    publisher->on_deactivate();
-  } catch (const std::exception& ex) {
-    RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to deactivate TF broadcaster: " << ex.what());
-  }
-}
-
-template<class NodeT>
 inline void ComponentInterface<NodeT>::send_transform(const state_representation::CartesianPose& transform) {
   if (this->tf_broadcaster_ == nullptr) {
     RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
@@ -752,9 +713,7 @@ inline void ComponentInterface<NodeT>::send_transform(const state_representation
   try {
     geometry_msgs::msg::TransformStamped transform_message;
     modulo_new_core::translators::write_message(transform_message, transform, this->get_clock()->now());
-    tf2_msgs::msg::TFMessage tf_message;
-    tf_message.transforms.emplace_back(transform_message);
-    this->tf_broadcaster_->publish(tf_message);
+    this->tf_broadcaster_->sendTransform(transform_message);
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
                                  "Failed to send transform: " << ex.what());

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -240,7 +240,7 @@ private:
    */
   bool cleanup_signals();
 
-  using rclcpp_lifecycle::LifecycleNode::create_publisher;
+  // TODO hide ROS methods
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::create_output;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::inputs_;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::outputs_;

--- a/source/modulo_components/include/modulo_components/utilities/utilities.hpp
+++ b/source/modulo_components/include/modulo_components/utilities/utilities.hpp
@@ -13,7 +13,7 @@ namespace modulo_components::utilities {
  * @param result the default argument value that is overwritten by reference if the given pattern is found
  * @return the value of the resultant string
  */
-static std::string
+[[maybe_unused]] static std::string
 parse_string_argument(const std::vector<std::string>& args, const std::string& pattern, std::string& result) {
   for (const auto& arg: args) {
     std::string::size_type index = arg.find(pattern);
@@ -32,7 +32,8 @@ parse_string_argument(const std::vector<std::string>& args, const std::string& p
  * @param fallback the default name if the NodeOptions structure cannot be parsed
  * @return the parsed node name or the fallback name
  */
-static std::string parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback = "") {
+[[maybe_unused]]  static std::string
+parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback = "") {
   std::string node_name(fallback);
   const std::string pattern("__node:=");
   return parse_string_argument(options.arguments(), pattern, node_name);
@@ -45,7 +46,7 @@ static std::string parse_node_name(const rclcpp::NodeOptions& options, const std
  * @param signal_name The input string
  * @return The sanitized string
  */
-static std::string parse_signal_name(const std::string& signal_name) {
+[[maybe_unused]] static std::string parse_signal_name(const std::string& signal_name) {
   std::string output;
   for (char c: signal_name) {
     if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
@@ -63,7 +64,8 @@ static std::string parse_signal_name(const std::string& signal_name) {
  * @param predicate_name The name of the predicate
  * @return The generated predicate topic as /predicates/component_name/predicate_name
  */
-static std::string generate_predicate_topic(const std::string& component_name, const std::string& predicate_name) {
+[[maybe_unused]] static std::string
+generate_predicate_topic(const std::string& component_name, const std::string& predicate_name) {
   return "/predicates/" + component_name + "/" + predicate_name;
 }
 }// namespace modulo_components::utilities

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -29,7 +29,6 @@ public:
   using ComponentInterface<NodeT>::outputs_;
   using ComponentInterface<NodeT>::add_tf_broadcaster;
   using ComponentInterface<NodeT>::add_tf_listener;
-  using ComponentInterface<NodeT>::activate_tf_broadcaster;
   using ComponentInterface<NodeT>::send_transform;
   using ComponentInterface<NodeT>::lookup_transform;
   using ComponentInterface<NodeT>::raise_error;

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -63,7 +63,6 @@ public:
       Component(node_options, start_thread) {}
   using Component::add_output;
   using Component::outputs_;
-  using Component::get_clock;
 };
 
 class LifecycleComponentPublicInterface : public LifecycleComponent {
@@ -73,6 +72,5 @@ public:
   using LifecycleComponent::configure_outputs;
   using LifecycleComponent::activate_outputs;
   using LifecycleComponent::outputs_;
-  using LifecycleComponent::get_clock;
 };
 }// namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -120,7 +120,6 @@ TYPED_TEST(ComponentInterfaceTest, CreateOutput) {
 TYPED_TEST(ComponentInterfaceTest, TF) {
   this->component_->add_tf_broadcaster();
   this->component_->add_tf_listener();
-  this->component_->activate_tf_broadcaster();
   auto send_tf = state_representation::CartesianPose::Random("test", "world");
   EXPECT_NO_THROW(this->component_->send_transform(send_tf));
   EXPECT_THROW(auto throw_tf = this->component_->lookup_transform("dummy", "world"), exceptions::LookupTransformException);


### PR DESCRIPTION
One of my initial tests showed that it is not possible to inherit with `private` from `NodeT` and we were already thinking of switching back to `public` so here it is. As a consequence, we can also switch back to a `TransformBroadcaster` and create `rclcpp::Publisher` explicitly for all predicate publishers. And finally, we can use lambda functions with `get_current_state` in the lifecycle components to get the current state for all predicates.

An important TODO here will be to hide all non necessary methods from ROS in the components