### PR TITLE
Component services

### DIFF
--- a/.github/actions/build-test-galactic/entrypoint.sh
+++ b/.github/actions/build-test-galactic/entrypoint.sh
@@ -26,6 +26,7 @@ build_and_test() {
 source /opt/ros/"${ROS_DISTRO}"/setup.bash
 cd /home/ros2/ros2_ws
 
+build_and_test modulo_component_interfaces
 build_and_test modulo_core
 build_and_test modulo_components
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,16 @@ FROM ghcr.io/aica-technology/ros2-control-libraries:${BASE_TAG} as dependencies
 WORKDIR ${HOME}/ros2_ws
 
 
-FROM dependencies as modulo-core
+FROM dependencies as modulo-component-interfaces
+
+COPY --chown=${USER} ./source/modulo_component_interfaces ./src/modulo_component_interfaces
+RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"
+
+
+FROM modulo-component-interfaces as modulo-core
 
 COPY --chown=${USER} ./source/modulo_core ./src/modulo_core
-RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build"
+RUN /bin/bash -c "source /opt/ros/$ROS_DISTRO/setup.bash; colcon build --packages-select modulo_core"
 
 
 FROM modulo-core as modulo-components

--- a/source/modulo_component_interfaces/CMakeLists.txt
+++ b/source/modulo_component_interfaces/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(modulo_component_interfaces)
+
+find_package(rosidl_default_generators REQUIRED)
+
+file(GLOB SRVS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} srv/*.srv)
+rosidl_generate_interfaces(${PROJECT_NAME} ${SRVS})
+
+ament_package()

--- a/source/modulo_component_interfaces/package.xml
+++ b/source/modulo_component_interfaces/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>modulo_component_interfaces</name>
+  <version>0.0.1</version>
+  <description>Interface package for communicating with modulo components through the ROS framework</description>
+  <maintainer email="enrico@aica.tech">Enrico Eberhard</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rcl_interfaces</depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/source/modulo_component_interfaces/srv/EmptyTrigger.srv
+++ b/source/modulo_component_interfaces/srv/EmptyTrigger.srv
@@ -1,0 +1,3 @@
+---
+bool success
+string message

--- a/source/modulo_component_interfaces/srv/StringTrigger.srv
+++ b/source/modulo_component_interfaces/srv/StringTrigger.srv
@@ -1,0 +1,4 @@
+string payload
+---
+bool success
+string message

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -800,9 +800,14 @@ inline void ComponentInterface<NodeT>::add_service(
             const std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Request>,
             std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Response> response
         ) {
-          auto callback_response = callback();
-          response->success = callback_response.success;
-          response->message = callback_response.message;
+          try {
+            auto callback_response = callback();
+            response->success = callback_response.success;
+            response->message = callback_response.message;
+          } catch (const std::exception& ex) {
+            response->success = false;
+            response->message = ex.what();
+          }
         });
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add service '" << service_name << "': " << ex.what());
@@ -821,9 +826,14 @@ inline void ComponentInterface<NodeT>::add_service(
             const std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Request> request,
             std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Response> response
         ) {
-          auto callback_response = callback(request->payload);
-          response->success = callback_response.success;
-          response->message = callback_response.message;
+          try {
+            auto callback_response = callback(request->payload);
+            response->success = callback_response.success;
+            response->message = callback_response.message;
+          } catch (const std::exception& ex) {
+            response->success = false;
+            response->message = ex.what();
+          }
         });
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add service '" << service_name << "': " << ex.what());

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -792,30 +792,42 @@ template<class NodeT>
 inline void ComponentInterface<NodeT>::add_service(
     const std::string& service_name, const std::function<ComponentServiceResponse(void)>& callback
 ) {
-  NodeT::template create_service<modulo_component_interfaces::srv::EmptyTrigger>(
-      service_name, [callback](
-          const std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Request>,
-          std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Response> response
-      ) {
-        auto callback_response = callback();
-        response->success = callback_response.success;
-        response->message = callback_response.message;
-      });
+  try {
+    std::string parsed_service_name = utilities::parse_signal_name(service_name);
+    RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding empty service '" << parsed_service_name << ".");
+    NodeT::template create_service<modulo_component_interfaces::srv::EmptyTrigger>(
+        parsed_service_name, [callback](
+            const std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Request>,
+            std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Response> response
+        ) {
+          auto callback_response = callback();
+          response->success = callback_response.success;
+          response->message = callback_response.message;
+        });
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add service '" << service_name << "': " << ex.what());
+  }
 }
 
 template<class NodeT>
 inline void ComponentInterface<NodeT>::add_service(
     const std::string& service_name, const std::function<ComponentServiceResponse(const std::string& string)>& callback
 ) {
-  NodeT::template create_service<modulo_component_interfaces::srv::StringTrigger>(
-      service_name, [callback](
-          const std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Request> request,
-          std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Response> response
-      ) {
-        auto callback_response = callback(request->payload);
-        response->success = callback_response.success;
-        response->message = callback_response.message;
-      });
+  try {
+    std::string parsed_service_name = utilities::parse_signal_name(service_name);
+    RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding string service '" << parsed_service_name << ".");
+    NodeT::template create_service<modulo_component_interfaces::srv::StringTrigger>(
+        parsed_service_name, [callback](
+            const std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Request> request,
+            std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Response> response
+        ) {
+          auto callback_response = callback(request->payload);
+          response->success = callback_response.success;
+          response->message = callback_response.message;
+        });
+  } catch (const std::exception& ex) {
+    RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add service '" << service_name << "': " << ex.what());
+  }
 }
 
 template<class NodeT>

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -24,6 +24,9 @@
 #include <modulo_core/translators/message_writers.hpp>
 #include <modulo_core/translators/parameter_translators.hpp>
 
+#include <modulo_component_interfaces/srv/empty_trigger.hpp>
+#include <modulo_component_interfaces/srv/string_trigger.hpp>
+
 #include "modulo_components/exceptions/AddSignalException.hpp"
 #include "modulo_components/exceptions/ComponentParameterException.hpp"
 #include "modulo_components/exceptions/LookupTransformException.hpp"
@@ -31,6 +34,15 @@
 #include "modulo_components/utilities/predicate_variant.hpp"
 
 namespace modulo_components {
+
+/**
+ * @struct ComponentServiceResponse
+ * @brief TODO
+ */
+struct ComponentServiceResponse {
+  bool success;
+  std::string message;
+};
 
 /**
  * @brief TODO
@@ -223,6 +235,26 @@ protected:
   void add_input(
       const std::string& signal_name, const std::function<void(const std::shared_ptr<MsgT>)>& callback,
       const std::string& default_topic = "", bool fixed_topic = false
+  );
+
+  /**
+   * @brief Add a service to trigger a callback function with no input arguments.
+   * @param service_name The name of the service
+   * @param callback A service callback function with no arguments that returns a ComponentServiceResponse
+   */
+  void add_service(const std::string& service_name, const std::function<ComponentServiceResponse(void)>& callback);
+
+  /**
+   * @brief Add a service to trigger a callback function with a string payload.
+   * @details The string payload can have an arbitrary format to parameterize and control the callback behaviour
+   * as desired. It is the responsibility of the service callback to parse the string according to some payload format.
+   * When adding a service with a string payload, be sure to document the payload format appropriately.
+   * @param service_name The name of the service
+   * @param callback A service callback function with a string argument that returns a ComponentServiceResponse
+   */
+  void add_service(
+      const std::string& service_name,
+      const std::function<ComponentServiceResponse(const std::string& string)>& callback
   );
 
   /**
@@ -754,6 +786,36 @@ inline void ComponentInterface<NodeT>::add_input(
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add input '" << signal_name << "': " << ex.what());
   }
+}
+
+template<class NodeT>
+inline void ComponentInterface<NodeT>::add_service(
+    const std::string& service_name, const std::function<ComponentServiceResponse(void)>& callback
+) {
+  NodeT::template create_service<modulo_component_interfaces::srv::EmptyTrigger>(
+      service_name, [callback](
+          const std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Request>,
+          std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Response> response
+      ) {
+        auto callback_response = callback();
+        response->success = callback_response.success;
+        response->message = callback_response.message;
+      });
+}
+
+template<class NodeT>
+inline void ComponentInterface<NodeT>::add_service(
+    const std::string& service_name, const std::function<ComponentServiceResponse(const std::string& string)>& callback
+) {
+  NodeT::template create_service<modulo_component_interfaces::srv::StringTrigger>(
+      service_name, [callback](
+          const std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Request> request,
+          std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Response> response
+      ) {
+        auto callback_response = callback(request->payload);
+        response->success = callback_response.success;
+        response->message = callback_response.message;
+      });
 }
 
 template<class NodeT>

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -423,7 +423,7 @@ class ComponentInterface(Node):
         except Exception as e:
             self.get_logger().error(f"Failed to add input '{signal_name}': {e}")
 
-    def add_service(self, service_name: str, callback: Union[Callable[[], dict], Callable[[string], dict]]):
+    def add_service(self, service_name: str, callback: Union[Callable[[], dict], Callable[[str], dict]]):
         """
         Add a service to trigger a callback function.
         The callback should take either no arguments (empty service) or a single string argument (string service).
@@ -463,6 +463,7 @@ class ComponentInterface(Node):
                 response.success = False
                 response.message = f"{e}"
             return response
+
         try:
             parsed_service_name = parse_signal_name(service_name)
             signature = inspect.signature(callback)

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -442,23 +442,17 @@ class ComponentInterface(Node):
                     ret = cb(request.payload)
                 else:
                     ret = cb()
-                response.success = True
 
-                # handle different return types
+                # if the return does not contain a success field or bool result,
+                # but the callback completes without error, assume it was successful
+                response.success = True
                 if isinstance(ret, dict):
                     if "success" in ret.keys():
                         response.success = ret["success"]
-                    else:
-                        # if the dict does not contain a success field, but the callback
-                        # completes without error, assume it was successful
-
-                        response.success = True
                     if "message" in ret.keys():
                         response.message = ret["message"]
                 elif isinstance(ret, bool):
                     response.success = ret
-                else:
-                    response.success = True
             except Exception as e:
                 response.success = False
                 response.message = f"{e}"

--- a/source/modulo_components/package.xml
+++ b/source/modulo_components/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>modulo_core</depend>
+  <depend>modulo_component_interfaces</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>tf2_ros</depend>
 

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -28,6 +28,7 @@ public:
   using ComponentInterface<NodeT>::trigger;
   using ComponentInterface<NodeT>::triggers_;
   using ComponentInterface<NodeT>::add_input;
+  using ComponentInterface<NodeT>::add_service;
   using ComponentInterface<NodeT>::inputs_;
   using ComponentInterface<NodeT>::create_output;
   using ComponentInterface<NodeT>::outputs_;

--- a/source/modulo_components/test/cpp/test_component_interface.cpp
+++ b/source/modulo_components/test/cpp/test_component_interface.cpp
@@ -99,6 +99,20 @@ TYPED_TEST(ComponentInterfaceTest, AddInput) {
             modulo_core::communication::MessageType::BOOL);
 }
 
+TYPED_TEST(ComponentInterfaceTest, AddService) {
+  auto empty_callback = []() -> ComponentServiceResponse {
+    return ComponentServiceResponse();
+  };
+  EXPECT_NO_THROW(this->component_->add_service("empty", empty_callback));
+
+  auto string_callback = [](const std::string&) -> ComponentServiceResponse {
+    return ComponentServiceResponse();
+  };
+  EXPECT_NO_THROW(this->component_->add_service("string", string_callback));
+
+  // TODO: use a service client to trigger the service and test the behaviour
+}
+
 TYPED_TEST(ComponentInterfaceTest, CreateOutput) {
   auto data = std::make_shared<bool>(true);
   EXPECT_NO_THROW(this->component_->create_output("test", data, "/topic", true));

--- a/source/modulo_components/test/python/test_component_interface.py
+++ b/source/modulo_components/test/python/test_component_interface.py
@@ -65,6 +65,18 @@ def test_add_input(component_interface):
     assert component_interface._inputs["test_13"].msg_type == Bool
 
 
+def test_add_service(component_interface):
+    def empty_callback():
+        return {"success": True, "message": "test"}
+    component_interface.add_service("empty", empty_callback)
+
+    def string_callback():
+        return {"success": True, "message": "test"}
+    component_interface.add_service("empty", string_callback)
+
+    # TODO: use a service client to trigger the service and test the behaviour
+
+
 def test_tf(component_interface):
     component_interface.add_tf_broadcaster()
     component_interface.add_tf_listener()


### PR DESCRIPTION
For components to have simple services that can trigger certain behaviours, it is necessary to define some service messages. A new package defines these component interfaces.

The new component add_service methods allow simple creation of these services with registered callbacks, either taking no arguments or a single string argument. They return a status and optional message. This should allow flexible and general usage while limiting the number of specific service types that need to be supported.

Still some TODOs for documentation and better tests but I think the general idea is ready for review