### PR TITLE
Add lifecycle component in Python

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -95,8 +95,6 @@ protected:
    * @param description The description of the parameter
    * @param read_only If true, the value of the parameter cannot be changed after declaration
    */
-   // TODO could be nice to add an optional callback here that would be executed along with the
-   // on_set_parameter_callback
   template<typename T>
   void add_parameter(const std::string& name, const T& value, const std::string& description, bool read_only = false);
 

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -95,6 +95,8 @@ protected:
    * @param description The description of the parameter
    * @param read_only If true, the value of the parameter cannot be changed after declaration
    */
+   // TODO could be nice to add an optional callback here that would be executed along with the
+   // on_set_parameter_callback
   template<typename T>
   void add_parameter(const std::string& name, const T& value, const std::string& description, bool read_only = false);
 

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -346,7 +346,7 @@ class ComponentInterface(Node):
         Add and configure an input signal of the component.
 
         :param signal_name: Name of the output signal
-        :param subscription: The callback to use for the subscription
+        :param subscription: Name of the attribute to receive messages for or the callback to use for the subscription
         :param message_type: ROS message type of the subscription
         :param fixed_topic: If true, the topic name of the output signal is fixed
         :param default_topic: If set, the default value for the topic name to use

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -80,9 +80,9 @@ class LifecycleComponent(ComponentInterface):
 
         :return: True if the transition was successful
         """
-        return self.__configure_outputs() and self.configure()
+        return self.__configure_outputs() and self.on_configure_callbacck()
 
-    def configure(self) -> bool:
+    def on_configure_callbacck(self) -> bool:
         """
         Function called from the configure transition service callback. To be redefined in derived classes.
 
@@ -126,9 +126,9 @@ class LifecycleComponent(ComponentInterface):
 
         :return: True if the transition was successful
         """
-        return self.cleanup()
+        return self.on_cleanup_callback()
 
-    def cleanup(self) -> bool:
+    def on_cleanup_callback(self) -> bool:
         """
         Function called from the cleanup transition service callback. To be redefined in derived classes.
 
@@ -159,9 +159,9 @@ class LifecycleComponent(ComponentInterface):
 
         :return: True if the transition was successful
         """
-        return self.activate()
+        return self.on_activate_callback()
 
-    def activate(self) -> bool:
+    def on_activate_callback(self) -> bool:
         """
         Function called from the activate transition service callback. To be redefined in derived classes.
 
@@ -192,9 +192,9 @@ class LifecycleComponent(ComponentInterface):
 
         :return: True if the transition was successful
         """
-        return self.deactivate()
+        return self.on_deactivate_callback()
 
-    def deactivate(self) -> bool:
+    def on_deactivate_callback(self) -> bool:
         """
         Function called from the deactivate transition service callback. To be redefined in derived classes.
 
@@ -210,7 +210,7 @@ class LifecycleComponent(ComponentInterface):
             if self.__state == State.PRIMARY_STATE_ACTIVE:
                 self._publish_outputs()
                 self._evaluate_periodic_callbacks()
-                self.step()
+                self.on_step_callback()
         except Exception as e:
             self.get_logger().error(f"Failed to execute step function: {e}", throttle_duration_sec=1.0)
 
@@ -233,7 +233,7 @@ class LifecycleComponent(ComponentInterface):
         except AddSignalError as e:
             self.get_logger().error(f"Failed to add output '{signal_name}': {e}")
 
-    def step(self):
+    def on_step_callback(self):
         """
         Steps to execute periodically. To be redefined by derived classes.
         """

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -1,0 +1,187 @@
+from typing import TypeVar
+
+import clproto
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState
+from modulo_components.component_interface import ComponentInterface
+from modulo_components.exceptions.component_exceptions import AddSignalError
+
+MsgT = TypeVar('MsgT')
+
+
+class LifecycleComponent(ComponentInterface):
+    """
+    Class to represent a LifecycleComponent in python, following the same logic pattern
+    as the c++ modulo_component::LifecycleComponent class.
+    ...
+    Attributes:
+    # TODO
+    """
+
+    def __init__(self, node_name: str, *kargs, **kwargs):
+        """
+        Constructs all the necessary attributes and declare all the parameters.
+            Parameters:
+                node_name (str): name of the node to be passed to the base Node class
+        """
+        super().__init__(node_name, *kargs, **kwargs)
+        self.__inactive = False
+        self.__active = False
+
+        # add the service to mimic the lifecycle paradigm
+        self._change_state_srv = self.create_service(ChangeState, '~/change_state', self.__change_state)
+
+        self.add_predicate("is_inactive", self.__is_inactive)
+        self.add_predicate("is_active", self.__is_active)
+
+    def __change_state(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
+        """
+        Change state service callback which calls the requested transition method.
+
+        :param request: The lifecycle_msgs.msg.ChangeState.Request message
+        :param response: The lifecycle_msgs.msg.ChangeState.Response message
+        :return: The response message
+        """
+        self.get_logger().debug(f'Change state service called with request {request}')
+        if request.transition.id == Transition.TRANSITION_CONFIGURE:
+            response = self.__configure(request, response)
+        elif request.transition.id == Transition.TRANSITION_ACTIVATE:
+            response = self.__activate(request, response)
+        elif request.transition.id == Transition.TRANSITION_DEACTIVATE:
+            response = self.__deactivate(request, response)
+        else:
+            self.get_logger().error(f'Unsupported state transition! {request}')
+            response.success = False
+        return response
+
+    def __configure(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
+        """
+        Configure service callback. Simply call the on_configure function.
+
+        :param request: request to change the state to non active
+        :param response: the response object from the service call
+        :return: true if the node configured properly
+        """
+        if self.__inactive:
+            response.success = False
+            return response
+
+        response.success = self._configure_outputs() and self.on_configure()
+        if response.success:
+            self.__inactive = True
+        return response
+
+    def on_configure(self) -> bool:
+        """
+        Function called from the configure service callback. To be redefined in derived classes.
+
+        :return: true if the node configured properly
+        """
+        return True
+
+    def __is_inactive(self) -> bool:
+        """
+        Predicate function to check the inactive property.
+        """
+        return self.__inactive
+
+    def _configure_outputs(self) -> bool:
+        success = True
+        for signal_name, output_dict in self._outputs.items():
+            try:
+                topic_name = self.get_parameter_value(signal_name + "_topic")
+                self.get_logger().debug(f"Configuring output '{signal_name}' with topic name '{topic_name}'.")
+                publisher = self.create_publisher(output_dict["message_type"], topic_name, self._qos)
+                self._outputs[signal_name]["publisher"] = publisher
+            except Exception as e:
+                success = False
+                self.get_logger().debug(f"Failed to configure output '{signal_name}': {e}")
+        return success
+
+    def __activate(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
+        """
+        Activate service callback. Set the node as active and call the on_activate function.
+
+        :param request: request to change the state to active state
+        :param response: the response object from the service call
+        :return: true if the node is activated properly
+        """
+        if not self.__inactive or self.__active:
+            response.success = False
+            return response
+
+        response.success = self.on_activate()
+        if response.success:
+            self.__active = True
+        return response
+
+    def on_activate(self) -> bool:
+        """
+        Function called from the activate service callback. To be redefined in derived classes.
+
+        :return: true if the node is activated properly
+        """
+        return True
+
+    def __is_active(self) -> bool:
+        """
+        Predicate function to check the active property.
+        """
+        return self.__active
+
+    def __deactivate(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
+        """
+        Deactivate service callback. Set the node as not active and call the on_deactivate function.
+
+        :param request: request to change the state to active state
+        :param response: the response object from the service call
+        :return: true if the node is deactivated properly
+        """
+        if not self.__inactive or not self.__active:
+            response.success = False
+            return response
+
+        response.success = self.on_deactivate()
+        if response.success:
+            self.__active = False
+        return response
+
+    def on_deactivate(self) -> bool:
+        """
+        Function called from the deactivate service callback. To be redefined in derived classes.
+
+        :return: true if the node is deactivated properly
+        """
+        return True
+
+    def _step(self):
+        try:
+            self._publish_predicates()
+            if self.__active:
+                self._publish_outputs()
+                self._evaluate_periodic_callbacks()
+                self.on_step()
+        except Exception as e:
+            self.get_logger().error(f"Failed to execute step function: {e}", throttle_duration_sec=1.0)
+
+    def add_output(self, signal_name: str, data: str, message_type: MsgT,
+                   clproto_message_type=clproto.MessageType.UNKNOWN_MESSAGE, fixed_topic=False, default_topic=""):
+        """
+        Add an output signal of the component.
+
+        :param signal_name: Name of the output signal
+        :param data: Name of the attribute to transmit over the channel
+        :param message_type: The ROS message type of the output
+        :param clproto_message_type: The clproto message type, if applicable
+        :param fixed_topic: If true, the topic name of the output signal is fixed
+        :param default_topic: If set, the default value for the topic name to use
+        """
+        try:
+            parsed_signal_name = self._create_output(signal_name, data, message_type, clproto_message_type, fixed_topic,
+                                                     default_topic)
+            self.get_logger().debug(f"Adding output '{parsed_signal_name}.")
+        except AddSignalError as e:
+            self.get_logger().error(f"Failed to add output '{signal_name}': {e}")
+
+    def on_step(self):
+        pass

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -44,9 +44,9 @@ class LifecycleComponent(ComponentInterface):
         """
         self.get_logger().debug(f'Change state service called with request {request}')
         if request.transition.id == Transition.TRANSITION_CONFIGURE:
-            response = self.__configure(request, response)
+            response = self._configure(request, response)
         elif request.transition.id == Transition.TRANSITION_ACTIVATE:
-            response = self.__activate(request, response)
+            response = self._activate(request, response)
         elif request.transition.id == Transition.TRANSITION_DEACTIVATE:
             response = self.__deactivate(request, response)
         else:
@@ -54,7 +54,7 @@ class LifecycleComponent(ComponentInterface):
             response.success = False
         return response
 
-    def __configure(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
+    def _configure(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
         """
         Configure service callback. Simply call the on_configure function.
 
@@ -98,7 +98,7 @@ class LifecycleComponent(ComponentInterface):
                 self.get_logger().debug(f"Failed to configure output '{signal_name}': {e}")
         return success
 
-    def __activate(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
+    def _activate(self, request: ChangeState.Request, response: ChangeState.Response) -> ChangeState.Response:
         """
         Activate service callback. Set the node as active and call the on_activate function.
 

--- a/source/modulo_components/src/LifecycleComponent.cpp
+++ b/source/modulo_components/src/LifecycleComponent.cpp
@@ -155,7 +155,7 @@ bool LifecycleComponent::on_deactivate() {
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 LifecycleComponent::on_shutdown(const rclcpp_lifecycle::State& previous_state) {
-  RCLCPP_DEBUG(this->get_logger(), "on_deactivate called from previous state %s", previous_state.label().c_str());
+  RCLCPP_DEBUG(this->get_logger(), "on_shutdown called from previous state %s", previous_state.label().c_str());
   switch (previous_state.id()) {
     case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
       return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;


### PR DESCRIPTION
Last but not least, the Python LifecycleComponent. It's more or less a copy of the old component from dynamic components except that I added the cleanup transition and I publish the predicates based on the current state of the component with lambda functions.

Has already been tested and works as expected. I'm not sure if we need to do better with the transitions and even add on shutdown but that could also wait until the humble upgrade.