### PR TITLE
Catch core and component exceptions

### DIFF
--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -144,9 +144,7 @@ inline void Component::add_output(
         break;
       }
     }
-  } catch (const modulo_core::exceptions::CoreException& ex) {
-    RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
-  } catch (const exceptions::ComponentException& ex) {
+  } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
   }
 }

--- a/source/modulo_components/include/modulo_components/Component.hpp
+++ b/source/modulo_components/include/modulo_components/Component.hpp
@@ -7,6 +7,7 @@
 #include "modulo_components/ComponentInterface.hpp"
 #include "modulo_components/utilities/utilities.hpp"
 #include "modulo_core/EncodedState.hpp"
+#include "modulo_core/exceptions/CoreException.hpp"
 
 namespace modulo_components {
 
@@ -143,8 +144,9 @@ inline void Component::add_output(
         break;
       }
     }
-  } catch (const std::exception& ex) {
-    // TODO if modulo::communication had a base exception, could catch that
+  } catch (const modulo_core::exceptions::CoreException& ex) {
+    RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
+  } catch (const exceptions::ComponentException& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
   }
 }

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -845,7 +845,8 @@ inline void ComponentInterface<NodeT>::add_service(
             response->success = false;
             response->message = ex.what();
           }
-        });
+        }
+    );
     this->empty_services_.insert_or_assign(parsed_service_name, service);
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add service '" << service_name << "': " << ex.what());
@@ -872,7 +873,8 @@ inline void ComponentInterface<NodeT>::add_service(
             response->success = false;
             response->message = ex.what();
           }
-        });
+        }
+    );
     this->string_services_.insert_or_assign(parsed_service_name, service);
   } catch (const std::exception& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add service '" << service_name << "': " << ex.what());
@@ -1029,9 +1031,10 @@ inline std::string ComponentInterface<NodeT>::create_output(
       );
     }
     return parsed_signal_name;
-  } catch (const std::exception& ex) {
-    // TODO if modulo::communication had a base exception, could catch that
-    throw exceptions::AddSignalException(std::string(ex.what()));
+  } catch (const modulo_core::exceptions::CoreException& ex) {
+    throw exceptions::AddSignalException(ex.what());
+  } catch (const exceptions::ComponentException& ex) {
+    throw exceptions::AddSignalException(ex.what());
   }
 }
 

--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -1031,9 +1031,7 @@ inline std::string ComponentInterface<NodeT>::create_output(
       );
     }
     return parsed_signal_name;
-  } catch (const modulo_core::exceptions::CoreException& ex) {
-    throw exceptions::AddSignalException(ex.what());
-  } catch (const exceptions::ComponentException& ex) {
+  } catch (const std::exception& ex) {
     throw exceptions::AddSignalException(ex.what());
   }
 }

--- a/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
+++ b/source/modulo_components/include/modulo_components/LifecycleComponent.hpp
@@ -269,8 +269,7 @@ inline void LifecycleComponent::add_output(
   }
   try {
     this->create_output(signal_name, data, default_topic, fixed_topic);
-  } catch (const std::exception& ex) {
-    // TODO if modulo::communication had a base exception, could catch that
+  } catch (const exceptions::AddSignalException& ex) {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to add output '" << signal_name << "': " << ex.what());
   }
 }

--- a/source/modulo_components/modulo_components/component.py
+++ b/source/modulo_components/modulo_components/component.py
@@ -34,7 +34,6 @@ class Component(ComponentInterface):
         Step function that is called periodically.
         """
         try:
-            # TODO catch here or in helpers...? (or re raise with ComponentError)
             self._publish_predicates()
             self._publish_outputs()
             self._evaluate_periodic_callbacks()

--- a/source/modulo_components/modulo_components/lifecycle_component.py
+++ b/source/modulo_components/modulo_components/lifecycle_component.py
@@ -14,9 +14,6 @@ class LifecycleComponent(ComponentInterface):
     """
     Class to represent a LifecycleComponent in python, following the same logic pattern
     as the c++ modulo_component::LifecycleComponent class.
-    ...
-    Attributes:
-    # TODO
     """
 
     def __init__(self, node_name: str, *kargs, **kwargs):

--- a/source/modulo_components/src/LifecycleComponent.cpp
+++ b/source/modulo_components/src/LifecycleComponent.cpp
@@ -1,5 +1,7 @@
 #include "modulo_components/LifecycleComponent.hpp"
 
+#include "modulo_core/exceptions/CoreException.hpp"
+
 using namespace modulo_core::communication;
 
 namespace modulo_components {
@@ -284,8 +286,7 @@ bool LifecycleComponent::configure_outputs() {
           break;
         }
       }
-    } catch (const std::exception& ex) {
-      // TODO if modulo::communication had a base exception, could catch that
+    } catch (const modulo_core::exceptions::CoreException& ex) {
       success = false;
       RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to configure output '" << name << "': " << ex.what());
     }
@@ -305,8 +306,7 @@ bool LifecycleComponent::activate_outputs() {
   for (auto const& [name, interface]: this->outputs_) {
     try {
       interface->activate();
-    } catch (const std::exception& ex) {
-      // TODO if modulo::communication had a base exception, could catch that
+    } catch (const modulo_core::exceptions::CoreException& ex) {
       success = false;
       RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to activate output '" << name << "': " << ex.what());
     }
@@ -320,8 +320,7 @@ bool LifecycleComponent::deactivate_outputs() {
   for (auto const& [name, interface]: this->outputs_) {
     try {
       interface->deactivate();
-    } catch (const std::exception& ex) {
-      // TODO if modulo::communication had a base exception, could catch that
+    } catch (const modulo_core::exceptions::CoreException& ex) {
       success = false;
       RCLCPP_ERROR_STREAM(this->get_logger(), "Failed to deactivate output '" << name << "': " << ex.what());
     }

--- a/source/modulo_components/test/python/test_component_interface_empty_parameters.py
+++ b/source/modulo_components/test/python/test_component_interface_empty_parameters.py
@@ -105,7 +105,7 @@ def test_validate_empty_parameter(component_test):
     assert Node.get_parameter(component_test, "name").type_ == Parameter.Type.STRING
     assert Node.get_parameter(component_test, "name").value == "again"
 
-    # TODO
+    # TODO clarify that behavior somewhere
     # Setting a parameter with type NOT_SET undeclares that parameter
     Node.set_parameters(component_test, [Parameter("name", type_=Parameter.Type.NOT_SET)])
     with pytest.raises(ParameterNotDeclaredException):

--- a/source/modulo_core/CMakeLists.txt
+++ b/source/modulo_core/CMakeLists.txt
@@ -21,8 +21,8 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 6.0.7 REQUIRED COMPONENTS state_representation)
-find_package(clproto 6.0.0 REQUIRED)
+find_package(control_libraries 6.0.8 REQUIRED COMPONENTS state_representation)
+find_package(clproto 6.0.8 REQUIRED)
 
 include_directories(include)
 

--- a/source/modulo_core/CMakeLists.txt
+++ b/source/modulo_core/CMakeLists.txt
@@ -21,8 +21,8 @@ find_package(ament_cmake_python REQUIRED)
 
 ament_auto_find_build_dependencies()
 
-find_package(control_libraries 6.0.8 REQUIRED COMPONENTS state_representation)
-find_package(clproto 6.0.8 REQUIRED)
+find_package(control_libraries 6.1.0 REQUIRED COMPONENTS state_representation)
+find_package(clproto 6.1.0 REQUIRED)
 
 include_directories(include)
 

--- a/source/modulo_core/include/modulo_core/communication/PublisherHandler.hpp
+++ b/source/modulo_core/include/modulo_core/communication/PublisherHandler.hpp
@@ -64,7 +64,11 @@ void PublisherHandler<PubT, MsgT>::on_activate() {
     throw exceptions::NullPointerException("Publisher not set");
   }
   if (this->get_type() == PublisherType::LIFECYCLE_PUBLISHER) {
-    this->publisher_->on_activate();
+    try {
+      this->publisher_->on_activate();
+    } catch (const std::exception& ex) {
+      throw exceptions::CoreException(ex.what());
+    }
   } else {
     RCLCPP_DEBUG(rclcpp::get_logger("PublisherHandler"), "Only LifecyclePublishers can be deactivated");
   }
@@ -76,7 +80,11 @@ void PublisherHandler<PubT, MsgT>::on_deactivate() {
     throw exceptions::NullPointerException("Publisher not set");
   }
   if (this->get_type() == PublisherType::LIFECYCLE_PUBLISHER) {
-    this->publisher_->on_deactivate();
+    try {
+      this->publisher_->on_deactivate();
+    } catch (const std::exception& ex) {
+      throw exceptions::CoreException(ex.what());
+    }
   } else {
     RCLCPP_DEBUG(rclcpp::get_logger("PublisherHandler"), "Only LifecyclePublishers can be deactivated");
   }
@@ -87,15 +95,23 @@ void PublisherHandler<PubT, MsgT>::publish(const MsgT& message) const {
   if (this->publisher_ == nullptr) {
     throw exceptions::NullPointerException("Publisher not set");
   }
-  this->publisher_->publish(message);
+  try {
+    this->publisher_->publish(message);
+  } catch (const std::exception& ex) {
+    throw exceptions::CoreException(ex.what());
+  }
 }
 
 template<typename PubT, typename MsgT>
 std::shared_ptr<PublisherInterface> PublisherHandler<PubT, MsgT>::create_publisher_interface(
     const std::shared_ptr<MessagePairInterface>& message_pair
 ) {
-  std::shared_ptr<PublisherInterface> publisher_interface(this->shared_from_this());
-  publisher_interface->set_message_pair(message_pair);
-  return publisher_interface;
+  try {
+    std::shared_ptr<PublisherInterface> publisher_interface(this->shared_from_this());
+    publisher_interface->set_message_pair(message_pair);
+    return publisher_interface;
+  } catch (const std::exception& ex) {
+    throw exceptions::CoreException(ex.what());
+  }
 }
 }// namespace modulo_core::communication

--- a/source/modulo_core/include/modulo_core/communication/PublisherHandler.hpp
+++ b/source/modulo_core/include/modulo_core/communication/PublisherHandler.hpp
@@ -106,12 +106,13 @@ template<typename PubT, typename MsgT>
 std::shared_ptr<PublisherInterface> PublisherHandler<PubT, MsgT>::create_publisher_interface(
     const std::shared_ptr<MessagePairInterface>& message_pair
 ) {
+  std::shared_ptr<PublisherInterface> publisher_interface;
   try {
-    std::shared_ptr<PublisherInterface> publisher_interface(this->shared_from_this());
-    publisher_interface->set_message_pair(message_pair);
-    return publisher_interface;
+    publisher_interface = std::shared_ptr<PublisherInterface>(this->shared_from_this());
   } catch (const std::exception& ex) {
     throw exceptions::CoreException(ex.what());
   }
+  publisher_interface->set_message_pair(message_pair);
+  return publisher_interface;
 }
 }// namespace modulo_core::communication

--- a/source/modulo_core/include/modulo_core/exceptions/CoreException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/CoreException.hpp
@@ -16,6 +16,8 @@ namespace modulo_core::exceptions {
  */
 class CoreException : public std::runtime_error {
 public:
-  explicit CoreException(const std::string& msg) : std::runtime_error(msg) {};
+  explicit CoreException(const std::string& msg) : CoreException("CoreException", msg) {};
+protected:
+  CoreException(const std::string& prefix, const std::string& msg) : std::runtime_error(prefix + ": " + msg) {}
 };
 }// namespace modulo_core::exceptions

--- a/source/modulo_core/include/modulo_core/exceptions/InvalidPointerCastException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/InvalidPointerCastException.hpp
@@ -11,7 +11,7 @@ namespace modulo_core::exceptions {
  */
 class InvalidPointerCastException : public CoreException {
 public:
-  explicit InvalidPointerCastException(const std::string& msg) : CoreException(msg) {};
+  explicit InvalidPointerCastException(const std::string& msg) : CoreException("InvalidPointerCastException", msg) {}
 };
 }// namespace modulo_core::exceptions
 

--- a/source/modulo_core/include/modulo_core/exceptions/InvalidPointerException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/InvalidPointerException.hpp
@@ -11,7 +11,7 @@ namespace modulo_core::exceptions {
  */
 class InvalidPointerException : public CoreException {
 public:
-  explicit InvalidPointerException(const std::string& msg) : CoreException(msg) {};
+  explicit InvalidPointerException(const std::string& msg) : CoreException("InvalidPointerException", msg) {}
 };
 }// namespace modulo_core::exceptions
 

--- a/source/modulo_core/include/modulo_core/exceptions/MessageTranslationException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/MessageTranslationException.hpp
@@ -10,7 +10,7 @@ namespace modulo_core::exceptions {
  */
 class MessageTranslationException : public CoreException {
 public:
-  explicit MessageTranslationException(const std::string& msg) : CoreException(msg) {};
+  explicit MessageTranslationException(const std::string& msg) : CoreException("MessageTranslationException", msg) {}
 };
 }// namespace modulo_core::exceptions
 

--- a/source/modulo_core/include/modulo_core/exceptions/NullPointerException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/NullPointerException.hpp
@@ -11,7 +11,7 @@ namespace modulo_core::exceptions {
  */
 class NullPointerException : public CoreException {
 public:
-  explicit NullPointerException(const std::string& msg) : CoreException(msg) {};
+  explicit NullPointerException(const std::string& msg) : CoreException("NullPointerException", msg) {}
 };
 }// namespace modulo_core::exceptions
 

--- a/source/modulo_core/include/modulo_core/exceptions/ParameterTranslationException.hpp
+++ b/source/modulo_core/include/modulo_core/exceptions/ParameterTranslationException.hpp
@@ -12,7 +12,8 @@ namespace modulo_core::exceptions {
  */
 class ParameterTranslationException : public CoreException {
 public:
-  explicit ParameterTranslationException(const std::string& msg) : CoreException(msg) {};
+  explicit ParameterTranslationException(const std::string& msg) :
+      CoreException("ParameterTranslationException", msg) {}
 };
 }// namespace modulo_core::exceptions
 

--- a/source/modulo_core/include/modulo_core/translators/message_readers.hpp
+++ b/source/modulo_core/include/modulo_core/translators/message_readers.hpp
@@ -277,214 +277,218 @@ template<>
 inline void read_message(std::shared_ptr<state_representation::State>& state, const EncodedState& message) {
   using namespace state_representation;
   std::string tmp(message.data.begin(), message.data.end());
-  auto new_state = clproto::decode<std::shared_ptr<State>>(tmp);
-  switch (state->get_type()) {
-    case StateType::STATE: {
-      if (new_state->get_type() == StateType::STATE) {
-        *state = *new_state;
-      } else {
-        *state = State(StateType::STATE, new_state->get_name(), new_state->is_empty());
+  try {
+    auto new_state = clproto::decode<std::shared_ptr<State>>(tmp);
+    switch (state->get_type()) {
+      case StateType::STATE: {
+        if (new_state->get_type() == StateType::STATE) {
+          *state = *new_state;
+        } else {
+          *state = State(StateType::STATE, new_state->get_name(), new_state->is_empty());
+        }
+        break;
       }
-      break;
-    }
-    case StateType::SPATIAL_STATE: {
-      std::set<StateType> spatial_state_types = {
-          StateType::SPATIAL_STATE, StateType::CARTESIAN_STATE, StateType::CARTESIAN_POSE, StateType::CARTESIAN_TWIST,
-          StateType::CARTESIAN_ACCELERATION, StateType::CARTESIAN_WRENCH
-      };
-      if (spatial_state_types.find(new_state->get_type()) != spatial_state_types.cend()) {
-        safe_spatial_state_conversion<SpatialState, SpatialState>(state, new_state);
-      } else {
-        safe_dynamic_cast<SpatialState>(state, new_state);
+      case StateType::SPATIAL_STATE: {
+        std::set<StateType> spatial_state_types = {
+            StateType::SPATIAL_STATE, StateType::CARTESIAN_STATE, StateType::CARTESIAN_POSE, StateType::CARTESIAN_TWIST,
+            StateType::CARTESIAN_ACCELERATION, StateType::CARTESIAN_WRENCH
+        };
+        if (spatial_state_types.find(new_state->get_type()) != spatial_state_types.cend()) {
+          safe_spatial_state_conversion<SpatialState, SpatialState>(state, new_state);
+        } else {
+          safe_dynamic_cast<SpatialState>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::CARTESIAN_STATE: {
-      if (new_state->get_type() == StateType::CARTESIAN_POSE) {
-        safe_spatial_state_conversion<CartesianState, CartesianPose>(
-            state, new_state, [](CartesianState& a, const CartesianPose& b) {
-              a.set_pose(b.get_pose());
-            });
-      } else if (new_state->get_type() == StateType::CARTESIAN_TWIST) {
-        safe_spatial_state_conversion<CartesianState, CartesianTwist>(
-            state, new_state, [](CartesianState& a, const CartesianTwist& b) {
-              a.set_twist(b.get_twist());
-            });
-      } else if (new_state->get_type() == StateType::CARTESIAN_ACCELERATION) {
-        safe_spatial_state_conversion<CartesianState, CartesianAcceleration>(
-            state, new_state, [](CartesianState& a, const CartesianAcceleration& b) {
-              a.set_acceleration(b.get_acceleration());
-            });
-      } else if (new_state->get_type() == StateType::CARTESIAN_WRENCH) {
-        safe_spatial_state_conversion<CartesianState, CartesianWrench>(
-            state, new_state, [](CartesianState& a, const CartesianWrench& b) {
-              a.set_wrench(b.get_wrench());
-            });
-      } else {
-        safe_dynamic_cast<CartesianState>(state, new_state);
+      case StateType::CARTESIAN_STATE: {
+        if (new_state->get_type() == StateType::CARTESIAN_POSE) {
+          safe_spatial_state_conversion<CartesianState, CartesianPose>(
+              state, new_state, [](CartesianState& a, const CartesianPose& b) {
+                a.set_pose(b.get_pose());
+              });
+        } else if (new_state->get_type() == StateType::CARTESIAN_TWIST) {
+          safe_spatial_state_conversion<CartesianState, CartesianTwist>(
+              state, new_state, [](CartesianState& a, const CartesianTwist& b) {
+                a.set_twist(b.get_twist());
+              });
+        } else if (new_state->get_type() == StateType::CARTESIAN_ACCELERATION) {
+          safe_spatial_state_conversion<CartesianState, CartesianAcceleration>(
+              state, new_state, [](CartesianState& a, const CartesianAcceleration& b) {
+                a.set_acceleration(b.get_acceleration());
+              });
+        } else if (new_state->get_type() == StateType::CARTESIAN_WRENCH) {
+          safe_spatial_state_conversion<CartesianState, CartesianWrench>(
+              state, new_state, [](CartesianState& a, const CartesianWrench& b) {
+                a.set_wrench(b.get_wrench());
+              });
+        } else {
+          safe_dynamic_cast<CartesianState>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::CARTESIAN_POSE: {
-      if (new_state->get_type() == StateType::CARTESIAN_STATE) {
-        safe_spatial_state_conversion<CartesianPose, CartesianState>(
-            state, new_state, [](CartesianPose& a, const CartesianState& b) {
-              a.set_pose(b.get_pose());
-            });
-      } else {
-        safe_dynamic_cast<CartesianPose>(state, new_state);
+      case StateType::CARTESIAN_POSE: {
+        if (new_state->get_type() == StateType::CARTESIAN_STATE) {
+          safe_spatial_state_conversion<CartesianPose, CartesianState>(
+              state, new_state, [](CartesianPose& a, const CartesianState& b) {
+                a.set_pose(b.get_pose());
+              });
+        } else {
+          safe_dynamic_cast<CartesianPose>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::CARTESIAN_TWIST: {
-      if (new_state->get_type() == StateType::CARTESIAN_STATE) {
-        safe_spatial_state_conversion<CartesianTwist, CartesianState>(
-            state, new_state, [](CartesianTwist& a, const CartesianState& b) {
-              a.set_twist(b.get_twist());
-            });
-      } else {
-        safe_dynamic_cast<CartesianTwist>(state, new_state);
+      case StateType::CARTESIAN_TWIST: {
+        if (new_state->get_type() == StateType::CARTESIAN_STATE) {
+          safe_spatial_state_conversion<CartesianTwist, CartesianState>(
+              state, new_state, [](CartesianTwist& a, const CartesianState& b) {
+                a.set_twist(b.get_twist());
+              });
+        } else {
+          safe_dynamic_cast<CartesianTwist>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::CARTESIAN_ACCELERATION: {
-      if (new_state->get_type() == StateType::CARTESIAN_STATE) {
-        safe_spatial_state_conversion<CartesianAcceleration, CartesianState>(
-            state, new_state, [](CartesianAcceleration& a, const CartesianState& b) {
-              a.set_acceleration(b.get_acceleration());
-            });
-      } else {
-        safe_dynamic_cast<CartesianAcceleration>(state, new_state);
+      case StateType::CARTESIAN_ACCELERATION: {
+        if (new_state->get_type() == StateType::CARTESIAN_STATE) {
+          safe_spatial_state_conversion<CartesianAcceleration, CartesianState>(
+              state, new_state, [](CartesianAcceleration& a, const CartesianState& b) {
+                a.set_acceleration(b.get_acceleration());
+              });
+        } else {
+          safe_dynamic_cast<CartesianAcceleration>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::CARTESIAN_WRENCH: {
-      if (new_state->get_type() == StateType::CARTESIAN_STATE) {
-        safe_spatial_state_conversion<CartesianWrench, CartesianState>(
-            state, new_state, [](CartesianWrench& a, const CartesianState& b) {
-              a.set_wrench(b.get_wrench());
-            });
-      } else {
-        safe_dynamic_cast<CartesianWrench>(state, new_state);
+      case StateType::CARTESIAN_WRENCH: {
+        if (new_state->get_type() == StateType::CARTESIAN_STATE) {
+          safe_spatial_state_conversion<CartesianWrench, CartesianState>(
+              state, new_state, [](CartesianWrench& a, const CartesianState& b) {
+                a.set_wrench(b.get_wrench());
+              });
+        } else {
+          safe_dynamic_cast<CartesianWrench>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::JOINT_STATE: {
-      auto derived_state = safe_dynamic_pointer_cast<JointState>(state);
-      if (new_state->get_type() == StateType::JOINT_POSITIONS) {
-        safe_joint_state_conversion<JointState, JointPositions>(
-            state, new_state, [](JointState& a, const JointPositions& b) {
-              a.set_positions(b.get_positions());
-            });
-      } else if (new_state->get_type() == StateType::JOINT_VELOCITIES) {
-        safe_joint_state_conversion<JointState, JointVelocities>(
-            state, new_state, [](JointState& a, const JointVelocities& b) {
-              a.set_velocities(b.get_velocities());
-            });
-      } else if (new_state->get_type() == StateType::JOINT_ACCELERATIONS) {
-        safe_joint_state_conversion<JointState, JointAccelerations>(
-            state, new_state, [](JointState& a, const JointAccelerations& b) {
-              a.set_accelerations(b.get_accelerations());
-            });
-      } else if (new_state->get_type() == StateType::JOINT_TORQUES) {
-        safe_joint_state_conversion<JointState, JointTorques>(
-            state, new_state, [](JointState& a, const JointTorques& b) {
-              a.set_torques(b.get_torques());
-            });
-      } else {
-        safe_dynamic_cast<JointState>(state, new_state);
+      case StateType::JOINT_STATE: {
+        auto derived_state = safe_dynamic_pointer_cast<JointState>(state);
+        if (new_state->get_type() == StateType::JOINT_POSITIONS) {
+          safe_joint_state_conversion<JointState, JointPositions>(
+              state, new_state, [](JointState& a, const JointPositions& b) {
+                a.set_positions(b.get_positions());
+              });
+        } else if (new_state->get_type() == StateType::JOINT_VELOCITIES) {
+          safe_joint_state_conversion<JointState, JointVelocities>(
+              state, new_state, [](JointState& a, const JointVelocities& b) {
+                a.set_velocities(b.get_velocities());
+              });
+        } else if (new_state->get_type() == StateType::JOINT_ACCELERATIONS) {
+          safe_joint_state_conversion<JointState, JointAccelerations>(
+              state, new_state, [](JointState& a, const JointAccelerations& b) {
+                a.set_accelerations(b.get_accelerations());
+              });
+        } else if (new_state->get_type() == StateType::JOINT_TORQUES) {
+          safe_joint_state_conversion<JointState, JointTorques>(
+              state, new_state, [](JointState& a, const JointTorques& b) {
+                a.set_torques(b.get_torques());
+              });
+        } else {
+          safe_dynamic_cast<JointState>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::JOINT_POSITIONS: {
-      if (new_state->get_type() == StateType::JOINT_STATE) {
-        safe_joint_state_conversion<JointPositions, JointState>(
-            state, new_state, [](JointPositions& a, const JointState& b) {
-              a.set_positions(b.get_positions());
-            });
-      } else {
-        safe_dynamic_cast<JointPositions>(state, new_state);
+      case StateType::JOINT_POSITIONS: {
+        if (new_state->get_type() == StateType::JOINT_STATE) {
+          safe_joint_state_conversion<JointPositions, JointState>(
+              state, new_state, [](JointPositions& a, const JointState& b) {
+                a.set_positions(b.get_positions());
+              });
+        } else {
+          safe_dynamic_cast<JointPositions>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::JOINT_VELOCITIES: {
-      if (new_state->get_type() == StateType::JOINT_STATE) {
-        safe_joint_state_conversion<JointVelocities, JointState>(
-            state, new_state, [](JointVelocities& a, const JointState& b) {
-              a.set_velocities(b.get_velocities());
-            });
-      } else {
-        safe_dynamic_cast<JointVelocities>(state, new_state);
+      case StateType::JOINT_VELOCITIES: {
+        if (new_state->get_type() == StateType::JOINT_STATE) {
+          safe_joint_state_conversion<JointVelocities, JointState>(
+              state, new_state, [](JointVelocities& a, const JointState& b) {
+                a.set_velocities(b.get_velocities());
+              });
+        } else {
+          safe_dynamic_cast<JointVelocities>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::JOINT_ACCELERATIONS: {
-      if (new_state->get_type() == StateType::JOINT_STATE) {
-        safe_joint_state_conversion<JointAccelerations, JointState>(
-            state, new_state, [](JointAccelerations& a, const JointState& b) {
-              a.set_accelerations(b.get_accelerations());
-            });
-      } else {
-        safe_dynamic_cast<JointAccelerations>(state, new_state);
+      case StateType::JOINT_ACCELERATIONS: {
+        if (new_state->get_type() == StateType::JOINT_STATE) {
+          safe_joint_state_conversion<JointAccelerations, JointState>(
+              state, new_state, [](JointAccelerations& a, const JointState& b) {
+                a.set_accelerations(b.get_accelerations());
+              });
+        } else {
+          safe_dynamic_cast<JointAccelerations>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::JOINT_TORQUES: {
-      if (new_state->get_type() == StateType::JOINT_STATE) {
-        safe_joint_state_conversion<JointTorques, JointState>(
-            state, new_state, [](JointTorques& a, const JointState& b) {
-              a.set_torques(b.get_torques());
-            });
-      } else {
-        safe_dynamic_cast<JointTorques>(state, new_state);
+      case StateType::JOINT_TORQUES: {
+        if (new_state->get_type() == StateType::JOINT_STATE) {
+          safe_joint_state_conversion<JointTorques, JointState>(
+              state, new_state, [](JointTorques& a, const JointState& b) {
+                a.set_torques(b.get_torques());
+              });
+        } else {
+          safe_dynamic_cast<JointTorques>(state, new_state);
+        }
+        break;
       }
-      break;
-    }
-    case StateType::JACOBIAN:
-      safe_dynamic_cast<Jacobian>(state, new_state);
-      break;
-    case StateType::PARAMETER: {
-      auto param_ptr = std::dynamic_pointer_cast<ParameterInterface>(state);
-      switch (param_ptr->get_parameter_type()) {
-        case ParameterType::BOOL:
-          safe_dynamic_cast<Parameter<bool>>(state, new_state);
-          break;
-        case ParameterType::BOOL_ARRAY:
-          safe_dynamic_cast<Parameter<std::vector<bool>>>(state, new_state);
-          break;
-        case ParameterType::INT:
-          safe_dynamic_cast<Parameter<int>>(state, new_state);
-          break;
-        case ParameterType::INT_ARRAY:
-          safe_dynamic_cast<Parameter<std::vector<int>>>(state, new_state);
-          break;
-        case ParameterType::DOUBLE:
-          safe_dynamic_cast<Parameter<double>>(state, new_state);
-          break;
-        case ParameterType::DOUBLE_ARRAY:
-          safe_dynamic_cast<Parameter<std::vector<double>>>(state, new_state);
-          break;
-        case ParameterType::STRING:
-          safe_dynamic_cast<Parameter<std::string>>(state, new_state);
-          break;
-        case ParameterType::STRING_ARRAY:
-          safe_dynamic_cast<Parameter<std::vector<std::string>>>(state, new_state);
-          break;
-        case ParameterType::VECTOR:
-          safe_dynamic_cast<Parameter<Eigen::VectorXd>>(state, new_state);
-          break;
-        case ParameterType::MATRIX:
-          safe_dynamic_cast<Parameter<Eigen::MatrixXd>>(state, new_state);
-          break;
-        default:
-          throw exceptions::MessageTranslationException(
-              "The ParameterType contained by parameter " + param_ptr->get_name() + " is unsupported.");
+      case StateType::JACOBIAN:
+        safe_dynamic_cast<Jacobian>(state, new_state);
+        break;
+      case StateType::PARAMETER: {
+        auto param_ptr = std::dynamic_pointer_cast<ParameterInterface>(state);
+        switch (param_ptr->get_parameter_type()) {
+          case ParameterType::BOOL:
+            safe_dynamic_cast<Parameter<bool>>(state, new_state);
+            break;
+          case ParameterType::BOOL_ARRAY:
+            safe_dynamic_cast<Parameter<std::vector<bool>>>(state, new_state);
+            break;
+          case ParameterType::INT:
+            safe_dynamic_cast<Parameter<int>>(state, new_state);
+            break;
+          case ParameterType::INT_ARRAY:
+            safe_dynamic_cast<Parameter<std::vector<int>>>(state, new_state);
+            break;
+          case ParameterType::DOUBLE:
+            safe_dynamic_cast<Parameter<double>>(state, new_state);
+            break;
+          case ParameterType::DOUBLE_ARRAY:
+            safe_dynamic_cast<Parameter<std::vector<double>>>(state, new_state);
+            break;
+          case ParameterType::STRING:
+            safe_dynamic_cast<Parameter<std::string>>(state, new_state);
+            break;
+          case ParameterType::STRING_ARRAY:
+            safe_dynamic_cast<Parameter<std::vector<std::string>>>(state, new_state);
+            break;
+          case ParameterType::VECTOR:
+            safe_dynamic_cast<Parameter<Eigen::VectorXd>>(state, new_state);
+            break;
+          case ParameterType::MATRIX:
+            safe_dynamic_cast<Parameter<Eigen::MatrixXd>>(state, new_state);
+            break;
+          default:
+            throw exceptions::MessageTranslationException(
+                "The ParameterType contained by parameter " + param_ptr->get_name() + " is unsupported.");
+        }
+        break;
       }
-      break;
+      default:
+        throw exceptions::MessageTranslationException(
+            "The StateType contained by state " + new_state->get_name() + " is unsupported.");
     }
-    default:
-      throw exceptions::MessageTranslationException(
-          "The StateType contained by state " + new_state->get_name() + " is unsupported.");
+  } catch (const std::exception& ex) {
+    throw exceptions::MessageTranslationException(ex.what());
   }
 }
 }// namespace modulo_core::translators

--- a/source/modulo_core/include/modulo_core/translators/message_readers.hpp
+++ b/source/modulo_core/include/modulo_core/translators/message_readers.hpp
@@ -277,8 +277,13 @@ template<>
 inline void read_message(std::shared_ptr<state_representation::State>& state, const EncodedState& message) {
   using namespace state_representation;
   std::string tmp(message.data.begin(), message.data.end());
+  std::shared_ptr<State> new_state;
   try {
-    auto new_state = clproto::decode<std::shared_ptr<State>>(tmp);
+    new_state = clproto::decode<std::shared_ptr<State>>(tmp);
+  } catch (const std::exception& ex) {
+    throw exceptions::MessageTranslationException(ex.what());
+  }
+  try {
     switch (state->get_type()) {
       case StateType::STATE: {
         if (new_state->get_type() == StateType::STATE) {
@@ -487,8 +492,8 @@ inline void read_message(std::shared_ptr<state_representation::State>& state, co
         throw exceptions::MessageTranslationException(
             "The StateType contained by state " + new_state->get_name() + " is unsupported.");
     }
-  } catch (const std::exception& ex) {
-    throw exceptions::MessageTranslationException(ex.what());
+  } catch (const exceptions::MessageTranslationException& ex) {
+    throw;
   }
 }
 }// namespace modulo_core::translators


### PR DESCRIPTION
There were some smaller TODOs left regarding exception handling that I tried to resolve here. With the publisher handler (hopefully) only throwing CoreExceptions, we can just catch those explicitely.