### PR TITLE
Handle empty parameters in ComponentInterface

### DIFF
--- a/source/modulo_components/CMakeLists.txt
+++ b/source/modulo_components/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 6.0.2 REQUIRED COMPONENTS state_representation)
+find_package(control_libraries 6.0.6 REQUIRED COMPONENTS state_representation)
 find_package(clproto 6.0.0 REQUIRED)
 
 include_directories(include)

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -408,14 +408,15 @@ inline void ComponentInterface<NodeT>::add_parameter(
       descriptor.description = description;
       descriptor.read_only = read_only;
       if (parameter->is_empty()) {
+        descriptor.dynamic_typing = true;
+        descriptor.type = modulo_core::translators::get_ros_parameter_type(parameter->get_parameter_type());
+        NodeT::declare_parameter(parameter->get_name(), rclcpp::ParameterValue{}, descriptor);
         if (!this->validate_parameter(parameter)) {
+          NodeT::undeclare_parameter(parameter->get_name());
           throw exceptions::ComponentParameterException(
               "Validation of parameter '" + parameter->get_name() + "' returned false!"
           );
         }
-        descriptor.dynamic_typing = true;
-        descriptor.type = modulo_core::translators::get_ros_parameter_type(parameter->get_parameter_type());
-        NodeT::declare_parameter(parameter->get_name(), rclcpp::ParameterValue{}, descriptor);
       } else {
         NodeT::declare_parameter(parameter->get_name(), ros_param.get_parameter_value(), descriptor);
       }

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -476,9 +476,9 @@ ComponentInterface<NodeT>::on_set_parameters_callback(const std::vector<rclcpp::
 
       // convert the ROS parameter into a ParameterInterface without modifying the original
       auto new_parameter = modulo_core::translators::read_parameter_const(ros_parameter, parameter);
-      if (!validate_parameter(new_parameter)) {
+      if (!this->validate_parameter(new_parameter)) {
         result.successful = false;
-        result.reason += "Parameter " + ros_parameter.get_name() + " could not be set! ";
+        result.reason += "Validation of parameter '" + ros_parameter.get_name() + "' returned false!";
       } else {
         // update the value of the parameter in the map
         modulo_core::translators::copy_parameter_value(new_parameter, parameter);

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -32,29 +32,9 @@ class ComponentInterface(Node):
     """
     Abstract class to represent a Component in python, following the same logic pattern  as the C++
     modulo_component::ComponentInterface class.
-    ...
-    # TODO class docstring and attributes
-    Attributes:
-        predicates (dict(Parameters(bool))): map of predicates added to the Component.
-        predicate_publishers (dict(rclpy.Publisher(Bool))): map of publishers associated to each predicate.
-        parameter_dict (dict(Publisher)): dict of parameters
-        periodic_callbacks (dict(Callable): dict of periodic callback functions
-        qos (rclpy.qos.QoSProfile: the Quality of Service for publishers and subscribers
-        inputs: dict of inputs
-        outputs: dict of output
-        tf_buffer (tf2_ros.Buffer): the buffer to lookup transforms published on tf2.
-        tf_listener (tf2_ros.TransformListener): the listener to lookup transforms published on tf2.
-        tf_broadcaster (tf2_ros.TransformBroadcaster): the broadcaster to publish transforms on tf2
-    Parameters:
-        period (double): period (in s) between step function calls.
     """
 
     def __init__(self, node_name: str, *kargs, **kwargs):
-        """
-        Constructs all the necessary attributes and declare all the parameters.
-            Parameters:
-                node_name (str): name of the node to be passed to the base Node class
-        """
         super().__init__(node_name, *kargs, **kwargs)
         self._parameter_dict: Dict[str, Union[str, sr.Parameter]] = {}
         self._predicates: Dict[str, Union[bool, Callable[[], bool]]] = {}
@@ -221,7 +201,7 @@ class ComponentInterface(Node):
                 new_parameter = read_parameter_const(ros_param, parameter)
                 if not self._validate_parameter(new_parameter):
                     result.successful = False
-                    result.reason = f"Parameter {ros_param.name} could not be set!"
+                    result.reason = f"Validation of parameter '{ros_param.name}' returned false!"
                 else:
                     if isinstance(self._parameter_dict[ros_param.name], str):
                         self.__setattr__(self._parameter_dict[ros_param.name], new_parameter)

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -11,7 +11,8 @@ from modulo_components.exceptions.component_exceptions import AddSignalError, Co
     LookupTransformError
 from modulo_components.utilities.utilities import generate_predicate_topic, parse_signal_name
 from modulo_core.encoded_state import EncodedState
-from modulo_core.translators.parameter_translators import write_parameter, read_parameter_const
+from modulo_core.exceptions.core_exceptions import ParameterTranslationError
+from modulo_core.translators.parameter_translators import get_ros_parameter_type, read_parameter_const, write_parameter
 from rcl_interfaces.msg import ParameterDescriptor, SetParametersResult
 from rclpy.duration import Duration
 from rclpy.node import Node
@@ -92,6 +93,7 @@ class ComponentInterface(Node):
         :param parameter: Either the name of the parameter attribute or the parameter itself
         :param description: The parameter description
         :param read_only: If True, the value of the parameter cannot be changed after declaration
+        :raises ComponentParameterError if the parameter could not be added
         """
         try:
             if isinstance(parameter, sr.Parameter):
@@ -107,18 +109,24 @@ class ComponentInterface(Node):
                 raise TypeError("Provide either a state_representation.Parameter object or a string "
                                 "containing the name of the attribute that refers to the parameter to add.")
             ros_param = write_parameter(sr_parameter)
-            if not self.has_parameter(sr_parameter.get_name()):
-                self.get_logger().debug(f"Adding parameter '{sr_parameter.get_name()}'.")
-                self._parameter_dict[sr_parameter.get_name()] = parameter
-                # TODO ignore override
-                self.declare_parameter(ros_param.name, ros_param.value,
-                                       descriptor=ParameterDescriptor(description=description),
-                                       ignore_override=read_only)
-            else:
-                self.get_logger().warn(f"Parameter '{sr_parameter.get_name()}' already exists, overwriting.")
-                self.set_parameters([ros_param])
-        except Exception as e:
-            self.get_logger().error(f"Failed to add parameter: {e}")
+        except (TypeError, ParameterTranslationError) as e:
+            raise ComponentParameterError(f"Failed to add parameter: {e}")
+        if not self.has_parameter(sr_parameter.get_name()):
+            self.get_logger().debug(f"Adding parameter '{sr_parameter.get_name()}'.")
+            self._parameter_dict[sr_parameter.get_name()] = parameter
+            try:
+                descriptor = ParameterDescriptor(description=description, read_only=read_only)
+                if sr_parameter.is_empty():
+                    descriptor.dynamic_typing = True
+                    descriptor.type = get_ros_parameter_type(sr_parameter.get_parameter_type()).value
+                    self.declare_parameter(ros_param.name, None, descriptor=descriptor)
+                else:
+                    self.declare_parameter(ros_param.name, ros_param.value, descriptor=descriptor)
+            except Exception as e:
+                del self._parameter_dict[sr_parameter.get_name()]
+                raise ComponentParameterError(f"Failed to add parameter: {e}")
+        else:
+            self.get_logger().warn(f"Parameter '{sr_parameter.get_name()}' already exists.")
 
     def get_parameter(self, name: str) -> Union[sr.Parameter, Parameter]:
         """

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -12,8 +12,9 @@ template<class NodeT>
 class ComponentInterfacePublicInterface : public ComponentInterface<NodeT> {
 public:
   explicit ComponentInterfacePublicInterface(
-      const rclcpp::NodeOptions& node_options, modulo_core::communication::PublisherType publisher_type
-  ) : ComponentInterface<NodeT>(node_options, publisher_type) {}
+      const rclcpp::NodeOptions& node_options, modulo_core::communication::PublisherType publisher_type,
+      const std::string& fallback_name = "ComponentInterfacePublicInterface"
+  ) : ComponentInterface<NodeT>(node_options, publisher_type, fallback_name) {}
   using ComponentInterface<NodeT>::add_parameter;
   using ComponentInterface<NodeT>::get_parameter;
   using ComponentInterface<NodeT>::get_parameter_value;

--- a/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+
+#include "modulo_components/exceptions/ComponentParameterException.hpp"
+#include "modulo_core/EncodedState.hpp"
+#include "test_modulo_components/component_public_interfaces.hpp"
+
+namespace modulo_components {
+
+template<class NodeT>
+class EmptyParameterInterface : public ComponentInterfacePublicInterface<NodeT> {
+public:
+  explicit EmptyParameterInterface(
+      const rclcpp::NodeOptions& node_options, modulo_core::communication::PublisherType publisher_type,
+      const std::string& fallback_name = "EmptyParameterInterface", bool allow_empty = true, bool add_parameter = true
+  ) : ComponentInterfacePublicInterface<NodeT>(node_options, publisher_type, fallback_name), allow_empty_(allow_empty) {
+    if (add_parameter) {
+      this->add_parameter(std::make_shared<Parameter<std::string>>("name"), "Test parameter");
+    }
+  };
+
+private:
+  bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override {
+    if (parameter->get_name() == "period") {
+      return false;
+    }
+    if (parameter->get_name() == "name") {
+      if (parameter->is_empty()) {
+        return this->allow_empty_;
+      } else if (parameter->get_parameter_value<std::string>().empty()) {
+        RCLCPP_ERROR(this->get_logger(), "Provide a non empty value for parameter 'name'");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool allow_empty_;
+};
+
+template<class NodeT>
+class ComponentInterfaceEmptyParameterTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override {
+    if (std::is_same<NodeT, rclcpp::Node>::value) {
+      this->component_ = std::make_shared<EmptyParameterInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_core::communication::PublisherType::PUBLISHER
+      );
+    } else if (std::is_same<NodeT, rclcpp_lifecycle::LifecycleNode>::value) {
+      this->component_ = std::make_shared<EmptyParameterInterface<NodeT>>(
+          rclcpp::NodeOptions(), modulo_core::communication::PublisherType::LIFECYCLE_PUBLISHER
+      );
+    }
+  }
+
+  std::shared_ptr<EmptyParameterInterface<NodeT>> component_;
+};
+using NodeTypes = ::testing::Types<rclcpp::Node, rclcpp_lifecycle::LifecycleNode>;
+TYPED_TEST_SUITE(ComponentInterfaceEmptyParameterTest, NodeTypes);
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, NotAllowEmptyOnConstruction) {
+  if (std::is_same<TypeParam, rclcpp::Node>::value) {
+    EXPECT_THROW(std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions(), modulo_core::communication::PublisherType::PUBLISHER, "EmptyParameterComponent", false
+    ), modulo_components::exceptions::ComponentParameterException);
+  } else if (std::is_same<TypeParam, rclcpp_lifecycle::LifecycleNode>::value) {
+    EXPECT_THROW(std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions(), modulo_core::communication::PublisherType::LIFECYCLE_PUBLISHER,
+        "EmptyParameterComponent", false
+    ), modulo_components::exceptions::ComponentParameterException);
+  }
+}
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, NotAllowEmpty) {
+  std::shared_ptr<EmptyParameterInterface<TypeParam>> component;
+  if (std::is_same<TypeParam, rclcpp::Node>::value) {
+    component = std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions(), modulo_core::communication::PublisherType::PUBLISHER, "EmptyParameterComponent", false,
+        false
+    );
+  } else if (std::is_same<TypeParam, rclcpp_lifecycle::LifecycleNode>::value) {
+    component = std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions(), modulo_core::communication::PublisherType::LIFECYCLE_PUBLISHER,
+        "EmptyParameterComponent", false, false
+    );
+  }
+  EXPECT_THROW(component->add_parameter(std::make_shared<Parameter<std::string>>("name"), "Test parameter"),
+               exceptions::ComponentParameterException);
+  EXPECT_THROW(auto param = component->get_parameter("name"), exceptions::ComponentParameterException);
+  EXPECT_THROW(component->get_ros_parameter("name"), rclcpp::exceptions::ParameterNotDeclaredException);
+}
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, AllowEmpty) {
+  std::shared_ptr<EmptyParameterInterface<TypeParam>> component;
+  if (std::is_same<TypeParam, rclcpp::Node>::value) {
+    component = std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions(), modulo_core::communication::PublisherType::PUBLISHER, "EmptyParameterComponent", true,
+        false
+    );
+  } else if (std::is_same<TypeParam, rclcpp_lifecycle::LifecycleNode>::value) {
+    component = std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions(), modulo_core::communication::PublisherType::LIFECYCLE_PUBLISHER,
+        "EmptyParameterComponent", true, false
+    );
+  }
+  EXPECT_NO_THROW(component->add_parameter(std::make_shared<Parameter<std::string>>("name"), "Test parameter"));
+  EXPECT_EQ(component->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_TRUE(component->get_parameter("name")->is_empty());
+  EXPECT_EQ(component->get_ros_parameter("name").get_type(), rclcpp::PARAMETER_NOT_SET);
+}
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, ValidateEmptyParameter) {
+  // component comes with empty parameter 'name'
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_TRUE(this->component_->get_parameter("name")->is_empty());
+  auto ros_param = rclcpp::Parameter();
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+
+  // Trying to overwrite a parameter is not possible
+  this->component_->add_parameter(std::make_shared<Parameter<bool>>("name"), "Test parameter");
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_TRUE(this->component_->get_parameter("name")->is_empty());
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_NOT_SET);
+
+  // Set parameter value from ROS interface should update ROS parameter type
+  this->component_->set_ros_parameter({"name", "test"});
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "test");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "test");
+
+  // Set parameter value from component interface
+  this->component_->template set_parameter_value<std::string>("name", "again");
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "again");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "again");
+
+  // Setting it with empty value should be rejected in parameter evaluation
+  this->component_->template set_parameter_value<std::string>("name", "");
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "again");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "again");
+
+  // Setting it with empty value should be rejected in parameter evaluation
+  this->component_->set_ros_parameter({"name", ""});
+  EXPECT_EQ(this->component_->get_parameter("name")->get_parameter_type(), ParameterType::STRING);
+  EXPECT_EQ(this->component_->get_parameter("name")->template get_parameter_value<std::string>(), "again");
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("name"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_STRING);
+  EXPECT_EQ(ros_param.template get_value<std::string>(), "again");
+
+  // TODO clarify that behavior somewhere
+  // Setting a parameter with type NOT_SET undeclares that parameter
+  this->component_->set_ros_parameter(rclcpp::Parameter("name", rclcpp::ParameterValue{}));
+  EXPECT_THROW(this->component_->get_ros_parameter("name"), rclcpp::exceptions::ParameterNotDeclaredException);
+}
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, ChangeParameterType) {
+  // Add parameter from component interface
+  this->component_->add_parameter(std::make_shared<Parameter<int>>("int"), "Test parameter");
+  EXPECT_TRUE(this->component_->describe_parameter("int").dynamic_typing);
+  this->component_->template set_parameter_value<int>("int", 1);
+  EXPECT_EQ(this->component_->get_parameter("int")->get_parameter_type(), ParameterType::INT);
+  EXPECT_EQ(this->component_->get_parameter("int")->template get_parameter_value<int>(), 1);
+  auto ros_param = rclcpp::Parameter();
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("int"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_INTEGER);
+  EXPECT_EQ(ros_param.template get_value<int>(), 1);
+
+  // Set parameter value from component interface with different type should not work
+  this->component_->template set_parameter_value<double>("int", 2.0);
+  EXPECT_EQ(this->component_->get_parameter("int")->get_parameter_type(), ParameterType::INT);
+  EXPECT_EQ(this->component_->get_parameter("int")->template get_parameter_value<int>(), 1);
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("int"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_INTEGER);
+  EXPECT_EQ(ros_param.template get_value<int>(), 1);
+
+  // Set parameter value from ROS interface with different type should not work
+  auto result = this->component_->set_ros_parameter(rclcpp::Parameter("int", 2.0));
+  EXPECT_FALSE(result.successful);
+  EXPECT_EQ(this->component_->get_parameter("int")->get_parameter_type(), ParameterType::INT);
+  EXPECT_EQ(this->component_->get_parameter("int")->template get_parameter_value<int>(), 1);
+  EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("int"););
+  EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_INTEGER);
+  EXPECT_EQ(ros_param.template get_value<int>(), 1);
+}
+} // namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_empty_parameters.cpp
@@ -20,9 +20,6 @@ public:
 
 private:
   bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override {
-    if (parameter->get_name() == "period") {
-      return false;
-    }
     if (parameter->get_name() == "name") {
       if (parameter->is_empty()) {
         return this->allow_empty_;
@@ -197,5 +194,20 @@ TYPED_TEST(ComponentInterfaceEmptyParameterTest, ChangeParameterType) {
   EXPECT_NO_THROW(ros_param = this->component_->get_ros_parameter("int"););
   EXPECT_EQ(ros_param.get_type(), rclcpp::ParameterType::PARAMETER_INTEGER);
   EXPECT_EQ(ros_param.template get_value<int>(), 1);
+}
+
+TYPED_TEST(ComponentInterfaceEmptyParameterTest, ParameterOverrides) {
+  // Construction with allowing empty parameters but providing the parameter override should succeed
+  if (std::is_same<TypeParam, rclcpp::Node>::value) {
+    EXPECT_NO_THROW(std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("name", "test")}),
+        modulo_core::communication::PublisherType::PUBLISHER, "EmptyParameterComponent", false
+    ));
+  } else if (std::is_same<TypeParam, rclcpp_lifecycle::LifecycleNode>::value) {
+    EXPECT_NO_THROW(std::make_shared<EmptyParameterInterface<TypeParam>>(
+        rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("name", "test")}),
+        modulo_core::communication::PublisherType::LIFECYCLE_PUBLISHER, "EmptyParameterComponent", false
+    ));
+  }
 }
 } // namespace modulo_components

--- a/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface_parameters.cpp
@@ -75,9 +75,8 @@ TYPED_TEST(ComponentInterfaceParameterTest, AddParameterAgain) {
   // Adding an existing parameter again should just set the value
   this->component_->validate_parameter_was_called = false;
   EXPECT_NO_THROW(this->component_->add_parameter("test", 2, "foo"));
-  EXPECT_TRUE(this->component_->validate_parameter_was_called);
-  this->template expect_parameter_value<int>(2);
-  EXPECT_EQ(this->param_->get_value(), 2);
+  EXPECT_FALSE(this->component_->validate_parameter_was_called);
+  this->template expect_parameter_value<int>(1);
 }
 
 TYPED_TEST(ComponentInterfaceParameterTest, SetParameter) {

--- a/source/modulo_components/test/python/test_component_interface_empty_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_empty_parameters.py
@@ -135,3 +135,8 @@ def test_change_parameter_type(component_test):
     ros_param = component_test.get_ros_parameter("int")
     assert ros_param.type_ == Parameter.Type.INTEGER
     assert ros_param.value == 1
+
+
+def test_parameter_overrides(ros_context):
+    # Construction with allowing empty parameters but providing the parameter override should succeed
+    EmtpyParameterInterface("component", False, parameter_overrides=[Parameter("name", value="test")])

--- a/source/modulo_components/test/python/test_component_interface_empty_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_empty_parameters.py
@@ -1,0 +1,137 @@
+import pytest
+import rclpy
+import state_representation as sr
+from modulo_components.component_interface import ComponentInterface
+from modulo_components.exceptions.component_exceptions import ComponentParameterError
+from rcl_interfaces.msg import SetParametersResult
+from rclpy.exceptions import ParameterNotDeclaredException
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+
+
+class EmtpyParameterInterface(ComponentInterface):
+    def __init__(self, node_name, allow_empty=True, add_parameter=True, *kargs, **kwargs):
+        super().__init__(node_name, *kargs, **kwargs)
+        self._allow_empty = allow_empty
+        if add_parameter:
+            self.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+
+    def get_ros_parameter(self, name: str) -> rclpy.Parameter:
+        return rclpy.node.Node.get_parameter(self, name)
+
+    def set_ros_parameter(self, param: rclpy.Parameter) -> SetParametersResult:
+        return rclpy.node.Node.set_parameters(self, [param])[0]
+
+    def _validate_parameter(self, parameter: sr.Parameter) -> bool:
+        if parameter.get_name() == "name":
+            if parameter.is_empty():
+                return self._allow_empty
+            elif not parameter.get_value():
+                self.get_logger().error("Provide a non empty value for parameter 'name'")
+                return False
+        return True
+
+
+@pytest.fixture()
+def component_test(ros_context):
+    yield EmtpyParameterInterface("component")
+
+
+def test_not_allow_empty_on_construction(ros_context):
+    # Construction with empty parameter should raise if the empty parameter is not allowed
+    with pytest.raises(ComponentParameterError):
+        EmtpyParameterInterface("component", False)
+
+
+def test_not_allow_empty(ros_context):
+    component = EmtpyParameterInterface("component", allow_empty=False, add_parameter=False)
+    with pytest.raises(ComponentParameterError):
+        component.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+    with pytest.raises(ComponentParameterError):
+        component.get_parameter("name")
+    with pytest.raises(ParameterNotDeclaredException):
+        assert Node.get_parameter(component, "name")
+
+    component = EmtpyParameterInterface("component", allow_empty=True, add_parameter=False)
+    component.add_parameter(sr.Parameter("name", sr.ParameterType.STRING), "Test parameter")
+    assert component.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component.get_parameter("name").is_empty()
+    assert Node.get_parameter(component, "name").type_ == Parameter.Type.NOT_SET
+
+
+def test_validate_empty_parameter(component_test):
+    # component_test comes with empty parameter 'name'
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter("name").is_empty()
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+
+    # Trying to overwrite a parameter is not possible
+    component_test.add_parameter(sr.Parameter("name", sr.ParameterType.BOOL), "Test parameter")
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter("name").is_empty()
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.NOT_SET
+
+    # Set parameter with empty parameter isn't possible because there is no method for that
+    # component_test.set_parameter(sr.Parameter("name", sr.ParameterType.STRING))
+
+    # Set parameter value from ROS interface should update ROS parameter type
+    Node.set_parameters(component_test, [Parameter("name", value="test")])
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "test"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "test"
+
+    # Set parameter value from component interface
+    component_test.set_parameter_value("name", "again", sr.ParameterType.STRING)
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "again"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "again"
+
+    # Setting it with empty value should be rejected in parameter evaluation
+    component_test.set_parameter_value("name", "", sr.ParameterType.STRING)
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "again"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "again"
+
+    # Setting it with empty value should be rejected in parameter evaluation
+    Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.STRING, value="")])
+    assert component_test.get_parameter("name").get_parameter_type() == sr.ParameterType.STRING
+    assert component_test.get_parameter_value("name") == "again"
+    assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
+    assert Node.get_parameter(component_test, "name").value == "again"
+
+    # TODO
+    # Setting a parameter with type NOT_SET undeclares that parameter
+    Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.NOT_SET)])
+    with pytest.raises(ParameterNotDeclaredException):
+        Node.get_parameter(component_test, "name")
+
+
+def test_change_parameter_type(component_test):
+    # Add parameter from component interface
+    component_test.add_parameter(sr.Parameter("int", sr.ParameterType.INT), "Test parameter")
+    assert component_test.describe_parameter("int").dynamic_typing
+    component_test.set_parameter_value("int", 1, sr.ParameterType.INT)
+    assert component_test.get_parameter("int").get_parameter_type() == sr.ParameterType.INT
+    assert component_test.get_parameter_value("int") == 1
+    ros_param = component_test.get_ros_parameter("int")
+    assert ros_param.type_ == Parameter.Type.INTEGER
+    assert ros_param.value == 1
+
+    # Set parameter value from component interface with different type should not work
+    component_test.set_parameter_value("int", 2.0, sr.ParameterType.DOUBLE)
+    assert component_test.get_parameter("int").get_parameter_type() == sr.ParameterType.INT
+    assert component_test.get_parameter_value("int") == 1
+    ros_param = component_test.get_ros_parameter("int")
+    assert ros_param.type_ == Parameter.Type.INTEGER
+    assert ros_param.value == 1
+
+    # Set parameter value from ROS interface with different type should not work
+    component_test.set_ros_parameter(Parameter("int", value=2.0))
+    assert component_test.get_parameter("int").get_parameter_type() == sr.ParameterType.INT
+    assert component_test.get_parameter_value("int") == 1
+    ros_param = component_test.get_ros_parameter("int")
+    assert ros_param.type_ == Parameter.Type.INTEGER
+    assert ros_param.value == 1

--- a/source/modulo_components/test/python/test_component_interface_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_parameters.py
@@ -59,9 +59,8 @@ def test_add_parameter_again(component_interface):
     component_interface.add_parameter("param", "Test parameter")
     component_interface.validate_was_called = False
     component_interface.add_parameter(sr.Parameter("test", 2, sr.ParameterType.INT), "foo")
-    assert component_interface.validate_was_called
-    assert_param_value_equal(component_interface, "test", 2)
-    assert component_interface.param.get_value() == 2
+    assert not component_interface.validate_was_called
+    assert_param_value_equal(component_interface, "test", 1)
 
 
 def test_add_parameter_again_not_attribute(component_interface):
@@ -73,9 +72,8 @@ def test_add_parameter_again_not_attribute(component_interface):
     component_interface.add_parameter(component_interface.param, "Test parameter")
     component_interface.validate_was_called = False
     component_interface.add_parameter(sr.Parameter("test", 2, sr.ParameterType.INT), "foo")
-    assert component_interface.validate_was_called
-    assert_param_value_equal(component_interface, "test", 2)
-    assert component_interface.param.get_value() == 1
+    assert not component_interface.validate_was_called
+    assert_param_value_equal(component_interface, "test", 1)
 
 
 def test_set_parameter(component_interface):
@@ -140,16 +138,14 @@ def test_read_only_parameter(component_interface):
     component_interface.get_ros_parameter("test")
     assert_param_value_equal(component_interface, "test", 1)
 
-    # TODO read only
     component_interface.validate_was_called = False
-    # with pytest.raises(RuntimeError):
-    #     component_interface.set_parameter_value("test", 2, sr.ParameterType.INT)
-    # assert not component_interface.validate_was_called
+    component_interface.set_parameter_value("test", 2, sr.ParameterType.INT)
+    assert not component_interface.validate_was_called
     assert_param_value_equal(component_interface, "test", 1)
     assert component_interface.param.get_value() == 1
 
     component_interface.validate_was_called = False
-    # result = component_interface.set_ros_parameter(rclpy.Parameter("test", value=2))
-    # assert not component_interface.validate_was_called
-    # assert not result.successful
+    result = component_interface.set_ros_parameter(rclpy.Parameter("test", value=2))
+    assert not component_interface.validate_was_called
+    assert not result.successful
     assert_param_value_equal(component_interface, "test", 1)

--- a/source/modulo_core/src/translators/parameter_translators.cpp
+++ b/source/modulo_core/src/translators/parameter_translators.cpp
@@ -236,7 +236,8 @@ std::shared_ptr<ParameterInterface> read_parameter_const(
     }
     default:
       throw exceptions::ParameterTranslationException(
-          "Something went wrong while reading parameter " + parameter->get_name());
+          "Incompatible parameter type encountered while reading parameter '" + parameter->get_name() + "'."
+      );
   }
   return new_parameter;
 }


### PR DESCRIPTION
Okay now I think we're getting somewhere..There are a few changes to the logic here but most of the lines come from the tests

- Add parameter now throws an exception if the parameter could not be added for some reason (translation failed or validation failed). Note that upon declaration of a `NOT_SET` parameter in C++, the set parameter callback is not called, hence we need to validate that parameter explicitly in the `add_parameter`.
- Even though, empty parameters are declared with `dynamic_typing=true`, it's not possible to change the parameter type once the parameter was set because `read_parameter_const` will throw an exception and the callback will return false.
- Along the other changes, I added the `read_only` field for python ROS parameters and it works as in C++ (tested)

Also another few key points that came up and that we have to keep in mind:
- I'd be glad if we would only hide the ROS methods in the Component and LifecycleComponent and not in ComponentInterface, such that we can still do all those tests
- We are calling a virtual method `validate_parameter` from the constructor, where we also add the `period` parameter. This means that the period parameter is still validated with the virtual method that just returns true because the base class has not been fully constructed yet. Only for parameters added in the constructor of any derived component, the override `validate_parameter` will be called. We could check the period for meaningful values, e.g. between 1ms and 10s or something and issue a warning otherwise.
