### PR TITLE
Add trigger and send predicate on set

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -611,6 +611,7 @@ inline void ComponentInterface<NodeT>::trigger(const std::string& trigger_name) 
     return;
   }
   this->triggers_.at(trigger_name) = true;
+  publish_predicate(trigger_name);
 }
 
 template<class NodeT>

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -308,6 +308,7 @@ class ComponentInterface(Node):
             self.get_logger().error(f"Failed to trigger: could not find trigger with name '{trigger_name}'.")
             return
         self._triggers[trigger_name] = True
+        self._publish_predicate(trigger_name)
 
     def _create_output(self, signal_name: str, data: str, message_type: MsgT, clproto_message_type: clproto.MessageType,
                        default_topic: str, fixed_topic: bool) -> str:

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -24,6 +24,9 @@ public:
   using ComponentInterface<NodeT>::get_predicate;
   using ComponentInterface<NodeT>::set_predicate;
   using ComponentInterface<NodeT>::predicates_;
+  using ComponentInterface<NodeT>::add_trigger;
+  using ComponentInterface<NodeT>::trigger;
+  using ComponentInterface<NodeT>::triggers_;
   using ComponentInterface<NodeT>::add_input;
   using ComponentInterface<NodeT>::inputs_;
   using ComponentInterface<NodeT>::create_output;

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -146,7 +146,8 @@ TYPED_TEST(ComponentInterfaceTest, AddTrigger) {
   EXPECT_FALSE(this->component_->triggers_.at("trigger"));
   EXPECT_FALSE(this->component_->get_predicate("trigger"));
   EXPECT_NO_THROW(this->component_->trigger("trigger"));
-  // After triggering, the trigger will be true only once
+  // When reading, the trigger will be true only once
+  this->component_->triggers_.at("trigger") = true;
   EXPECT_TRUE(this->component_->triggers_.at("trigger"));
   EXPECT_TRUE(this->component_->get_predicate("trigger"));
   // After the predicate function was evaluated once, the trigger is back to false

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -139,4 +139,18 @@ TYPED_TEST(ComponentInterfaceTest, RaiseError) {
   this->component_->raise_error();
   EXPECT_TRUE(this->component_->get_predicate("in_error_state"));
 }
+
+TYPED_TEST(ComponentInterfaceTest, AddTrigger) {
+  EXPECT_NO_THROW(this->component_->add_trigger("trigger"));
+  ASSERT_FALSE(this->component_->triggers_.find("trigger") == this->component_->triggers_.end());
+  EXPECT_FALSE(this->component_->triggers_.at("trigger"));
+  EXPECT_FALSE(this->component_->get_predicate("trigger"));
+  EXPECT_NO_THROW(this->component_->trigger("trigger"));
+  // After triggering, the trigger will be true only once
+  EXPECT_TRUE(this->component_->triggers_.at("trigger"));
+  EXPECT_TRUE(this->component_->get_predicate("trigger"));
+  // After the predicate function was evaluated once, the trigger is back to false
+  EXPECT_FALSE(this->component_->triggers_.at("trigger"));
+  EXPECT_FALSE(this->component_->get_predicate("trigger"));
+}
 }// namespace modulo_components

--- a/source/modulo_components/test/python/test_component_interface.py
+++ b/source/modulo_components/test/python/test_component_interface.py
@@ -78,3 +78,17 @@ def test_tf(component_interface):
     identity = send_tf * lookup_tf.inverse()
     assert np.linalg.norm(identity.data()) - 1 < 1e-3
     assert abs(identity.get_orientation().w) - 1 < 1e-3
+
+
+def test_add_trigger(component_interface):
+    component_interface.add_trigger("trigger")
+    assert "trigger" in component_interface._triggers.keys()
+    assert not component_interface._triggers["trigger"]
+    assert not component_interface.get_predicate("trigger")
+    component_interface.trigger("trigger")
+    # After triggering, the trigger will be true only once
+    assert component_interface._triggers["trigger"]
+    assert component_interface.get_predicate("trigger")
+    # After the predicate function was evaluated once, the trigger is back to false
+    assert not component_interface._triggers["trigger"]
+    assert not component_interface.get_predicate("trigger")

--- a/source/modulo_components/test/python/test_component_interface.py
+++ b/source/modulo_components/test/python/test_component_interface.py
@@ -86,7 +86,8 @@ def test_add_trigger(component_interface):
     assert not component_interface._triggers["trigger"]
     assert not component_interface.get_predicate("trigger")
     component_interface.trigger("trigger")
-    # After triggering, the trigger will be true only once
+    # When reading, the trigger will be true only once
+    component_interface._triggers["trigger"] = True
     assert component_interface._triggers["trigger"]
     assert component_interface.get_predicate("trigger")
     # After the predicate function was evaluated once, the trigger is back to false


### PR DESCRIPTION
Two minor features that we discussed over the past days:
- Send a predicate value immediately after its set, on top of the periodic publishing
- Add a trigger that is essentially a predicate that is always false except when its triggered it will be evaluated to true exactly once.