### PR TITLE
Execute user transition callback first

### DIFF
--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <lifecycle_msgs/msg/state.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #include "modulo_components/ComponentInterface.hpp"
@@ -260,6 +261,12 @@ inline void LifecycleComponent::add_output(
     const std::string& signal_name, const std::shared_ptr<DataT>& data, bool fixed_topic,
     const std::string& default_topic
 ) {
+  if (this->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED
+      && this->get_current_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+    RCLCPP_WARN_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                                "Adding output in state " << this->get_current_state().label() << " is not allowed.");
+    return;
+  }
   try {
     this->create_output(signal_name, data, fixed_topic, default_topic);
   } catch (const std::exception& ex) {

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -243,6 +243,9 @@ class LifecycleComponent(ComponentInterface):
         :param fixed_topic: If true, the topic name of the output signal is fixed
         :param default_topic: If set, the default value for the topic name to use
         """
+        if self.__state not in [State.PRIMARY_STATE_UNCONFIGURED, State.PRIMARY_STATE_INACTIVE]:
+            self.get_logger().warn(f"Adding output in state {self.__state} is not allowed.", throttle_duration_sec=1.0)
+            return
         try:
             parsed_signal_name = self._create_output(signal_name, data, message_type, clproto_message_type, fixed_topic,
                                                      default_topic)

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -82,7 +82,7 @@ class LifecycleComponent(ComponentInterface):
 
         :return: True if the transition was successful
         """
-        return self.__configure_outputs() and self.on_configure_callback()
+        return self.on_configure_callback() and self.__configure_outputs()
 
     def on_configure_callback(self) -> bool:
         """

--- a/source/modulo_components/src/LifecycleComponent.cpp
+++ b/source/modulo_components/src/LifecycleComponent.cpp
@@ -120,8 +120,8 @@ LifecycleComponent::on_activate(const rclcpp_lifecycle::State& previous_state) {
 }
 
 bool LifecycleComponent::handle_activate() {
-  bool result = this->on_activate_callback();
-  return result && this->activate_outputs();
+  bool result = this->activate_outputs();
+  return result && this->on_activate_callback();
 }
 
 bool LifecycleComponent::on_activate_callback() {

--- a/source/modulo_components/src/LifecycleComponent.cpp
+++ b/source/modulo_components/src/LifecycleComponent.cpp
@@ -1,7 +1,5 @@
 #include "modulo_components/LifecycleComponent.hpp"
 
-#include <lifecycle_msgs/msg/state.hpp>
-
 using namespace modulo_core::communication;
 
 namespace modulo_components {
@@ -69,8 +67,8 @@ LifecycleComponent::on_configure(const rclcpp_lifecycle::State& previous_state) 
 }
 
 bool LifecycleComponent::handle_configure() {
-  bool result = this->configure_outputs();
-  return result && this->on_configure_callback();
+  bool result = this->on_configure_callback();
+  return result && this->configure_outputs();
 }
 
 bool LifecycleComponent::on_configure_callback() {
@@ -92,8 +90,8 @@ LifecycleComponent::on_cleanup(const rclcpp_lifecycle::State& previous_state) {
 }
 
 bool LifecycleComponent::handle_cleanup() {
-  bool result = this->cleanup_signals();
-  return result && this->on_cleanup_callback();
+  bool result = this->on_cleanup_callback();
+  return result && this->cleanup_signals();
 }
 
 bool LifecycleComponent::on_cleanup_callback() {
@@ -122,8 +120,8 @@ LifecycleComponent::on_activate(const rclcpp_lifecycle::State& previous_state) {
 }
 
 bool LifecycleComponent::handle_activate() {
-  bool result = this->activate_outputs();
-  return result && this->on_activate_callback();
+  bool result = this->on_activate_callback();
+  return result && this->activate_outputs();
 }
 
 bool LifecycleComponent::on_activate_callback() {
@@ -145,8 +143,8 @@ LifecycleComponent::on_deactivate(const rclcpp_lifecycle::State& previous_state)
 }
 
 bool LifecycleComponent::handle_deactivate() {
-  bool result = this->deactivate_outputs();
-  return result && this->on_deactivate_callback();
+  bool result = this->on_deactivate_callback();
+  return result && this->deactivate_outputs();
 }
 
 bool LifecycleComponent::on_deactivate_callback() {


### PR DESCRIPTION
This change allows lifecycle components to add outputs on configure and I think it's better this way anyway, that we first do what the user wants and then what we want to do in the background.