### PR TITLE
Make sure predicate is a bool

### DIFF
--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -256,9 +256,7 @@ class ComponentInterface(Node):
             except Exception as e:
                 self.get_logger().error(f"Error while evaluating the callback function: {e}",
                                         throttle_duration_sec=1.0)
-            value = bool_value
-        if isinstance(value, numpy.bool) or isinstance(value, numpy.bool_):
-            value = bool(value)
+            return bool_value
         return value
 
     def set_predicate(self, name: str, value: Union[bool, Callable[[], bool]]):

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Callable, Dict, List, Optional, TypeVar, Union
 
-import numpy
 import rclpy
 import state_representation as sr
 import tf2_py
@@ -371,9 +370,15 @@ class ComponentInterface(Node):
         """
         for name in self._predicates.keys():
             message = Bool()
-            message.data = self.get_predicate(name)
+            value = self.get_predicate(name)
+            try:
+                message.data = value
+            except AssertionError:
+                self.get_logger().error(f"Predicate '{name}' has invalid type: expected 'bool', got '{type(value)}'.",
+                                        throttle_duration_sec=1.0)
+                return
             if name not in self._predicate_publishers.keys():
-                self.get_logger().error(f"No publisher for predicate {name} found.", throttle_duration_sec=1.0)
+                self.get_logger().error(f"No publisher for predicate '{name}' found.", throttle_duration_sec=1.0)
                 return
             self._predicate_publishers[name].publish(message)
 

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Callable, Dict, List, Optional, TypeVar, Union
 
+import numpy
 import rclpy
 import state_representation as sr
 import tf2_py
@@ -256,7 +257,9 @@ class ComponentInterface(Node):
             except Exception as e:
                 self.get_logger().error(f"Error while evaluating the callback function: {e}",
                                         throttle_duration_sec=1.0)
-            return bool_value
+            value = bool_value
+        if isinstance(value, numpy.bool) or isinstance(value, numpy.bool_):
+            value = bool(value)
         return value
 
     def set_predicate(self, name: str, value: Union[bool, Callable[[], bool]]):

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -376,10 +376,10 @@ class ComponentInterface(Node):
             except AssertionError:
                 self.get_logger().error(f"Predicate '{name}' has invalid type: expected 'bool', got '{type(value)}'.",
                                         throttle_duration_sec=1.0)
-                return
+                continue
             if name not in self._predicate_publishers.keys():
                 self.get_logger().error(f"No publisher for predicate '{name}' found.", throttle_duration_sec=1.0)
-                return
+                continue
             self._predicate_publishers[name].publish(message)
 
     def _evaluate_periodic_callbacks(self):


### PR DESCRIPTION
After testing with some base components, I had to learn the hard way that after some operations with state representation types, e.g. 
```
collision = target_tf.get_position()[2] - center_tf.get_position()[2] < 0
self._in_bounds = not collision if self._flip_normal.get_value() else collision
```
the resulting variable could be of type `numpy.bool` or `numpy.bool_` and I think we should catch those cases in the component interface and convert to builtin bool.