### PR TITLE
Don't start execute thread on construction

### DIFF
--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -24,7 +24,7 @@ public:
    * @param fallback_name The name of the component if it was not provided through the node options
    */
   explicit Component(
-      const rclcpp::NodeOptions& node_options, bool start_thread = false, const std::string& fallback_name = "Component"
+      const rclcpp::NodeOptions& node_options, const std::string& fallback_name = "Component", bool start_thread = false
   );
 
   /**

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -33,13 +33,13 @@ protected:
   /**
    * @brief Start the execution thread.
    */
-  void start_thread();
+  void execute();
 
   /**
    * @brief Execute the component logic. To be redefined in derived classes.
    * @return True, if the execution was successful, false otherwise
    */
-  virtual bool execute();
+  virtual bool on_execute_callback();
 
   /**
    * @brief Add and configure an output signal of the component.
@@ -57,16 +57,15 @@ protected:
 
 private:
   /**
-   * @brief Step function that is called periodically and publishes predicates,
-   * outputs, and evaluates daemon callbacks.
+   * @brief Step function that is called periodically and publishes predicates, outputs, and evaluates daemon callbacks.
    */
   void step() override;
 
   /**
-   * @brief Run the execution function in a try catch block and
-   * set the predicates according to the outcome of the execution.
+   * @brief Run the execution function in a try catch block and set the predicates according to the outcome of the
+   * execution.
    */
-  void run();
+  void on_execute();
 
   // TODO hide ROS methods
   using ComponentInterface<rclcpp::Node>::create_output;
@@ -77,7 +76,7 @@ private:
   using ComponentInterface<rclcpp::Node>::publish_outputs;
   using ComponentInterface<rclcpp::Node>::evaluate_periodic_callbacks;
 
-  std::thread run_thread_; ///< The execution thread of the component
+  std::thread execute_thread_; ///< The execution thread of the component
   bool started_; ///< Flag that indicates if execution has started or not
 };
 

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -24,7 +24,7 @@ public:
    * @param fallback_name The name of the component if it was not provided through the node options
    */
   explicit Component(
-      const rclcpp::NodeOptions& node_options, bool start_thread = true, const std::string& fallback_name = "Component"
+      const rclcpp::NodeOptions& node_options, bool start_thread = false, const std::string& fallback_name = "Component"
   );
 
   /**

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -20,12 +20,9 @@ public:
   /**
    * @brief Constructor from node options.
    * @param node_options Node options as used in ROS2 Node
-   * @param start_thread If true, start the execution thread on construction
    * @param fallback_name The name of the component if it was not provided through the node options
    */
-  explicit Component(
-      const rclcpp::NodeOptions& node_options, const std::string& fallback_name = "Component", bool start_thread = false
-  );
+  explicit Component(const rclcpp::NodeOptions& node_options, const std::string& fallback_name = "Component");
 
   /**
    * @brief Virtual default destructor.

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -17,7 +17,7 @@ class Component(ComponentInterface):
         run_thread (Thread): the execution thread
     """
 
-    def __init__(self, node_name: str, start_thread=False, *kargs, **kwargs):
+    def __init__(self, node_name: str, *kargs, **kwargs):
         """
         Constructs all the necessary attributes and declare all the parameters.
             Parameters:
@@ -28,9 +28,6 @@ class Component(ComponentInterface):
         self.__started = False
         self.__run_thread = None
         self.add_predicate("is_finished", False)
-
-        if start_thread:
-            self.start_thread()
 
     def _step(self):
         """

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -26,7 +26,7 @@ class Component(ComponentInterface):
         """
         super().__init__(node_name, *kargs, **kwargs)
         self.__started = False
-        self.__run_thread = None
+        self.__execute_thread = None
         self.add_predicate("is_finished", False)
 
     def _step(self):
@@ -41,47 +41,40 @@ class Component(ComponentInterface):
         except Exception as e:
             self.get_logger().error(f"Failed to execute step function: {e}", throttle_duration_sec=1.0)
 
-    def start_thread(self):
+    def execute(self):
         """
         Start the execution thread.
         """
         if self.__started:
-            self.get_logger().error(f"Run thread for component {self.get_name()} has already been started",
-                                    throttle_duration_sec=1.0)
+            self.get_logger().error("Failed to start execution thread: Thread has already been started.")
             return
         self.__started = True
-        self.__run_thread = Thread(target=self.__run)
-        self.__run_thread.start()
+        self.__execute_thread = Thread(target=self.__on_execute)
+        self.__execute_thread.start()
 
-    def __run(self):
+    def __on_execute(self):
         """
         Run the execution function in a try catch block and set the predicates according to the outcome of the
         execution.
         """
         try:
-            if not self.execute():
+            if not self.on_execute_callback():
                 self.raise_error()
                 return
         except Exception as e:
-            self.get_logger().error(f"Failed to run component {self.get_name()}: {e}", throttle_duration_sec=1.0)
+            self.get_logger().error(f"Failed to run the execute function: {e}")
             self.raise_error()
             return
+        self.get_logger().debug("Execution finished, setting 'is_finished' predicate to true.")
         self.set_predicate("is_finished", True)
 
-    def execute(self):
+    def on_execute_callback(self):
         """
         Execute the component logic. To be redefined in the derived classes.
 
         :return: True, if the execution was successful, false otherwise
         """
         return True
-
-    def _raise_error(self):
-        """
-        Put the component in error state by setting the 'in_error_state'
-        predicate to true.
-        """
-        self.set_predicate("in_error_state", True)
 
     def add_output(self, signal_name: str, data: str, message_type: MsgT,
                    clproto_message_type=clproto.MessageType.UNKNOWN_MESSAGE, fixed_topic=False, default_topic=""):

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -17,7 +17,7 @@ class Component(ComponentInterface):
         run_thread (Thread): the execution thread
     """
 
-    def __init__(self, node_name: str, start_thread=True, *kargs, **kwargs):
+    def __init__(self, node_name: str, start_thread=False, *kargs, **kwargs):
         """
         Constructs all the necessary attributes and declare all the parameters.
             Parameters:

--- a/source/modulo_components/src/Component.cpp
+++ b/source/modulo_components/src/Component.cpp
@@ -4,7 +4,7 @@ using namespace modulo_core::communication;
 
 namespace modulo_components {
 
-Component::Component(const rclcpp::NodeOptions& node_options, bool start_thread, const std::string& fallback_name) :
+Component::Component(const rclcpp::NodeOptions& node_options, const std::string& fallback_name, bool start_thread) :
     ComponentInterface<rclcpp::Node>(node_options, PublisherType::PUBLISHER, fallback_name), started_(false) {
   this->add_predicate("is_finished", false);
 

--- a/source/modulo_components/src/Component.cpp
+++ b/source/modulo_components/src/Component.cpp
@@ -20,18 +20,18 @@ void Component::step() {
   }
 }
 
-void Component::start_thread() {
+void Component::execute() {
   if (this->started_) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to start run thread: Thread has already been started.");
+    RCLCPP_ERROR(this->get_logger(), "Failed to start execution thread: Thread has already been started.");
     return;
   }
   this->started_ = true;
-  this->run_thread_ = std::thread([this]() { this->run(); });
+  this->execute_thread_ = std::thread([this]() { this->on_execute(); });
 }
 
-void Component::run() {
+void Component::on_execute() {
   try {
-    if (!this->execute()) {
+    if (!this->on_execute_callback()) {
       this->raise_error();
       return;
     }
@@ -40,11 +40,11 @@ void Component::run() {
     this->raise_error();
     return;
   }
-  RCLCPP_DEBUG(this->get_logger(), "Execution finished, setting is_finished predicate to true");
+  RCLCPP_DEBUG(this->get_logger(), "Execution finished, setting 'is_finished' predicate to true.");
   this->set_predicate("is_finished", true);
 }
 
-bool Component::execute() {
+bool Component::on_execute_callback() {
   return true;
 }
 }// namespace modulo_components

--- a/source/modulo_components/src/Component.cpp
+++ b/source/modulo_components/src/Component.cpp
@@ -4,13 +4,9 @@ using namespace modulo_core::communication;
 
 namespace modulo_components {
 
-Component::Component(const rclcpp::NodeOptions& node_options, const std::string& fallback_name, bool start_thread) :
+Component::Component(const rclcpp::NodeOptions& node_options, const std::string& fallback_name) :
     ComponentInterface<rclcpp::Node>(node_options, PublisherType::PUBLISHER, fallback_name), started_(false) {
   this->add_predicate("is_finished", false);
-
-  if (start_thread) {
-    this->start_thread();
-  }
 }
 
 void Component::step() {

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -59,9 +59,8 @@ public:
 class ComponentPublicInterface : public Component {
 public:
   explicit ComponentPublicInterface(
-      const rclcpp::NodeOptions& node_options, const std::string& fallback_name = "ComponentPublicInterface",
-      bool start_thread = false
-  ) : Component(node_options, fallback_name, start_thread) {}
+      const rclcpp::NodeOptions& node_options, const std::string& fallback_name = "ComponentPublicInterface"
+  ) : Component(node_options, fallback_name) {}
   using Component::add_output;
   using Component::outputs_;
 };

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -58,7 +58,7 @@ public:
 
 class ComponentPublicInterface : public Component {
 public:
-  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options, bool start_thread = true) :
+  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options, bool start_thread = false) :
       Component(node_options, start_thread) {}
   using Component::add_output;
   using Component::outputs_;

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -58,8 +58,10 @@ public:
 
 class ComponentPublicInterface : public Component {
 public:
-  explicit ComponentPublicInterface(const rclcpp::NodeOptions& node_options, bool start_thread = false) :
-      Component(node_options, start_thread) {}
+  explicit ComponentPublicInterface(
+      const rclcpp::NodeOptions& node_options, const std::string& fallback_name = "ComponentPublicInterface",
+      bool start_thread = false
+  ) : Component(node_options, fallback_name, start_thread) {}
   using Component::add_output;
   using Component::outputs_;
 };

--- a/source/modulo_components/test/cpp/test_component.cpp
+++ b/source/modulo_components/test/cpp/test_component.cpp
@@ -20,7 +20,7 @@ protected:
   }
 
   void SetUp() override {
-    component_ = std::make_shared<ComponentPublicInterface>(rclcpp::NodeOptions(), false);
+    component_ = std::make_shared<ComponentPublicInterface>(rclcpp::NodeOptions());
   }
 
   std::shared_ptr<ComponentPublicInterface> component_;


### PR DESCRIPTION
To be fair, we should even think about removing that option entirely (especially in C++), because we could not think of a component that would want to start a thread on execution and I think it's even really dangerous because we are calling a virtual function from the constructor. In Python it's not such a big problem