### PR TITLE
Hide a first set of ROS methods

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -318,6 +318,24 @@ private:
    */
   void set_variant_predicate(const std::string& name, const utilities::PredicateVariant& predicate);
 
+  using NodeT::remove_on_set_parameters_callback;
+  using NodeT::add_on_set_parameters_callback;
+  using NodeT::declare_parameter;
+  using NodeT::undeclare_parameter;
+  using NodeT::declare_parameters;
+  using NodeT::has_parameter;
+  using NodeT::get_parameter;
+  using NodeT::get_parameters;
+  using NodeT::get_parameter_or;
+  using NodeT::list_parameters;
+  using NodeT::set_parameter;
+  using NodeT::set_parameters_atomically;
+  using NodeT::now;
+  using NodeT::create_callback_group;
+  using NodeT::for_each_callback_group;
+  using NodeT::create_generic_publisher;
+  using NodeT::create_generic_subscription;
+
   modulo_core::communication::PublisherType
       publisher_type_; ///< Type of the output publishers (one of PUBLISHER, LIFECYCLE_PUBLISHER)
 

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -244,6 +244,22 @@ private:
   bool cleanup_signals();
 
   // TODO hide ROS methods
+  using rclcpp_lifecycle::LifecycleNode::configure;
+  using rclcpp_lifecycle::LifecycleNode::activate;
+  using rclcpp_lifecycle::LifecycleNode::deactivate;
+  using rclcpp_lifecycle::LifecycleNode::shutdown;
+  using rclcpp_lifecycle::LifecycleNode::cleanup;
+  using rclcpp_lifecycle::LifecycleNode::on_configure;
+  using rclcpp_lifecycle::LifecycleNode::on_activate;
+  using rclcpp_lifecycle::LifecycleNode::on_deactivate;
+  using rclcpp_lifecycle::LifecycleNode::on_error;
+  using rclcpp_lifecycle::LifecycleNode::on_cleanup;
+  using rclcpp_lifecycle::LifecycleNode::register_on_configure;
+  using rclcpp_lifecycle::LifecycleNode::register_on_activate;
+  using rclcpp_lifecycle::LifecycleNode::register_on_deactivate;
+  using rclcpp_lifecycle::LifecycleNode::register_on_error;
+  using rclcpp_lifecycle::LifecycleNode::register_on_cleanup;
+//  using rclcpp_lifecycle::LifecycleNode::trigger_transition; // TODO can we use that?
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::create_output;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::inputs_;
   using ComponentInterface<rclcpp_lifecycle::LifecycleNode>::outputs_;


### PR DESCRIPTION
As all ROS methods are now publicly exposed, we need to think which ones we want to hide. What sure is that we can not hide everything because we should probably still allow the user to create his/her own publishers/subscriptions. However, what we can hide is everything related to parameters and lifecycle transitions such that the user doesn't mess with anything that might break the way our components work.

To be discussed, just wanted to get that off my stash