### PR TITLE
Create service under local namespace

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -794,9 +794,9 @@ inline void ComponentInterface<NodeT>::add_service(
 ) {
   try {
     std::string parsed_service_name = utilities::parse_signal_name(service_name);
-    RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding empty service '" << parsed_service_name << ".");
+    RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding empty service '" << parsed_service_name << "'.");
     NodeT::template create_service<modulo_component_interfaces::srv::EmptyTrigger>(
-        parsed_service_name, [callback](
+        "~/" + parsed_service_name, [callback](
             const std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Request>,
             std::shared_ptr<modulo_component_interfaces::srv::EmptyTrigger::Response> response
         ) {
@@ -820,9 +820,9 @@ inline void ComponentInterface<NodeT>::add_service(
 ) {
   try {
     std::string parsed_service_name = utilities::parse_signal_name(service_name);
-    RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding string service '" << parsed_service_name << ".");
+    RCLCPP_DEBUG_STREAM(this->get_logger(), "Adding string service '" << parsed_service_name << "'.");
     NodeT::template create_service<modulo_component_interfaces::srv::StringTrigger>(
-        parsed_service_name, [callback](
+        "~/" + parsed_service_name, [callback](
             const std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Request> request,
             std::shared_ptr<modulo_component_interfaces::srv::StringTrigger::Response> response
         ) {

--- a/source/modulo_components/modulo_components/component_interface.py
+++ b/source/modulo_components/modulo_components/component_interface.py
@@ -462,12 +462,12 @@ class ComponentInterface(Node):
             parsed_service_name = parse_signal_name(service_name)
             signature = inspect.signature(callback)
             if len(signature.parameters) == 0:
-                self.get_logger().debug(f"Adding empty service {parsed_service_name}")
+                self.get_logger().debug(f"Adding empty service '{parsed_service_name}'")
                 service_type = EmptyTrigger
             else:
-                self.get_logger().debug(f"Adding string service {parsed_service_name}")
+                self.get_logger().debug(f"Adding string service '{parsed_service_name}'")
                 service_type = StringTrigger
-            self.create_service(service_type, parsed_service_name,
+            self.create_service(service_type,  "~/" + parsed_service_name,
                                 lambda request, response: callback_wrapper(request, response, callback))
         except Exception as e:
             self.get_logger().error(f"Failed to add service '{service_name}': {e}")


### PR DESCRIPTION
* Formatting fixes in log lines

I missed something in #103 - though I tested that the services were created, I forgot about the namespace. The intended syntax is that some `service_endpoint` on component `foo` becomes available on the topic `/foo/service_endpoint`, so that the AICA state engine ComponentInterface can automatically associate the service endpoint with the target component. While add_input provides a "default topic" option for flexible renaming or remapping, I believe services should be more static in their registered namespace. Signals can be renamed to connect components together, but services are always endpoints associated with a component, and so should be in the namespace of that component.

This has been tested and works as intended.