### PR TITLE
Improve exception handling in modulo_core

### DIFF
--- a/source/modulo_core/include/modulo_core/communication/MessagePair.hpp
+++ b/source/modulo_core/include/modulo_core/communication/MessagePair.hpp
@@ -30,6 +30,7 @@ public:
    * @brief Write the value of the data pointer to a ROS message.
    * @return The value of the data pointer as a ROS message
    * @throws NullPointerException if the data pointer is null
+   * @throws MessageTranslationException if the data could not be written to message
    */
   [[nodiscard]] MsgT write_message() const;
 
@@ -37,6 +38,7 @@ public:
    * @brief Read a ROS message and store the value in the data pointer.
    * @param message The ROS message to read
    * @throws NullPointerException if the data pointer is null
+   * @throws MessageTranslationException if the message could not be read
    */
   void read_message(const MsgT& message);
 

--- a/source/modulo_core/include/modulo_core/exceptions/CoreException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/CoreException.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace modulo_core::exceptions {
+
+/**
+ * @class CoreException
+ * @brief A base class for all core exceptions.
+ * @details This inherits from std::runtime_exception.
+ */
+class CoreException : public std::runtime_error {
+public:
+  explicit CoreException(const std::string& msg) : std::runtime_error(msg) {};
+};
+}// namespace modulo_core::exceptions

--- a/source/modulo_core/include/modulo_core/exceptions/IncompatibleParameterException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/IncompatibleParameterException.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <state_representation/exceptions/InvalidParameterException.hpp>
+#include "modulo_core/exceptions/CoreException.hpp"
 
 namespace modulo_core::exceptions {
 
@@ -10,9 +10,10 @@ namespace modulo_core::exceptions {
  * @details This is an exception class to be thrown if there is a problem while translating from a ROS parameter to a
  * state_representation parameter and vice versa.
  */
-class IncompatibleParameterException : public state_representation::exceptions::InvalidParameterException {
+class IncompatibleParameterException : public CoreException {
 public:
-  explicit IncompatibleParameterException(const std::string& msg) :
-      state_representation::exceptions::InvalidParameterException(msg) {};
+  explicit IncompatibleParameterException(const std::string& msg) : CoreException(msg) {};
 };
 }// namespace modulo_core::exceptions
+
+

--- a/source/modulo_core/include/modulo_core/exceptions/InvalidPointerCastException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/InvalidPointerCastException.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <stdexcept>
-#include <string>
+#include "modulo_core/exceptions/CoreException.hpp"
 
 namespace modulo_core::exceptions {
 
@@ -10,8 +9,10 @@ namespace modulo_core::exceptions {
  * @brief An exception class to notify if the result of getting an instance of a derived class through dynamic
  * down-casting of an object of the base class is not a correctly typed instance of the derived class.
  */
-class InvalidPointerCastException : public std::runtime_error {
+class InvalidPointerCastException : public CoreException {
 public:
-  explicit InvalidPointerCastException(const std::string& msg) : std::runtime_error(msg) {};
+  explicit InvalidPointerCastException(const std::string& msg) : CoreException(msg) {};
 };
 }// namespace modulo_core::exceptions
+
+

--- a/source/modulo_core/include/modulo_core/exceptions/InvalidPointerException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/InvalidPointerException.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <stdexcept>
-#include <string>
+#include "modulo_core/exceptions/CoreException.hpp"
 
 namespace modulo_core::exceptions {
 
@@ -10,8 +9,9 @@ namespace modulo_core::exceptions {
  * @brief An exception class to notify if an object has no reference count (if the object is not owned by any pointer)
  * when attempting to get a derived instance through dynamic down-casting.
  */
-class InvalidPointerException : public std::runtime_error {
+class InvalidPointerException : public CoreException {
 public:
-  explicit InvalidPointerException(const std::string& msg) : std::runtime_error(msg) {};
+  explicit InvalidPointerException(const std::string& msg) : CoreException(msg) {};
 };
 }// namespace modulo_core::exceptions
+

--- a/source/modulo_core/include/modulo_core/exceptions/MessageTranslationException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/MessageTranslationException.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "modulo_core/exceptions/CoreException.hpp"
+
+namespace modulo_core::exceptions {
+
+/**
+ * @class MessageTranslationException
+ * @brief An exception class to notify that the translation of a ROS message failed.
+ */
+class MessageTranslationException : public CoreException {
+public:
+  explicit MessageTranslationException(const std::string& msg) : CoreException(msg) {};
+};
+}// namespace modulo_core::exceptions
+
+

--- a/source/modulo_core/include/modulo_core/exceptions/NullPointerException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/NullPointerException.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <stdexcept>
-#include <string>
+#include "modulo_core/exceptions/CoreException.hpp"
 
 namespace modulo_core::exceptions {
 
@@ -10,8 +9,9 @@ namespace modulo_core::exceptions {
  * @brief An exception class to notify that a certain pointer is null.
  * @details This is an exception class to be thrown if a pointer is null or is trying to be set to a null pointer.
  */
-class NullPointerException : public std::runtime_error {
+class NullPointerException : public CoreException {
 public:
-  explicit NullPointerException(const std::string& msg) : std::runtime_error(msg) {};
+  explicit NullPointerException(const std::string& msg) : CoreException(msg) {};
 };
 }// namespace modulo_core::exceptions
+

--- a/source/modulo_core/include/modulo_core/exceptions/ParameterTranslationException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/ParameterTranslationException.hpp
@@ -10,9 +10,9 @@ namespace modulo_core::exceptions {
  * @details This is an exception class to be thrown if there is a problem while translating from a ROS parameter to a
  * state_representation parameter and vice versa.
  */
-class IncompatibleParameterException : public CoreException {
+class ParameterTranslationException : public CoreException {
 public:
-  explicit IncompatibleParameterException(const std::string& msg) : CoreException(msg) {};
+  explicit ParameterTranslationException(const std::string& msg) : CoreException(msg) {};
 };
 }// namespace modulo_core::exceptions
 

--- a/source/modulo_core/include/modulo_core/translators/message_writers.hpp
+++ b/source/modulo_core/include/modulo_core/translators/message_writers.hpp
@@ -20,6 +20,7 @@
 #include <state_representation/parameters/Parameter.hpp>
 
 #include "modulo_core/EncodedState.hpp"
+#include "modulo_core/exceptions/MessageTranslationException.hpp"
 
 namespace modulo_core::translators {
 
@@ -28,6 +29,7 @@ namespace modulo_core::translators {
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::Accel& message, const state_representation::CartesianState& state, const rclcpp::Time& time
@@ -38,6 +40,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::AccelStamped& message, const state_representation::CartesianState& state,
@@ -49,6 +52,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::Pose& message, const state_representation::CartesianState& state, const rclcpp::Time& time
@@ -59,6 +63,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::PoseStamped& message, const state_representation::CartesianState& state,
@@ -70,6 +75,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::Transform& message, const state_representation::CartesianState& state, const rclcpp::Time& time
@@ -80,6 +86,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::TransformStamped& message, const state_representation::CartesianState& state,
@@ -91,6 +98,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::Twist& message, const state_representation::CartesianState& state, const rclcpp::Time& time
@@ -101,6 +109,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::TwistStamped& message, const state_representation::CartesianState& state,
@@ -112,6 +121,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::Wrench& message, const state_representation::CartesianState& state, const rclcpp::Time& time
@@ -122,6 +132,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     geometry_msgs::msg::WrenchStamped& message, const state_representation::CartesianState& state,
@@ -133,6 +144,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     sensor_msgs::msg::JointState& message, const state_representation::JointState& state, const rclcpp::Time& time
@@ -143,6 +155,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 void write_message(
     tf2_msgs::msg::TFMessage& message, const state_representation::CartesianState& state, const rclcpp::Time& time
@@ -155,6 +168,7 @@ void write_message(
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the provided state is empty.
  */
 template<typename U, typename T>
 void write_message(U& message, const state_representation::Parameter<T>& state, const rclcpp::Time&);
@@ -206,10 +220,15 @@ void write_message(std_msgs::msg::String& message, const std::string& state, con
  * @param message The ROS message to populate
  * @param state The state to read from
  * @param time The time of the message
+ * @throws MessageTranslationException if the translation failed or is not supported.
  */
 template<typename T>
 inline void write_message(EncodedState& message, const T& state, const rclcpp::Time&) {
-  std::string tmp = clproto::encode<T>(state);
-  message.data = std::vector<unsigned char>(tmp.begin(), tmp.end());
+  try {
+    std::string tmp = clproto::encode<T>(state);
+    message.data = std::vector<unsigned char>(tmp.begin(), tmp.end());
+  } catch (const std::exception& ex) {
+    throw exceptions::MessageTranslationException(ex.what());
+  }
 }
 }// namespace modulo_core::translators

--- a/source/modulo_core/include/modulo_core/translators/parameter_translators.hpp
+++ b/source/modulo_core/include/modulo_core/translators/parameter_translators.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/parameter.hpp>
 #include <state_representation/parameters/Parameter.hpp>
 
 namespace modulo_core::translators {
@@ -14,7 +14,7 @@ namespace modulo_core::translators {
  * to modify the value of the parameter instance while preserving the reference of the original pointer.
  * @param source_parameter The ParameterInterface with a value to copy
  * @param parameter The destination ParameterInterface to be updated
- * @throws IncompatibleParameterException if the copying failed
+ * @throws ParameterTranslationException if the copying failed
  */
 void copy_parameter_value(
     const std::shared_ptr<const state_representation::ParameterInterface>& source_parameter,
@@ -24,7 +24,7 @@ void copy_parameter_value(
 /**
  * @brief Write a ROS Parameter from a ParameterInterface pointer.
  * @param parameter The ParameterInterface pointer with a name and value
- * @throws IncompatibleParameterException if the ROS parameter could not be written
+ * @throws ParameterTranslationException if the ROS parameter could not be written
  * @return A new ROS Parameter object
  */
 rclcpp::Parameter write_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter);
@@ -32,7 +32,7 @@ rclcpp::Parameter write_parameter(const std::shared_ptr<state_representation::Pa
 /**
  * @brief Create a new ParameterInterface from a ROS Parameter object.
  * @param ros_parameter The ROS parameter object to read
- * @throws IncompatibleParameterException if the ROS parameter could not be read
+ * @throws ParameterTranslationException if the ROS parameter could not be read
  * @return A new ParameterInterface pointer
  */
 std::shared_ptr<state_representation::ParameterInterface> read_parameter(const rclcpp::Parameter& ros_parameter);
@@ -42,7 +42,7 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter(const r
  * the same name and the ROS Parameter value can be interpreted as a ParameterInterface value.
  * @param ros_parameter The ROS parameter object to read
  * @param parameter An existing ParameterInterface pointer
- * @throws IncompatibleParameterException if the ROS parameter could not be read
+ * @throws ParameterTranslationException if the ROS parameter could not be read
  * @return A new ParameterInterface pointer with the updated value
  */
 std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
@@ -55,7 +55,7 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
  * @details The destination ParameterInterface must have a compatible parameter name and type.
  * @param ros_parameter The ROS parameter object to read
  * @param parameter An existing ParameterInterface pointer
- * @throws IncompatibleParameterException if the ROS parameter could not be read
+ * @throws ParameterTranslationException if the ROS parameter could not be read
  */
 void read_parameter(
     const rclcpp::Parameter& ros_parameter, const std::shared_ptr<state_representation::ParameterInterface>& parameter

--- a/source/modulo_core/modulo_core/exceptions/core_exceptions.py
+++ b/source/modulo_core/modulo_core/exceptions/core_exceptions.py
@@ -1,0 +1,27 @@
+class CoreError(Exception):
+    """
+    A base class for all core exceptions.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class MessageTranslationError(CoreError):
+    """
+    An exception class to notify that the translation of a ROS message failed.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class ParameterTranslationError(CoreError):
+    """
+    An exception class to notify incompatibility when translating parameters from different sources. This is an
+    exception class to be thrown if there is a problem while translating from a ROS parameter to a state_representation
+    parameter and vice versa.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/source/modulo_core/src/translators/message_readers.cpp
+++ b/source/modulo_core/src/translators/message_readers.cpp
@@ -66,15 +66,19 @@ void read_message(state_representation::CartesianState& state, const geometry_ms
 }
 
 void read_message(state_representation::JointState& state, const sensor_msgs::msg::JointState& message) {
-  state.set_names(message.name);
-  if (!message.position.empty()) {
-    state.set_positions(Eigen::VectorXd::Map(message.position.data(), message.position.size()));
-  }
-  if (!message.velocity.empty()) {
-    state.set_velocities(Eigen::VectorXd::Map(message.velocity.data(), message.velocity.size()));
-  }
-  if (!message.effort.empty()) {
-    state.set_torques(Eigen::VectorXd::Map(message.effort.data(), message.effort.size()));
+  try {
+    state.set_names(message.name);
+    if (!message.position.empty()) {
+      state.set_positions(Eigen::VectorXd::Map(message.position.data(), message.position.size()));
+    }
+    if (!message.velocity.empty()) {
+      state.set_velocities(Eigen::VectorXd::Map(message.velocity.data(), message.velocity.size()));
+    }
+    if (!message.effort.empty()) {
+      state.set_torques(Eigen::VectorXd::Map(message.effort.data(), message.effort.size()));
+    }
+  } catch (const std::exception& ex) {
+    throw exceptions::MessageTranslationException(ex.what());
   }
 }
 

--- a/source/modulo_core/src/translators/message_writers.cpp
+++ b/source/modulo_core/src/translators/message_writers.cpp
@@ -1,6 +1,5 @@
 #include "modulo_core/translators/message_writers.hpp"
 
-#include <state_representation/exceptions/EmptyStateException.hpp>
 #include <state_representation/space/cartesian/CartesianPose.hpp>
 
 using namespace state_representation;
@@ -28,7 +27,9 @@ static void write_quaternion(geometry_msgs::msg::Quaternion& message, const Eige
 
 void write_message(geometry_msgs::msg::Accel& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   write_vector3(message.linear, state.get_linear_acceleration());
   write_vector3(message.angular, state.get_angular_acceleration());
@@ -42,7 +43,9 @@ void write_message(geometry_msgs::msg::AccelStamped& message, const CartesianSta
 
 void write_message(geometry_msgs::msg::Pose& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   write_point(message.position, state.get_position());
   write_quaternion(message.orientation, state.get_orientation());
@@ -56,7 +59,9 @@ void write_message(geometry_msgs::msg::PoseStamped& message, const CartesianStat
 
 void write_message(geometry_msgs::msg::Transform& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   write_vector3(message.translation, state.get_position());
   write_quaternion(message.rotation, state.get_orientation());
@@ -72,7 +77,9 @@ write_message(geometry_msgs::msg::TransformStamped& message, const CartesianStat
 
 void write_message(geometry_msgs::msg::Twist& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   write_vector3(message.linear, state.get_linear_velocity());
   write_vector3(message.angular, state.get_angular_velocity());
@@ -86,7 +93,9 @@ void write_message(geometry_msgs::msg::TwistStamped& message, const CartesianSta
 
 void write_message(geometry_msgs::msg::Wrench& message, const CartesianState& state, const rclcpp::Time&) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   write_vector3(message.force, state.get_force());
   write_vector3(message.torque, state.get_torque());
@@ -100,7 +109,9 @@ void write_message(geometry_msgs::msg::WrenchStamped& message, const CartesianSt
 
 void write_message(sensor_msgs::msg::JointState& message, const JointState& state, const rclcpp::Time& time) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   message.header.stamp = time;
   message.name = state.get_names();
@@ -114,7 +125,9 @@ void write_message(sensor_msgs::msg::JointState& message, const JointState& stat
 
 void write_message(tf2_msgs::msg::TFMessage& message, const CartesianState& state, const rclcpp::Time& time) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   geometry_msgs::msg::TransformStamped transform;
   write_message(transform, state, time);
@@ -124,7 +137,9 @@ void write_message(tf2_msgs::msg::TFMessage& message, const CartesianState& stat
 template<typename U, typename T>
 void write_message(U& message, const Parameter<T>& state, const rclcpp::Time&) {
   if (state.is_empty()) {
-    throw exceptions::EmptyStateException(state.get_name() + " state is empty while attempting to publish it");
+    throw exceptions::MessageTranslationException(
+        state.get_name() + " state is empty while attempting to write it to message"
+    );
   }
   message.data = state.get_value();
 }

--- a/source/modulo_core/src/translators/parameter_translators.cpp
+++ b/source/modulo_core/src/translators/parameter_translators.cpp
@@ -6,7 +6,7 @@
 #include <state_representation/space/joint/JointPositions.hpp>
 #include <state_representation/space/joint/JointState.hpp>
 
-#include "modulo_core/exceptions/IncompatibleParameterException.hpp"
+#include "modulo_core/exceptions/ParameterTranslationException.hpp"
 
 using namespace state_representation;
 
@@ -17,7 +17,7 @@ void copy_parameter_value(
     const std::shared_ptr<ParameterInterface>& parameter
 ) {
   if (source_parameter->get_parameter_type() != parameter->get_parameter_type()) {
-    throw exceptions::IncompatibleParameterException(
+    throw exceptions::ParameterTranslationException(
         "Source parameter " + source_parameter->get_name()
             + " to be copied does not have the same type as destination parameter " + parameter->get_name());
   }
@@ -54,7 +54,7 @@ void copy_parameter_value(
       return;
     case ParameterType::STATE:
       if (source_parameter->get_parameter_state_type() != parameter->get_parameter_state_type()) {
-        throw exceptions::IncompatibleParameterException(
+        throw exceptions::ParameterTranslationException(
             "Source parameter " + source_parameter->get_name()
                 + " to be copied does not have the same parameter state type as destination parameter "
                 + parameter->get_name());
@@ -79,7 +79,7 @@ void copy_parameter_value(
     default:
       break;
   }
-  throw InvalidParameterException(
+  throw exceptions::ParameterTranslationException(
       "Could not copy the value from source parameter " + source_parameter->get_name() + " into parameter "
           + parameter->get_name());
 }
@@ -130,7 +130,7 @@ rclcpp::Parameter write_parameter(const std::shared_ptr<state_representation::Pa
     default:
       break;
   }
-  throw InvalidParameterException("Parameter " + parameter->get_name() + " could not be written!");
+  throw exceptions::ParameterTranslationException("Parameter " + parameter->get_name() + " could not be written!");
 }
 
 std::shared_ptr<state_representation::ParameterInterface> read_parameter(const rclcpp::Parameter& parameter) {
@@ -171,17 +171,17 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter(const r
         case clproto::JOINT_POSITIONS_MESSAGE:
           return make_shared_parameter<JointPositions>(parameter.get_name(), clproto::decode<JointPositions>(encoding));
         default:
-          throw InvalidParameterException(
+          throw exceptions::ParameterTranslationException(
               "Parameter " + parameter.get_name() + " has an unsupported encoded message type");
       }
     }
     case rclcpp::PARAMETER_BYTE_ARRAY:
       // TODO: try clproto decode, re-use logic from above
-      throw InvalidParameterException("Parameter byte arrays are not currently supported.");
+      throw exceptions::ParameterTranslationException("Parameter byte arrays are not currently supported.");
     default:
       break;
   }
-  throw InvalidParameterException("Parameter " + parameter.get_name() + " could not be read!");
+  throw exceptions::ParameterTranslationException("Parameter " + parameter.get_name() + " could not be read!");
 }
 
 std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
@@ -189,7 +189,7 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
     const std::shared_ptr<const state_representation::ParameterInterface>& parameter
 ) {
   if (ros_parameter.get_name() != parameter->get_name()) {
-    throw exceptions::IncompatibleParameterException(
+    throw exceptions::ParameterTranslationException(
         "The ROS parameter " + ros_parameter.get_name()
             + " to be read does not have the same name as the reference parameter " + parameter->get_name());
   }
@@ -209,7 +209,7 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
         case ParameterType::MATRIX: {
           auto matrix = parameter->get_parameter_value<Eigen::MatrixXd>();
           if (static_cast<std::size_t>(matrix.size()) != value.size()) {
-            throw exceptions::IncompatibleParameterException(
+            throw exceptions::ParameterTranslationException(
                 "The ROS parameter " + ros_parameter.get_name() + " with type double array has size "
                     + std::to_string(value.size()) + " while the reference parameter matrix " + parameter->get_name()
                     + " has size " + std::to_string(matrix.size()));
@@ -219,7 +219,7 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
           break;
         }
         default:
-          throw exceptions::IncompatibleParameterException(
+          throw exceptions::ParameterTranslationException(
               "The ROS parameter " + ros_parameter.get_name()
                   + " with type double array cannot be interpreted by reference parameter " + parameter->get_name()
                   + " (type code " + std::to_string(static_cast<int>(parameter->get_parameter_type())) + ")");
@@ -227,7 +227,7 @@ std::shared_ptr<state_representation::ParameterInterface> read_parameter_const(
       break;
     }
     default:
-      throw state_representation::exceptions::InvalidParameterException(
+      throw exceptions::ParameterTranslationException(
           "Something went wrong while reading parameter " + parameter->get_name());
   }
   return new_parameter;

--- a/source/modulo_core/test/cpp_tests/translators/test_messages.cpp
+++ b/source/modulo_core/test/cpp_tests/translators/test_messages.cpp
@@ -55,7 +55,7 @@ TEST_F(MessageTranslatorsTest, TestAccel) {
   expect_vector_equal(state_.get_angular_acceleration(), accel.angular);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_message(accel, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  EXPECT_THROW(write_message(accel, new_state, clock_.now()), modulo_core::exceptions::MessageTranslationException);
   read_message(new_state, accel);
   EXPECT_TRUE(new_state.get_acceleration().isApprox(state_.get_acceleration()));
 
@@ -77,7 +77,7 @@ TEST_F(MessageTranslatorsTest, TestPose) {
   expect_quaternion_equal(state_.get_orientation(), pose.orientation);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_message(pose, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  EXPECT_THROW(write_message(pose, new_state, clock_.now()), modulo_core::exceptions::MessageTranslationException);
   read_message(new_state, pose);
   EXPECT_TRUE(new_state.get_pose().isApprox(state_.get_pose()));
 
@@ -99,7 +99,7 @@ TEST_F(MessageTranslatorsTest, TestTransform) {
   expect_quaternion_equal(state_.get_orientation(), tf.rotation);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_message(tf, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  EXPECT_THROW(write_message(tf, new_state, clock_.now()), modulo_core::exceptions::MessageTranslationException);
   read_message(new_state, tf);
   EXPECT_TRUE(new_state.get_pose().isApprox(state_.get_pose()));
 
@@ -123,7 +123,7 @@ TEST_F(MessageTranslatorsTest, TestTwist) {
   expect_vector_equal(state_.get_angular_velocity(), twist.angular);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_message(twist, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  EXPECT_THROW(write_message(twist, new_state, clock_.now()), modulo_core::exceptions::MessageTranslationException);
   read_message(new_state, twist);
   EXPECT_TRUE(new_state.get_twist().isApprox(state_.get_twist()));
 
@@ -145,7 +145,7 @@ TEST_F(MessageTranslatorsTest, TestWrench) {
   expect_vector_equal(state_.get_torque(), wrench.torque);
 
   state_representation::CartesianState new_state("new");
-  EXPECT_THROW(write_message(wrench, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  EXPECT_THROW(write_message(wrench, new_state, clock_.now()), modulo_core::exceptions::MessageTranslationException);
   read_message(new_state, wrench);
   EXPECT_TRUE(new_state.get_wrench().isApprox(state_.get_wrench()));
 
@@ -171,7 +171,7 @@ TEST_F(MessageTranslatorsTest, TestJointState) {
   }
 
   auto new_state = state_representation::JointState("test", {"1", "2", "3"});
-  EXPECT_THROW(write_message(message, new_state, clock_.now()), state_representation::exceptions::EmptyStateException);
+  EXPECT_THROW(write_message(message, new_state, clock_.now()), modulo_core::exceptions::MessageTranslationException);
   read_message(new_state, message);
   EXPECT_TRUE(new_state.get_positions().isApprox(joint_state_.get_positions()));
   EXPECT_TRUE(new_state.get_velocities().isApprox(joint_state_.get_velocities()));

--- a/source/modulo_core/test/python_tests/translators/test_messages.py
+++ b/source/modulo_core/test/python_tests/translators/test_messages.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import state_representation as sr
 from modulo_core.encoded_state import EncodedState
+from modulo_core.exceptions.core_exceptions import MessageTranslationError
 from rclpy.clock import Clock
 from sensor_msgs.msg import JointState
 
@@ -32,7 +33,7 @@ def test_accel(cart_state: sr.CartesianState, clock: Clock):
     assert_np_array_equal(read_xyz(message.angular), cart_state.get_angular_acceleration())
 
     new_state = sr.CartesianState("new")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MessageTranslationError):
         modulo_writers.write_message(new_state, message)
     modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_acceleration(), new_state.get_acceleration())
@@ -55,7 +56,7 @@ def test_pose(cart_state: sr.CartesianState, clock: Clock):
     assert_np_array_equal(read_quaternion(message.orientation), cart_state.get_orientation_coefficients())
 
     new_state = sr.CartesianState("new")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MessageTranslationError):
         modulo_writers.write_message(new_state, message)
     modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_pose(), new_state.get_pose())
@@ -78,7 +79,7 @@ def test_transform(cart_state: sr.CartesianState, clock: Clock):
     assert_np_array_equal(read_quaternion(message.rotation), cart_state.get_orientation_coefficients())
 
     new_state = sr.CartesianState("new")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MessageTranslationError):
         modulo_writers.write_message(new_state, message)
     modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_pose(), new_state.get_pose())
@@ -103,7 +104,7 @@ def test_twist(cart_state: sr.CartesianState, clock: Clock):
     assert_np_array_equal(read_xyz(message.angular), cart_state.get_angular_velocity())
 
     new_state = sr.CartesianState("new")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MessageTranslationError):
         modulo_writers.write_message(new_state, message)
     modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_twist(), new_state.get_twist())
@@ -126,7 +127,7 @@ def test_wrench(cart_state: sr.CartesianState, clock: Clock):
     assert_np_array_equal(read_xyz(message.torque), cart_state.get_torque())
 
     new_state = sr.CartesianState("new")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MessageTranslationError):
         modulo_writers.write_message(new_state, message)
     modulo_readers.read_message(new_state, message)
     assert_np_array_equal(cart_state.get_wrench(), new_state.get_wrench())
@@ -152,7 +153,7 @@ def test_joint_state(joint_state: sr.JointState):
     assert_np_array_equal(message.effort, joint_state.get_torques())
 
     new_state = sr.JointState("test", ["1", "2", "3"])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MessageTranslationError):
         modulo_writers.write_message(new_state, message)
     modulo_readers.read_message(new_state, message)
     for i in range(joint_state.get_size()):


### PR DESCRIPTION
In order to improve the exception handling in modulo core and components, I'm adding here in a first step a `CoreException` from which all exceptions in modulo core inherit. This means all known and handled exceptions throw the same base exception class and can be handled more easily on a higher level (in modulo components). I'm doing this in C++ and Python.

Two slight changes in the code logic:
- Catch the obvious exception that can happen when translating a joint state message of a certain size to a state rep JointState of different size
- put the clproto encoding and decoding into a try catch block as well and throw a MessageTranslationException in the message translators