### PR TITLE
Allow declaring unintialized ROS parameters

### DIFF
--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 6.0.2 REQUIRED COMPONENTS state_representation)
+find_package(control_libraries 6.0.4 REQUIRED COMPONENTS state_representation)
 find_package(clproto 6.0.0 REQUIRED)
 
 include_directories(include)

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -400,9 +400,9 @@ inline void ComponentInterface<NodeT>::add_parameter(
       descriptor.description = description;
       descriptor.read_only = read_only;
       if (parameter->is_empty()) {
-        descriptor.dynamic_typing = true;
         NodeT::declare_parameter(
-            parameter->get_name(), utilities::get_ros_parameter_type(parameter->get_parameter_type()));
+            parameter->get_name(), utilities::get_ros_parameter_type(parameter->get_parameter_type()), descriptor
+        );
       } else {
         NodeT::declare_parameter(parameter->get_name(), ros_param.get_parameter_value(), descriptor);
       }

--- a/source/modulo_components/include/modulo_components/utilities/utilities.hpp
+++ b/source/modulo_components/include/modulo_components/utilities/utilities.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <rclcpp/rclcpp.hpp>
+#include <state_representation/parameters/ParameterType.hpp>
 
 namespace modulo_components::utilities {
 

--- a/source/modulo_components/include/modulo_components/utilities/utilities.hpp
+++ b/source/modulo_components/include/modulo_components/utilities/utilities.hpp
@@ -70,6 +70,11 @@ generate_predicate_topic(const std::string& component_name, const std::string& p
   return "/predicates/" + component_name + "/" + predicate_name;
 }
 
+/**
+ * @brief Given a state representation parameter type, get the corresponding ROS parameter type.
+ * @param parameter_type The state representation parameter type
+ * @return The corresponding ROS parameter type
+ */
 [[maybe_unused]] static rclcpp::ParameterType
 get_ros_parameter_type(const state_representation::ParameterType& parameter_type) {
   using namespace state_representation;

--- a/source/modulo_components/include/modulo_components/utilities/utilities.hpp
+++ b/source/modulo_components/include/modulo_components/utilities/utilities.hpp
@@ -68,4 +68,32 @@ parse_node_name(const rclcpp::NodeOptions& options, const std::string& fallback 
 generate_predicate_topic(const std::string& component_name, const std::string& predicate_name) {
   return "/predicates/" + component_name + "/" + predicate_name;
 }
+
+[[maybe_unused]] static rclcpp::ParameterType
+get_ros_parameter_type(const state_representation::ParameterType& parameter_type) {
+  using namespace state_representation;
+  switch (parameter_type) {
+    case ParameterType::BOOL:
+      return rclcpp::ParameterType::PARAMETER_BOOL;
+    case ParameterType::BOOL_ARRAY:
+      return rclcpp::ParameterType::PARAMETER_BOOL_ARRAY;
+    case ParameterType::INT:
+      return rclcpp::ParameterType::PARAMETER_INTEGER;
+    case ParameterType::INT_ARRAY:
+      return rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY;
+    case ParameterType::DOUBLE:
+      return rclcpp::ParameterType::PARAMETER_DOUBLE;
+    case ParameterType::DOUBLE_ARRAY:
+    case ParameterType::VECTOR:
+    case ParameterType::MATRIX:
+      return rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY;
+    case ParameterType::STRING:
+      return rclcpp::ParameterType::PARAMETER_STRING;
+    case ParameterType::STRING_ARRAY:
+    case ParameterType::STATE:
+      return rclcpp::ParameterType::PARAMETER_STRING_ARRAY;
+    default:
+      return rclcpp::ParameterType::PARAMETER_NOT_SET;
+  }
+}
 }// namespace modulo_components::utilities

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -111,9 +111,14 @@ class ComponentInterface(Node):
                 self.get_logger().debug(f"Adding parameter '{sr_parameter.get_name()}'.")
                 self._parameter_dict[sr_parameter.get_name()] = parameter
                 # TODO ignore override
-                self.declare_parameter(ros_param.name, ros_param.value,
-                                       descriptor=ParameterDescriptor(description=description),
-                                       ignore_override=read_only)
+                if sr_parameter.is_empty():
+                    self.declare_parameter(ros_param.name, None,
+                                           descriptor=ParameterDescriptor(description=description,
+                                                                          type=Parameter.Type.NOT_SET.value,
+                                                                          dynamic_typing=True))
+                else:
+                    self.declare_parameter(ros_param.name, ros_param.value,
+                                           descriptor=ParameterDescriptor(description=description))
             else:
                 self.get_logger().warn(f"Parameter '{sr_parameter.get_name()}' already exists, overwriting.")
                 self.set_parameters([ros_param])
@@ -208,6 +213,8 @@ class ComponentInterface(Node):
         """
         result = SetParametersResult(successful=True)
         for ros_param in ros_parameters:
+            if ros_param.type_ == Parameter.Type.NOT_SET:
+                continue
             try:
                 parameter = self._get_component_parameter(ros_param.name)
                 new_parameter = read_parameter_const(ros_param, parameter)

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -9,7 +9,7 @@ import state_representation as sr
 from geometry_msgs.msg import TransformStamped
 from modulo_components.exceptions.component_exceptions import AddSignalError, ComponentParameterError, \
     LookupTransformError
-from modulo_components.utilities.utilities import generate_predicate_topic, parse_signal_name
+from modulo_components.utilities.utilities import generate_predicate_topic, get_ros_parameter_type, parse_signal_name
 from modulo_core.encoded_state import EncodedState
 from modulo_core.translators.parameter_translators import write_parameter, read_parameter_const
 from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult
@@ -111,14 +111,12 @@ class ComponentInterface(Node):
                 self.get_logger().debug(f"Adding parameter '{sr_parameter.get_name()}'.")
                 self._parameter_dict[sr_parameter.get_name()] = parameter
                 # TODO read_only
+                descriptor = ParameterDescriptor(description=description, read_only=read_only)
                 if sr_parameter.is_empty():
-                    self.declare_parameter(ros_param.name, None,
-                                           descriptor=ParameterDescriptor(description=description,
-                                                                          type=Parameter.Type.NOT_SET.value,
-                                                                          dynamic_typing=True))
+                    self.declare_parameter(ros_param.name, get_ros_parameter_type(sr_parameter.get_parameter_type()),
+                                           descriptor=descriptor)
                 else:
-                    self.declare_parameter(ros_param.name, ros_param.value,
-                                           descriptor=ParameterDescriptor(description=description))
+                    self.declare_parameter(ros_param.name, ros_param.value, descriptor=descriptor)
             else:
                 if sr_parameter.is_empty():
                     self.get_logger().error(

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -214,6 +214,8 @@ class ComponentInterface(Node):
         result = SetParametersResult(successful=True)
         for ros_param in ros_parameters:
             if ros_param.type_ == Parameter.Type.NOT_SET:
+                self.get_logger().debug(
+                    f"Parameter '{ros_param.name}' has type 'NOT_SET', skipping parameter validation and setting.")
                 continue
             try:
                 parameter = self._get_component_parameter(ros_param.name)

--- a/source/modulo_components/modulo_components/utilities/utilities.py
+++ b/source/modulo_components/modulo_components/utilities/utilities.py
@@ -1,5 +1,8 @@
 import re
 
+import state_representation as sr
+from rclpy import Parameter
+
 
 def generate_predicate_topic(node_name: str, predicate_name: str) -> str:
     """
@@ -23,3 +26,30 @@ def parse_signal_name(signal_name: str) -> str:
     sanitized_string = re.sub("\W", "", signal_name, flags=re.ASCII).lower()
     sanitized_string = sanitized_string.lstrip("_")
     return sanitized_string
+
+
+def get_ros_parameter_type(parameter_type: sr.ParameterType) -> Parameter.Type:
+    """
+    Given a state representation parameter type, get the corresponding ROS parameter type.
+
+    :param parameter_type: The state representation parameter type
+    :return: The corresponding ROS parameter type
+    """
+    if parameter_type == sr.ParameterType.BOOL:
+        return Parameter.Type.BOOL
+    elif parameter_type == sr.ParameterType.BOOL_ARRAY:
+        return Parameter.Type.BOOL_ARRAY
+    elif parameter_type == sr.ParameterType.INT:
+        return Parameter.Type.INTEGER
+    elif parameter_type == sr.ParameterType.INT_ARRAY:
+        return Parameter.Type.INTEGER_ARRAY
+    elif parameter_type == sr.ParameterType.DOUBLE:
+        return Parameter.Type.DOUBLE
+    elif parameter_type in [sr.ParameterType.DOUBLE_ARRAY, sr.ParameterType.VECTOR, sr.ParameterType.MATRIX]:
+        return Parameter.Type.DOUBLE_ARRAY
+    elif parameter_type in [sr.ParameterType.STRING, sr.ParameterType.STATE]:
+        return Parameter.Type.STRING
+    elif parameter_type == sr.ParameterType.STRING_ARRAY:
+        return Parameter.Type.STRING_ARRAY
+    else:
+        return Parameter.Type.NOT_SET

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -12,8 +12,9 @@ template<class NodeT>
 class ComponentInterfacePublicInterface : public ComponentInterface<NodeT> {
 public:
   explicit ComponentInterfacePublicInterface(
-      const rclcpp::NodeOptions& node_options, modulo_core::communication::PublisherType publisher_type
-  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
+      const rclcpp::NodeOptions& node_options, modulo_core::communication::PublisherType publisher_type,
+      const std::string& fallback_name = "ComponentInterfacePublicInterface"
+  ) : ComponentInterface<NodeT>(node_options, publisher_type, fallback_name) {}
   using ComponentInterface<NodeT>::add_parameter;
   using ComponentInterface<NodeT>::get_parameter;
   using ComponentInterface<NodeT>::get_parameter_value;

--- a/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include "modulo_components/exceptions/ComponentParameterException.hpp"
+#include "modulo_core/EncodedState.hpp"
+#include "test_modulo_components/component_public_interfaces.hpp"
+
+namespace modulo_components {
+
+template<class NodeT>
+class EmtpyParameterInterface : public ComponentInterfacePublicInterface<NodeT> {
+public:
+  explicit EmtpyParameterInterface(
+      const rclcpp::NodeOptions& node_options, modulo_core::communication::PublisherType publisher_type
+  ) : ComponentInterfacePublicInterface<NodeT>(node_options, publisher_type, "EmtpyParameterInterface") {
+    this->add_parameter(std::make_shared<Parameter<std::string>>("name"), "Test parameter");
+  };
+
+private:
+  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override {
+    if (parameter->get_name() == "name") {
+      if (parameter->get_parameter_value<std::string>().empty()) {
+        RCLCPP_ERROR(this->get_logger(), "Provide a non empty value for parameter 'name'");
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+template<class NodeT>
+class ComponentInterfaceEmptyParameterTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override {
+    if (std::is_same<NodeT, rclcpp::Node>::value) {
+      this->component_ = std::make_shared<EmtpyParameterInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_core::communication::PublisherType::PUBLISHER
+      );
+    } else if (std::is_same<NodeT, rclcpp_lifecycle::LifecycleNode>::value) {
+      this->component_ = std::make_shared<EmtpyParameterInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_core::communication::PublisherType::LIFECYCLE_PUBLISHER
+      );
+    }
+  }
+
+  std::shared_ptr<EmtpyParameterInterface<NodeT>> component_;
+};
+using NodeTypes = ::testing::Types<rclcpp::Node, rclcpp_lifecycle::LifecycleNode>;
+TYPED_TEST_SUITE(ComponentInterfaceEmptyParameterTest, NodeTypes);
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, ValidateEmptyParameter) {
+  // component comes with empty parameter 'name'
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_TRUE(this->component_->get_parameter("name")->is_empty());
+  auto ros_param = rclcpp::Parameter();
+  EXPECT_THROW(ros_param = this->component_->get_ros_parameter("name"),
+               rclcpp::exceptions::ParameterUninitializedException);
+//  EXPECT_NO_THROW(this->component_->get_ros_parameter("name"););
+//  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+
+  // Trying to overwrite with an empty parameter is not allowed
+  this->component_->add_parameter(std::make_shared<Parameter<bool>>("name"), "Test parameter");
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_THROW(ros_param = this->component_->get_ros_parameter("name"),
+               rclcpp::exceptions::ParameterUninitializedException);
+//  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+//  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+
+  // Set parameter with empty parameter isn't possible because there is no method for that
+  // component->set_parameter(std::make_shared<Parameter<std::string>>("name"));
+
+  // Set parameter value from rclcpp interface should update ROS parameter type
+  this->component_->set_ros_parameter({"name", "test"});
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "test");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "test");
+
+  // Set parameter value from component interface
+  this->component_->template set_parameter_value<std::string>("name", "again");
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "again");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "again");
+
+  // Setting it with empty value should be rejected in parameter evaluation
+  this->component_->template set_parameter_value<std::string>("name", "");
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "again");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "again");
+
+  // Setting a parameter with type NOT_SET, undeclares that parameter, hence the last assertion fails!
+  auto result = this->component_->set_ros_parameter(rclcpp::Parameter("name"));
+  RCLCPP_ERROR_STREAM(this->component_->get_logger(), result.reason);
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+//  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+//  EXPECT_EQ(ros_param.get_value<std::string>(), "again");
+}
+} // namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
@@ -62,16 +62,12 @@ TYPED_TEST(ComponentInterfaceEmptyParameterTest, ValidateEmptyParameter) {
   auto ros_param = rclcpp::Parameter();
   EXPECT_THROW(ros_param = this->component_->get_ros_parameter("name"),
                rclcpp::exceptions::ParameterUninitializedException);
-//  EXPECT_NO_THROW(this->component_->get_ros_parameter("name"););
-//  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
 
   // Trying to overwrite with an empty parameter is not allowed
   this->component_->add_parameter(std::make_shared<Parameter<bool>>("name"), "Test parameter");
   EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
   EXPECT_THROW(ros_param = this->component_->get_ros_parameter("name"),
                rclcpp::exceptions::ParameterUninitializedException);
-//  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
-//  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
 
   // Set parameter with empty parameter isn't possible because there is no method for that
   // component->set_parameter(std::make_shared<Parameter<std::string>>("name"));
@@ -100,13 +96,12 @@ TYPED_TEST(ComponentInterfaceEmptyParameterTest, ValidateEmptyParameter) {
   EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
   EXPECT_EQ(ros_param.template get_value<std::string>(), "again");
 
-  // Setting a parameter with type NOT_SET, undeclares that parameter, hence the last assertion fails!
+  // Setting a parameter with type NOT_SET is not possible, parameter remains unchanged
   auto result = this->component_->set_ros_parameter(rclcpp::Parameter("name"));
   RCLCPP_ERROR_STREAM(this->component_->get_logger(), result.reason);
   EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
   EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
-  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
-//  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
-//  EXPECT_EQ(ros_param.get_value<std::string>(), "again");
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.get_value<std::string>(), "again");
 }
 } // namespace modulo_components

--- a/source/modulo_components/test/python/test_component.py
+++ b/source/modulo_components/test/python/test_component.py
@@ -1,8 +1,5 @@
 import pytest
-import state_representation as sr
 from modulo_components.component import Component
-from rclpy.node import Node
-from rclpy.parameter import Parameter
 from std_msgs.msg import Bool, String
 
 
@@ -22,19 +19,3 @@ def test_add_output(component):
 
     component.add_output("test_13", "test", String)
     assert component._outputs["test_13"]["message_type"] == Bool
-
-
-def test_empty_parameter(component):
-    component.add_parameter(sr.Parameter("test", sr.ParameterType.DOUBLE_ARRAY), "description")
-    assert component.get_parameter("test").get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY
-    assert Node.get_parameter(component, "test").type_ == Parameter.Type.NOT_SET
-
-    component.set_parameter_value("test", [1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY)
-    assert Node.get_parameter(component, "test").type_ == Parameter.Type.DOUBLE_ARRAY
-
-    component.set_parameter_value("test", "test", sr.ParameterType.STRING)
-    assert component.get_parameter("test").get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY
-    assert Node.get_parameter(component, "test").type_ == Parameter.Type.DOUBLE_ARRAY
-
-    Node.set_parameters(component, [Parameter("test", value="test")])
-    assert Node.get_parameter(component, "test").type_ == Parameter.Type.DOUBLE_ARRAY

--- a/source/modulo_components/test/python/test_component.py
+++ b/source/modulo_components/test/python/test_component.py
@@ -1,5 +1,8 @@
 import pytest
+import state_representation as sr
 from modulo_components.component import Component
+from rclpy.node import Node
+from rclpy.parameter import Parameter
 from std_msgs.msg import Bool, String
 
 
@@ -19,3 +22,19 @@ def test_add_output(component):
 
     component.add_output("test_13", "test", String)
     assert component._outputs["test_13"]["message_type"] == Bool
+
+
+def test_empty_parameter(component):
+    component.add_parameter(sr.Parameter("test", sr.ParameterType.DOUBLE_ARRAY), "description")
+    assert component.get_parameter("test").get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY
+    assert Node.get_parameter(component, "test").type_ == Parameter.Type.NOT_SET
+
+    component.set_parameter_value("test", [1.0, 2.0], sr.ParameterType.DOUBLE_ARRAY)
+    assert Node.get_parameter(component, "test").type_ == Parameter.Type.DOUBLE_ARRAY
+
+    component.set_parameter_value("test", "test", sr.ParameterType.STRING)
+    assert component.get_parameter("test").get_parameter_type() == sr.ParameterType.DOUBLE_ARRAY
+    assert Node.get_parameter(component, "test").type_ == Parameter.Type.DOUBLE_ARRAY
+
+    Node.set_parameters(component, [Parameter("test", value="test")])
+    assert Node.get_parameter(component, "test").type_ == Parameter.Type.DOUBLE_ARRAY

--- a/source/modulo_components/test/python/test_component_interface_empty_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_empty_parameters.py
@@ -5,6 +5,7 @@ from modulo_components.component_interface import ComponentInterface
 from rcl_interfaces.msg import SetParametersResult
 from rclpy.node import Node
 from rclpy.parameter import Parameter
+from rclpy.exceptions import ParameterUninitializedException
 
 
 class EmtpyParameterInterface(ComponentInterface):
@@ -35,12 +36,14 @@ def test_validate_empty_parameter(component_test):
     # component_test comes with empty parameter 'name'
     assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
     assert component_test.get_parameter("name").is_empty()
-    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+    with pytest.raises(ParameterUninitializedException):
+        Node.get_parameter(component_test, "name")
 
     # Trying to overwrite with an empty parameter is not allowed
     component_test.add_parameter(sr.Parameter("name", sr.ParameterType.BOOL), "Test parameter")
     assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
-    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+    with pytest.raises(ParameterUninitializedException):
+        Node.get_parameter(component_test, "name")
 
     # Set parameter with empty parameter isn't possible because there is no method for that
     # component_test.set_parameter(sr.Parameter("name", sr.ParameterType.STRING))
@@ -66,7 +69,8 @@ def test_validate_empty_parameter(component_test):
     assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
     assert Node.get_parameter(component_test, "name").value == "again"
 
-    # Setting a parameter with type NOT_SET, undeclares that parameter, hence the last assertion fails!
+    # Setting a parameter with type NOT_SET is not possible, parameter remains unchanged
     Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.NOT_SET, value=None)])
     assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
-    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "again"

--- a/source/modulo_components/test/python/test_component_interface_empty_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_empty_parameters.py
@@ -1,0 +1,72 @@
+import pytest
+import rclpy
+import state_representation as sr
+from modulo_components.component_interface import ComponentInterface
+from rcl_interfaces.msg import SetParametersResult
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+
+
+class EmtpyParameterInterface(ComponentInterface):
+    def __init__(self, node_name, *kargs, **kwargs):
+        super().__init__(node_name, *kargs, **kwargs)
+        self.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+
+    def get_ros_parameter(self, name: str) -> rclpy.Parameter:
+        return rclpy.node.Node.get_parameter(self, name)
+
+    def set_ros_parameter(self, param: rclpy.Parameter) -> SetParametersResult:
+        return rclpy.node.Node.set_parameters(self, [param])[0]
+
+    def _validate_parameter(self, parameter: sr.Parameter) -> bool:
+        if parameter.get_name() == "name":
+            if not parameter.get_value():
+                self.get_logger().error("Provide a non empty value for parameter 'name'")
+                return False
+        return True
+
+
+@pytest.fixture()
+def component_test(ros_context):
+    yield EmtpyParameterInterface("component")
+
+
+def test_validate_empty_parameter(component_test):
+    # component_test comes with empty parameter 'name'
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter("name").is_empty()
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+
+    # Trying to overwrite with an empty parameter is not allowed
+    component_test.add_parameter(sr.Parameter("name", sr.ParameterType.BOOL), "Test parameter")
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+
+    # Set parameter with empty parameter isn't possible because there is no method for that
+    # component_test.set_parameter(sr.Parameter("name", sr.ParameterType.STRING))
+
+    # Set parameter value from rclpy interface should update ROS parameter type
+    Node.set_parameters(component_test, [Parameter("name", value="test")])
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "test"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "test"
+
+    # Set parameter value from component interface
+    component_test.set_parameter_value("name", "again", sr.ParameterType.STRING)
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "again"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "again"
+
+    # Setting it with empty value should be rejected in parameter evaluation
+    component_test.set_parameter_value("name", "", sr.ParameterType.STRING)
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "again"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "again"
+
+    # Setting a parameter with type NOT_SET, undeclares that parameter, hence the last assertion fails!
+    Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.NOT_SET, value=None)])
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET

--- a/source/modulo_components/test/python/test_component_interface_empty_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_empty_parameters.py
@@ -2,16 +2,19 @@ import pytest
 import rclpy
 import state_representation as sr
 from modulo_components.component_interface import ComponentInterface
+from modulo_components.exceptions.component_exceptions import ComponentParameterError
 from rcl_interfaces.msg import SetParametersResult
+from rclpy.exceptions import ParameterNotDeclaredException
 from rclpy.node import Node
 from rclpy.parameter import Parameter
-from rclpy.exceptions import ParameterUninitializedException
 
 
 class EmtpyParameterInterface(ComponentInterface):
-    def __init__(self, node_name, *kargs, **kwargs):
+    def __init__(self, node_name, allow_empty=True, add_parameter=True, *kargs, **kwargs):
         super().__init__(node_name, *kargs, **kwargs)
-        self.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+        self._allow_empty = allow_empty
+        if add_parameter:
+            self.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
 
     def get_ros_parameter(self, name: str) -> rclpy.Parameter:
         return rclpy.node.Node.get_parameter(self, name)
@@ -21,7 +24,9 @@ class EmtpyParameterInterface(ComponentInterface):
 
     def _validate_parameter(self, parameter: sr.Parameter) -> bool:
         if parameter.get_name() == "name":
-            if not parameter.get_value():
+            if parameter.is_empty():
+                return self._allow_empty
+            elif not parameter.get_value():
                 self.get_logger().error("Provide a non empty value for parameter 'name'")
                 return False
         return True
@@ -32,18 +37,39 @@ def component_test(ros_context):
     yield EmtpyParameterInterface("component")
 
 
+def test_not_allow_empty_on_construction(ros_context):
+    # Construction with empty parameter should raise if the empty parameter is not allowed
+    with pytest.raises(ComponentParameterError):
+        EmtpyParameterInterface("component", False)
+
+
+def test_not_allow_empty(ros_context):
+    component = EmtpyParameterInterface("component", allow_empty=False, add_parameter=False)
+    with pytest.raises(ComponentParameterError):
+        component.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+    with pytest.raises(ComponentParameterError):
+        component.get_parameter("name")
+    with pytest.raises(ParameterNotDeclaredException):
+        assert Node.get_parameter(component, "name").type_ == Parameter.Type.NOT_SET
+
+    component = EmtpyParameterInterface("component", allow_empty=True, add_parameter=False)
+    component.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+    assert component.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component.get_parameter("name").is_empty()
+    assert Node.get_parameter(component, "name").type_ == Parameter.Type.NOT_SET
+
+
 def test_validate_empty_parameter(component_test):
     # component_test comes with empty parameter 'name'
     assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
     assert component_test.get_parameter("name").is_empty()
-    with pytest.raises(ParameterUninitializedException):
-        Node.get_parameter(component_test, "name")
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
 
-    # Trying to overwrite with an empty parameter is not allowed
+    # Trying to overwrite a parameter is not possible
     component_test.add_parameter(sr.Parameter("name", sr.ParameterType.BOOL), "Test parameter")
     assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
-    with pytest.raises(ParameterUninitializedException):
-        Node.get_parameter(component_test, "name")
+    assert component_test.get_parameter("name").is_empty()
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
 
     # Set parameter with empty parameter isn't possible because there is no method for that
     # component_test.set_parameter(sr.Parameter("name", sr.ParameterType.STRING))
@@ -69,8 +95,13 @@ def test_validate_empty_parameter(component_test):
     assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
     assert Node.get_parameter(component_test, "name").value == "again"
 
-    # Setting a parameter with type NOT_SET is not possible, parameter remains unchanged
-    Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.NOT_SET, value=None)])
+    # Setting it with empty value should be rejected in parameter evaluation
+    component_test.set_parameter_value("name", "", sr.ParameterType.STRING)
+    Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.STRING, value="")])
     assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "again"
     assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
     assert Node.get_parameter(component_test, "name").value == "again"
+
+    # TODO
+    # Setting a parameter with type NOT_SET undeclares that parameter

--- a/source/modulo_core/modulo_core/translators/parameter_translators.py
+++ b/source/modulo_core/modulo_core/translators/parameter_translators.py
@@ -201,4 +201,6 @@ def read_parameter_const(ros_parameter: Parameter, parameter: sr.Parameter) -> s
                 f"The ROS parameter {ros_parameter.name} with type double array cannot be interpreted "
                 f"by reference parameter {parameter.get_name()} (type code {parameter.get_parameter_type()}")
     else:
-        raise ParameterTranslationError(f"Something went wrong while reading parameter {parameter.get_name()}")
+        raise ParameterTranslationError(
+            f"The ROS parameter has an incompatible type for component parameter '{parameter.get_name()}': "
+            f"expected {parameter.get_parameter_type().name}, got {ros_parameter.type_.name}")

--- a/source/modulo_core/modulo_core/translators/parameter_translators.py
+++ b/source/modulo_core/modulo_core/translators/parameter_translators.py
@@ -1,3 +1,4 @@
+from copy import copy
 from typing import Optional
 
 import clproto
@@ -15,7 +16,10 @@ def write_parameter(parameter: sr.Parameter) -> Parameter:
     :raises ParameterTranslationError if the parameter could not be written
     :return: The resulting ROS parameter
     """
-    if parameter.get_parameter_type() == sr.ParameterType.BOOL or \
+    if parameter.is_empty():
+        return Parameter(parameter.get_name(), value=None, type_=Parameter.Type.NOT_SET)
+    elif parameter.get_parameter_type() == sr.ParameterType.BOOL or \
+            parameter.get_parameter_type() == sr.ParameterType.BOOL_ARRAY or \
             parameter.get_parameter_type() == sr.ParameterType.INT or \
             parameter.get_parameter_type() == sr.ParameterType.DOUBLE or \
             parameter.get_parameter_type() == sr.ParameterType.STRING:
@@ -179,6 +183,8 @@ def read_parameter_const(ros_parameter: Parameter, parameter: sr.Parameter) -> s
     if ros_parameter.name != parameter.get_name():
         raise ParameterTranslationError(f"The ROS parameter {ros_parameter.name} to be read does not have "
                                         f"the same name as the reference parameter {parameter.get_name()}")
+    if ros_parameter.type_ == Parameter.Type.NOT_SET:
+        return copy(parameter)
     new_parameter = read_parameter(ros_parameter)
     if new_parameter.get_parameter_type() == parameter.get_parameter_type():
         return new_parameter

--- a/source/modulo_core/src/translators/parameter_translators.cpp
+++ b/source/modulo_core/src/translators/parameter_translators.cpp
@@ -85,6 +85,9 @@ void copy_parameter_value(
 }
 
 rclcpp::Parameter write_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) {
+  if (parameter->is_empty()) {
+    return rclcpp::Parameter(parameter->get_name());
+  }
   switch (parameter->get_parameter_type()) {
     case ParameterType::BOOL:
       return {parameter->get_name(), parameter->get_parameter_value<bool>()};
@@ -172,7 +175,8 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter(const r
           return make_shared_parameter<JointPositions>(parameter.get_name(), clproto::decode<JointPositions>(encoding));
         default:
           throw exceptions::ParameterTranslationException(
-              "Parameter " + parameter.get_name() + " has an unsupported encoded message type");
+              "Parameter " + parameter.get_name() + " has an unsupported encoded message type"
+          );
       }
     }
     case rclcpp::PARAMETER_BYTE_ARRAY:
@@ -222,7 +226,8 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
           throw exceptions::ParameterTranslationException(
               "The ROS parameter " + ros_parameter.get_name()
                   + " with type double array cannot be interpreted by reference parameter " + parameter->get_name()
-                  + " (type code " + std::to_string(static_cast<int>(parameter->get_parameter_type())) + ")");
+                  + " (type code " + std::to_string(static_cast<int>(parameter->get_parameter_type())) + ")"
+          );
       }
       break;
     }

--- a/source/modulo_core/test/cpp_tests/translators/parameters/test_parameter_translators.cpp
+++ b/source/modulo_core/test/cpp_tests/translators/parameters/test_parameter_translators.cpp
@@ -10,60 +10,38 @@ using namespace modulo_core::translators;
 
 template<typename T> using ParamT = std::vector<std::tuple<T, state_representation::ParameterType>>;
 
-static std::tuple<ParamT<bool>,
-                  ParamT<std::vector<bool>>,
-                  ParamT<int>,
-                  ParamT<std::vector<int>>,
-                  ParamT<double>,
-                  ParamT<std::vector<double>>,
-                  ParamT<std::string>,
-                  ParamT<std::vector<std::string>>> parameter_test_cases{{
-                                                                             std::make_tuple(
-                                                                                 true,
-                                                                                 state_representation::ParameterType::BOOL
-                                                                             ), std::make_tuple(
-        false, state_representation::ParameterType::BOOL
-    ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 std::vector<bool>({true, false, true}),
-                                                                                 state_representation::ParameterType::BOOL_ARRAY
-                                                                             ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 0,
-                                                                                 state_representation::ParameterType::INT
-                                                                             ), std::make_tuple(
-        1, state_representation::ParameterType::INT
-    ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 std::vector<int>({1, 2, 3}),
-                                                                                 state_representation::ParameterType::INT_ARRAY
-                                                                             ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 1.0,
-                                                                                 state_representation::ParameterType::DOUBLE
-                                                                             ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 std::vector<double>({1.0, 2.0, 3.0}),
-                                                                                 state_representation::ParameterType::DOUBLE_ARRAY
-                                                                             ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 "test",
-                                                                                 state_representation::ParameterType::STRING
-                                                                             ),
-                                                                         }, {
-                                                                             std::make_tuple(
-                                                                                 std::vector<std::string>(
-                                                                                     {"1", "2", "3"}
-                                                                                 ),
-                                                                                 state_representation::ParameterType::STRING_ARRAY
-                                                                             ),
-                                                                         },
+static std::tuple<
+    ParamT<bool>,
+    ParamT<std::vector<bool>>,
+    ParamT<int>,
+    ParamT<std::vector<int>>,
+    ParamT<double>,
+    ParamT<std::vector<double>>,
+    ParamT<std::string>,
+    ParamT<std::vector<std::string>>
+> parameter_test_cases{{
+                       std::make_tuple(true, state_representation::ParameterType::BOOL),
+                       std::make_tuple(false, state_representation::ParameterType::BOOL),
+                   }, {
+                       std::make_tuple(
+                           std::vector<bool>({true, false, true}), state_representation::ParameterType::BOOL_ARRAY),
+                   }, {
+                       std::make_tuple(0, state_representation::ParameterType::INT),
+                       std::make_tuple(1, state_representation::ParameterType::INT),
+                   }, {
+                       std::make_tuple(std::vector<int>({1, 2, 3}), state_representation::ParameterType::INT_ARRAY),
+                   }, {
+                       std::make_tuple(1.0, state_representation::ParameterType::DOUBLE),
+                   }, {
+                       std::make_tuple(
+                           std::vector<double>({1.0, 2.0, 3.0}), state_representation::ParameterType::DOUBLE_ARRAY),
+                   }, {
+                       std::make_tuple("test", state_representation::ParameterType::STRING),
+                   }, {
+                       std::make_tuple(
+                           std::vector<std::string>({"1", "2", "3"}),
+                           state_representation::ParameterType::STRING_ARRAY),
+                   },
 };
 
 template<typename T>
@@ -143,12 +121,6 @@ TYPED_TEST_P(ParameterTranslationTest, NonConstRead) {
 
 REGISTER_TYPED_TEST_SUITE_P(ParameterTranslationTest, Write, ReadAndReWrite, ConstRead, NonConstRead);
 
-using ParameterTestTypes = testing::Types<bool,
-                                          std::vector<bool>,
-                                          int,
-                                          std::vector<int>,
-                                          double,
-                                          std::vector<double>,
-                                          std::string,
-                                          std::vector<std::string>>;
+using ParameterTestTypes = testing::Types<
+    bool, std::vector<bool>, int, std::vector<int>, double, std::vector<double>, std::string, std::vector<std::string>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, ParameterTranslationTest, ParameterTestTypes);

--- a/source/modulo_core/test/cpp_tests/translators/parameters/test_parameter_translators.cpp
+++ b/source/modulo_core/test/cpp_tests/translators/parameters/test_parameter_translators.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "modulo_core/exceptions/ParameterTranslationException.hpp"
 #include "modulo_core/translators/parameter_translators.hpp"
 
 using namespace modulo_core::translators;
@@ -9,38 +10,60 @@ using namespace modulo_core::translators;
 
 template<typename T> using ParamT = std::vector<std::tuple<T, state_representation::ParameterType>>;
 
-static std::tuple<
-    ParamT<bool>,
-    ParamT<std::vector<bool>>,
-    ParamT<int>,
-    ParamT<std::vector<int>>,
-    ParamT<double>,
-    ParamT<std::vector<double>>,
-    ParamT<std::string>,
-    ParamT<std::vector<std::string>>
-> parameter_test_cases{{
-                       std::make_tuple(true, state_representation::ParameterType::BOOL),
-                       std::make_tuple(false, state_representation::ParameterType::BOOL),
-                   }, {
-                       std::make_tuple(
-                           std::vector<bool>({true, false, true}), state_representation::ParameterType::BOOL_ARRAY),
-                   }, {
-                       std::make_tuple(0, state_representation::ParameterType::INT),
-                       std::make_tuple(1, state_representation::ParameterType::INT),
-                   }, {
-                       std::make_tuple(std::vector<int>({1, 2, 3}), state_representation::ParameterType::INT_ARRAY),
-                   }, {
-                       std::make_tuple(1.0, state_representation::ParameterType::DOUBLE),
-                   }, {
-                       std::make_tuple(
-                           std::vector<double>({1.0, 2.0, 3.0}), state_representation::ParameterType::DOUBLE_ARRAY),
-                   }, {
-                       std::make_tuple("test", state_representation::ParameterType::STRING),
-                   }, {
-                       std::make_tuple(
-                           std::vector<std::string>({"1", "2", "3"}),
-                           state_representation::ParameterType::STRING_ARRAY),
-                   },
+static std::tuple<ParamT<bool>,
+                  ParamT<std::vector<bool>>,
+                  ParamT<int>,
+                  ParamT<std::vector<int>>,
+                  ParamT<double>,
+                  ParamT<std::vector<double>>,
+                  ParamT<std::string>,
+                  ParamT<std::vector<std::string>>> parameter_test_cases{{
+                                                                             std::make_tuple(
+                                                                                 true,
+                                                                                 state_representation::ParameterType::BOOL
+                                                                             ), std::make_tuple(
+        false, state_representation::ParameterType::BOOL
+    ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 std::vector<bool>({true, false, true}),
+                                                                                 state_representation::ParameterType::BOOL_ARRAY
+                                                                             ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 0,
+                                                                                 state_representation::ParameterType::INT
+                                                                             ), std::make_tuple(
+        1, state_representation::ParameterType::INT
+    ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 std::vector<int>({1, 2, 3}),
+                                                                                 state_representation::ParameterType::INT_ARRAY
+                                                                             ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 1.0,
+                                                                                 state_representation::ParameterType::DOUBLE
+                                                                             ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 std::vector<double>({1.0, 2.0, 3.0}),
+                                                                                 state_representation::ParameterType::DOUBLE_ARRAY
+                                                                             ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 "test",
+                                                                                 state_representation::ParameterType::STRING
+                                                                             ),
+                                                                         }, {
+                                                                             std::make_tuple(
+                                                                                 std::vector<std::string>(
+                                                                                     {"1", "2", "3"}
+                                                                                 ),
+                                                                                 state_representation::ParameterType::STRING_ARRAY
+                                                                             ),
+                                                                         },
 };
 
 template<typename T>
@@ -53,17 +76,22 @@ protected:
 TYPED_TEST_SUITE_P(ParameterTranslationTest);
 
 TYPED_TEST_P(ParameterTranslationTest, Write) {
-  for (auto const& test_case : this->test_cases_) {
-    auto param = state_representation::make_shared_parameter("test", std::get<0>(test_case));
+  for (auto const& test_case: this->test_cases_) {
+    auto param = std::make_shared<state_representation::Parameter<TypeParam>>("test");
     rclcpp::Parameter ros_param;
+    EXPECT_NO_THROW(ros_param = write_parameter(param));
+    EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+    param = state_representation::make_shared_parameter("test", std::get<0>(test_case));
     EXPECT_NO_THROW(ros_param = write_parameter(param));
     EXPECT_EQ(ros_param, rclcpp::Parameter("test", std::get<0>(test_case)));
   }
 }
 
 TYPED_TEST_P(ParameterTranslationTest, ReadAndReWrite) {
+  auto ros_param = rclcpp::Parameter("test");
+  EXPECT_THROW(read_parameter(ros_param), modulo_core::exceptions::ParameterTranslationException);
   for (auto const& [value, type]: this->test_cases_) {
-    auto ros_param = rclcpp::Parameter("test", value);
+    ros_param = rclcpp::Parameter("test", value);
     std::shared_ptr<state_representation::ParameterInterface> param;
     ASSERT_NO_THROW(param = read_parameter(ros_param));
     EXPECT_EQ(param->get_name(), ros_param.get_name());
@@ -115,6 +143,12 @@ TYPED_TEST_P(ParameterTranslationTest, NonConstRead) {
 
 REGISTER_TYPED_TEST_SUITE_P(ParameterTranslationTest, Write, ReadAndReWrite, ConstRead, NonConstRead);
 
-using ParameterTestTypes = testing::Types<
-    bool, std::vector<bool>, int, std::vector<int>, double, std::vector<double>, std::string, std::vector<std::string>>;
+using ParameterTestTypes = testing::Types<bool,
+                                          std::vector<bool>,
+                                          int,
+                                          std::vector<int>,
+                                          double,
+                                          std::vector<double>,
+                                          std::string,
+                                          std::vector<std::string>>;
 INSTANTIATE_TYPED_TEST_SUITE_P(TestPrefix, ParameterTranslationTest, ParameterTestTypes);


### PR DESCRIPTION
Ok wow that was painful. So far, it was not possible to create ROS parameters from an empty state rep parameter. One idea was to do that: 
```
if sr_parameter.is_empty():
    self.declare_parameter(ros_param.name, None,
                           descriptor=ParameterDescriptor(description=description,
                                                          type=Parameter.Type.DOUBLE_ARRAY))
```
This however, does not actually create an uninitialized ROS parameter of type double array, but a ROS parameter of type `NOT_SET`. Which means that next time we want to set that parameter in the on_set_parameter_callback, it will be incompatible. So the solution is that:
```
if sr_parameter.is_empty():
    self.declare_parameter(ros_param.name, None,
                           descriptor=ParameterDescriptor(description=description,
                                                          type=Parameter.Type.NOT_SET.value,
                                                          dynamic_typing=True))
```
We declare the parameter with type NOT_SET and allow dynamic_typing. Now you might say, no wait we dont want dynamic typing. Well it's really only dynamically typed until its set for the first time because every following time that we want to modify the parameter, we are checking that the types correspond, so we are good. This behaviour should be illustrated in the test. We can discuss if thats not what we want.