### PR TITLE
Don't run image build on push on develop

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - develop
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
We have an action that builds and pushes a modulo image if develop or main have new commits but the action does not differentiate between main and develop, hence on push on develop we'll always have a workflow that fails until main is building properly again. I propose to remove develop from that action, also because we don't need to rebuild an image that we are never actually using on each push to develop.