### PR TITLE
Translation of empty parameters

### DIFF
--- a/.github/actions/build-test-galactic/Dockerfile
+++ b/.github/actions/build-test-galactic/Dockerfile
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions
-FROM ghcr.io/aica-technology/ros2-control-libraries:galactic
+FROM ghcr.io/aica-technology/ros2-control-libraries:galactic-devel
 
 # Copy and set the entrypoint commands to execute when the container starts,
 # explicilty invoking as ros2 user and with bash interpreter.

--- a/build-server.sh
+++ b/build-server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BASE_TAG=galactic
+BASE_TAG=galactic-devel
 
 IMAGE_NAME=epfl-lasa/modulo
 IMAGE_TAG=latest

--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
+find_package(control_libraries 6.0.2 REQUIRED COMPONENTS state_representation)
 find_package(clproto 6.0.0 REQUIRED)
 
 include_directories(include)

--- a/source/modulo_new_core/CMakeLists.txt
+++ b/source/modulo_new_core/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 6.0.0 REQUIRED COMPONENTS state_representation)
+find_package(control_libraries 6.0.2 REQUIRED COMPONENTS state_representation)
 find_package(clproto 6.0.0 REQUIRED)
 
 include_directories(include)

--- a/source/modulo_new_core/modulo_new_core/translators/parameter_translators.py
+++ b/source/modulo_new_core/modulo_new_core/translators/parameter_translators.py
@@ -15,14 +15,18 @@ def write_parameter(parameter: sr.Parameter) -> Parameter:
     :return: The resulting ROS parameter
     """
     if parameter.get_parameter_type() == sr.ParameterType.BOOL or \
-            parameter.get_parameter_type() == sr.ParameterType.BOOL_ARRAY or \
             parameter.get_parameter_type() == sr.ParameterType.INT or \
-            parameter.get_parameter_type() == sr.ParameterType.INT_ARRAY or \
             parameter.get_parameter_type() == sr.ParameterType.DOUBLE or \
-            parameter.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY or \
-            parameter.get_parameter_type() == sr.ParameterType.STRING or \
-            parameter.get_parameter_type() == sr.ParameterType.STRING_ARRAY:
+            parameter.get_parameter_type() == sr.ParameterType.STRING:
         return Parameter(parameter.get_name(), value=parameter.get_value())
+    elif parameter.get_parameter_type() == sr.ParameterType.BOOL_ARRAY:
+        return Parameter(parameter.get_name(), value=parameter.get_value(), type_=Parameter.Type.BOOL_ARRAY)
+    elif parameter.get_parameter_type() == sr.ParameterType.INT_ARRAY:
+        return Parameter(parameter.get_name(), value=parameter.get_value(), type_=Parameter.Type.INTEGER_ARRAY)
+    elif parameter.get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY:
+        return Parameter(parameter.get_name(), value=parameter.get_value(), type_=Parameter.Type.DOUBLE_ARRAY)
+    elif parameter.get_parameter_type() == sr.ParameterType.STRING_ARRAY:
+        return Parameter(parameter.get_name(), value=parameter.get_value(), type_=Parameter.Type.STRING_ARRAY)
     elif parameter.get_parameter_type() == sr.ParameterType.STATE:
         if parameter.get_parameter_state_type() == sr.StateType.CARTESIAN_STATE:
             return Parameter(parameter.get_name(), Parameter.Type.STRING, clproto.to_json(
@@ -40,7 +44,8 @@ def write_parameter(parameter: sr.Parameter) -> Parameter:
             raise RuntimeError(f"Parameter {parameter.get_name()} could not be written!")
     elif parameter.get_parameter_type() == sr.ParameterType.VECTOR or \
             parameter.get_parameter_type() == sr.ParameterType.MATRIX:
-        return Parameter(parameter.get_name(), value=parameter.get_value().flatten().tolist())
+        return Parameter(parameter.get_name(), value=parameter.get_value().flatten().tolist(),
+                         type_=Parameter.Type.DOUBLE_ARRAY)
     else:
         raise RuntimeError(f"Parameter {parameter.get_name()} could not be written!")
 

--- a/source/modulo_new_core/test/python_tests/conftest.py
+++ b/source/modulo_new_core/test/python_tests/conftest.py
@@ -2,6 +2,7 @@ import clproto
 import pytest
 import rclpy.clock
 import state_representation as sr
+from rclpy import Parameter
 
 
 @pytest.fixture
@@ -21,14 +22,14 @@ def clock():
 
 @pytest.fixture
 def parameters():
-    return {"bool": [True, sr.ParameterType.BOOL, False],
-            "bool_array": [[True, False], sr.ParameterType.BOOL_ARRAY, [False]],
-            "int": [1, sr.ParameterType.INT, 2],
-            "int_array": [[1, 2], sr.ParameterType.INT_ARRAY, [2]],
-            "double": [1.0, sr.ParameterType.DOUBLE, 2.0],
-            "double_array": [[1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY, [2.0]],
-            "string": ["1", sr.ParameterType.STRING, "2"],
-            "string_array": [["1", "2"], sr.ParameterType.STRING_ARRAY, ["2"]]
+    return {"bool": [True, sr.ParameterType.BOOL, False, Parameter.Type.BOOL],
+            "bool_array": [[True, False], sr.ParameterType.BOOL_ARRAY, [False], Parameter.Type.BOOL_ARRAY],
+            "int": [1, sr.ParameterType.INT, 2, Parameter.Type.INTEGER],
+            "int_array": [[1, 2], sr.ParameterType.INT_ARRAY, [2], Parameter.Type.INTEGER_ARRAY],
+            "double": [1.0, sr.ParameterType.DOUBLE, 2.0, Parameter.Type.DOUBLE],
+            "double_array": [[1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY, [2.0], Parameter.Type.DOUBLE_ARRAY],
+            "string": ["1", sr.ParameterType.STRING, "2", Parameter.Type.STRING],
+            "string_array": [["1", "2"], sr.ParameterType.STRING_ARRAY, ["2"], Parameter.Type.STRING_ARRAY]
             }
 
 

--- a/source/modulo_new_core/test/python_tests/translators/test_parameters.py
+++ b/source/modulo_new_core/test/python_tests/translators/test_parameters.py
@@ -15,6 +15,9 @@ def assert_np_array_equal(a: np.array, b: np.array, places=3):
 
 def test_parameter_write(parameters):
     for name, value_types in parameters.items():
+        param = sr.Parameter(name, value_types[1])
+        ros_param = write_parameter(param)
+        assert ros_param.type_ == value_types[3]
         param = sr.Parameter(name, value_types[0], value_types[1])
         ros_param = write_parameter(param)
         assert ros_param.to_parameter_msg() == Parameter(name, value=value_types[0]).to_parameter_msg()
@@ -64,6 +67,9 @@ def test_parameter_non_const_read(parameters):
 
 def test_state_parameter_write(state_parameters):
     for name, value_types in state_parameters.items():
+        param = sr.Parameter(name, sr.ParameterType.STATE, value_types[1])
+        ros_param = write_parameter(param)
+        assert ros_param.type_ == Parameter.Type.STRING
         param = sr.Parameter(name, value_types[0], sr.ParameterType.STATE, value_types[1])
         ros_param = write_parameter(param)
         assert ros_param.name == param.get_name()
@@ -94,6 +100,9 @@ def test_state_parameter_read_write(state_parameters):
 
 def test_vector_parameter_read_write():
     vec = np.random.rand(3)
+    param = sr.Parameter("vector", sr.ParameterType.VECTOR)
+    ros_param = write_parameter(param)
+    assert ros_param.type_ == Parameter.Type.DOUBLE_ARRAY
     param = sr.Parameter("vector", vec, sr.ParameterType.VECTOR)
     ros_param = write_parameter(param)
     assert ros_param.name == param.get_name()
@@ -114,6 +123,9 @@ def test_vector_parameter_read_write():
 
 def test_matrix_parameter_read_write():
     mat = np.random.rand(3, 4)
+    param = sr.Parameter("vector", sr.ParameterType.MATRIX)
+    ros_param = write_parameter(param)
+    assert ros_param.type_ == Parameter.Type.DOUBLE_ARRAY
     param = sr.Parameter("matrix", mat, sr.ParameterType.MATRIX)
     ros_param = write_parameter(param)
     assert ros_param.name == param.get_name()


### PR DESCRIPTION
Now that the default value of empty parameters was fixed in control libraries PR [#298](https://github.com/epfl-lasa/control-libraries/pull/298), I can use the `galactic-devel` image of ros2-control-libraries and make sure that the translation between state representation parameters and ROS parameters works correctly. What happened before was:
- an empty state rep Parameter of type double, int, etc would have a non-default value (for example 1 for double).
- an empty state rep Parameter of type XXX_ARRAY would have ROS parameter type BYTE_ARRAY

Both of these bugs are fixed now and you get the correct parameter type in ROS with correct default value.