### PR TITLE
User-defined callback on inputs (C++)

### DIFF
--- a/source/modulo_components/include/modulo_components/ComponentInterface.hpp
+++ b/source/modulo_components/include/modulo_components/ComponentInterface.hpp
@@ -228,12 +228,25 @@ protected:
    * @param default_topic If set, the default value for the topic name to use
    * @param fixed_topic If true, the topic name of the input signal is fixed
    */
-  // TODO could be nice to add an optional callback here that would be executed from within the subscription callback
-  // in order to manipulate the data pointer upon reception of a message
   template<typename DataT>
   void add_input(
       const std::string& signal_name, const std::shared_ptr<DataT>& data, const std::string& default_topic = "",
       bool fixed_topic = false
+  );
+
+  /**
+   * @brief Add and configure an input signal of the component.
+   * @tparam DataT Type of the data pointer
+   * @param signal_name Name of the input signal
+   * @param data Data to receive on the input signal
+   * @param callback Callback function to trigger after receiving the input signal
+   * @param default_topic If set, the default value for the topic name to use
+   * @param fixed_topic If true, the topic name of the input signal is fixed
+   */
+  template<typename DataT>
+  void add_input(
+      const std::string& signal_name, const std::shared_ptr<DataT>& data, const std::function<void()>& callback,
+      const std::string& default_topic = "", bool fixed_topic = false
   );
 
   /**
@@ -766,6 +779,15 @@ inline void ComponentInterface<NodeT>::add_input(
     const std::string& signal_name, const std::shared_ptr<DataT>& data, const std::string& default_topic,
     bool fixed_topic
 ) {
+  this->add_input(signal_name, data, []{}, default_topic, fixed_topic);
+}
+
+template<class NodeT>
+template<typename DataT>
+inline void ComponentInterface<NodeT>::add_input(
+    const std::string& signal_name, const std::shared_ptr<DataT>& data, const std::function<void()>& user_callback,
+    const std::string& default_topic, bool fixed_topic
+) {
   using namespace modulo_core::communication;
   try {
     std::string parsed_signal_name = this->validate_input_signal_name(signal_name);
@@ -791,14 +813,14 @@ inline void ComponentInterface<NodeT>::add_input(
       case MessageType::BOOL: {
         auto subscription_handler = std::make_shared<SubscriptionHandler<std_msgs::msg::Bool>>(message_pair);
         auto subscription = NodeT::template create_subscription<std_msgs::msg::Bool>(
-            topic_name, this->qos_, subscription_handler->get_callback());
+            topic_name, this->qos_, subscription_handler->get_callback(user_callback));
         subscription_interface = subscription_handler->create_subscription_interface(subscription);
         break;
       }
       case MessageType::FLOAT64: {
         auto subscription_handler = std::make_shared<SubscriptionHandler<std_msgs::msg::Float64>>(message_pair);
         auto subscription = NodeT::template create_subscription<std_msgs::msg::Float64>(
-            topic_name, this->qos_, subscription_handler->get_callback());
+            topic_name, this->qos_, subscription_handler->get_callback(user_callback));
         subscription_interface = subscription_handler->create_subscription_interface(subscription);
         break;
       }
@@ -806,28 +828,28 @@ inline void ComponentInterface<NodeT>::add_input(
         auto subscription_handler =
             std::make_shared<SubscriptionHandler<std_msgs::msg::Float64MultiArray>>(message_pair);
         auto subscription = NodeT::template create_subscription<std_msgs::msg::Float64MultiArray>(
-            topic_name, this->qos_, subscription_handler->get_callback());
+            topic_name, this->qos_, subscription_handler->get_callback(user_callback));
         subscription_interface = subscription_handler->create_subscription_interface(subscription);
         break;
       }
       case MessageType::INT32: {
         auto subscription_handler = std::make_shared<SubscriptionHandler<std_msgs::msg::Int32>>(message_pair);
         auto subscription = NodeT::template create_subscription<std_msgs::msg::Int32>(
-            topic_name, this->qos_, subscription_handler->get_callback());
+            topic_name, this->qos_, subscription_handler->get_callback(user_callback));
         subscription_interface = subscription_handler->create_subscription_interface(subscription);
         break;
       }
       case MessageType::STRING: {
         auto subscription_handler = std::make_shared<SubscriptionHandler<std_msgs::msg::String>>(message_pair);
         auto subscription = NodeT::template create_subscription<std_msgs::msg::String>(
-            topic_name, this->qos_, subscription_handler->get_callback());
+            topic_name, this->qos_, subscription_handler->get_callback(user_callback));
         subscription_interface = subscription_handler->create_subscription_interface(subscription);
         break;
       }
       case MessageType::ENCODED_STATE: {
         auto subscription_handler = std::make_shared<SubscriptionHandler<modulo_core::EncodedState>>(message_pair);
         auto subscription = NodeT::template create_subscription<modulo_core::EncodedState>(
-            topic_name, this->qos_, subscription_handler->get_callback());
+            topic_name, this->qos_, subscription_handler->get_callback(user_callback));
         subscription_interface = subscription_handler->create_subscription_interface(subscription);
         break;
       }

--- a/source/modulo_components/test/cpp/include/test_modulo_components/communication_components.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/communication_components.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <state_representation/space/cartesian/CartesianState.hpp>
+
+#include "modulo_components/LifecycleComponent.hpp"
+
+using namespace state_representation;
+using namespace std::chrono_literals;
+
+namespace modulo_components {
+
+inline void add_configure_activate(
+    const std::shared_ptr<rclcpp::executors::SingleThreadedExecutor>& exec,
+    const std::shared_ptr<LifecycleComponent>& component
+) {
+  exec->add_node(component->get_node_base_interface());
+  component->configure();
+  component->activate();
+}
+
+template<class ComponentT>
+class MinimalOutput : public ComponentT {
+public:
+  MinimalOutput(
+      const rclcpp::NodeOptions& node_options, const std::string& topic, const CartesianState& cartesian_state
+  ) : ComponentT(node_options, "minimal_output"), output_(std::make_shared<CartesianState>(cartesian_state)) {
+    this->add_output("cartesian_state", this->output_, topic);
+  }
+
+private:
+  std::shared_ptr<CartesianState> output_;
+};
+
+template<class ComponentT>
+class MinimalInput : public ComponentT {
+public:
+  MinimalInput(const rclcpp::NodeOptions& node_options, const std::string& topic) :
+      ComponentT(node_options, "minimal_input"), input(std::make_shared<CartesianState>()) {
+    this->received_future = this->received_.get_future();
+    this->add_input("cartesian_state", this->input, [this]() { this->received_.set_value(); }, topic);
+  }
+
+  std::shared_ptr<CartesianState> input;
+  std::shared_future<void> received_future;
+
+private:
+  std::promise<void> received_;
+};
+}// namespace modulo_components

--- a/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
+++ b/source/modulo_components/test/cpp/include/test_modulo_components/component_public_interfaces.hpp
@@ -45,6 +45,7 @@ public:
   using ComponentInterface<NodeT>::raise_error;
   using ComponentInterface<NodeT>::get_qos;
   using ComponentInterface<NodeT>::set_qos;
+  using ComponentInterface<NodeT>::get_clock;
 
   bool validate_parameter(const std::shared_ptr<state_representation::ParameterInterface>&) override {
     validate_parameter_was_called = true;

--- a/source/modulo_components/test/cpp/test_component_communication.cpp
+++ b/source/modulo_components/test/cpp/test_component_communication.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include "modulo_components/Component.hpp"
+#include "test_modulo_components/communication_components.hpp"
+
+using namespace modulo_components;
+
+class ComponentCommunicationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    rclcpp::init(0, nullptr);
+    exec_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  }
+
+  void TearDown() override {
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
+};
+
+TEST_F(ComponentCommunicationTest, InputOutput) {
+  auto cartesian_state = state_representation::CartesianState::Random("test");
+  auto input_node = std::make_shared<MinimalInput<Component>>(
+      rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("period", 0.1)}), "/topic"
+  );
+  auto output_node = std::make_shared<MinimalOutput<Component>>(
+      rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("period", 0.1)}), "/topic", cartesian_state
+  );
+  this->exec_->add_node(input_node);
+  this->exec_->add_node(output_node);
+  this->exec_->template spin_until_future_complete(input_node->received_future, 500ms);
+  EXPECT_EQ(cartesian_state.get_name(), input_node->input->get_name());
+  EXPECT_TRUE(cartesian_state.data().isApprox(input_node->input->data()));
+  this->exec_.reset();
+}

--- a/source/modulo_components/test/cpp/test_lifecycle_component_communication.cpp
+++ b/source/modulo_components/test/cpp/test_lifecycle_component_communication.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include "modulo_components/LifecycleComponent.hpp"
+#include "test_modulo_components/communication_components.hpp"
+
+using namespace modulo_components;
+
+class LifecycleComponentCommunicationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    rclcpp::init(0, nullptr);
+    exec_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  }
+
+  void TearDown() override {
+    rclcpp::shutdown();
+  }
+
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
+};
+
+TEST_F(LifecycleComponentCommunicationTest, InputOutput) {
+  auto cartesian_state = state_representation::CartesianState::Random("test");
+  auto input_node = std::make_shared<MinimalInput<LifecycleComponent>>(
+      rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("period", 0.1)}), "/topic"
+  );
+  auto output_node = std::make_shared<MinimalOutput<LifecycleComponent>>(
+      rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("period", 0.1)}), "/topic", cartesian_state
+  );
+  add_configure_activate(this->exec_, input_node);
+  add_configure_activate(this->exec_, output_node);
+  this->exec_->template spin_until_future_complete(input_node->received_future, 500ms);
+  EXPECT_EQ(cartesian_state.get_name(), input_node->input->get_name());
+  EXPECT_TRUE(cartesian_state.data().isApprox(input_node->input->data()));
+  this->exec_.reset();
+}

--- a/source/modulo_core/include/modulo_core/communication/SubscriptionHandler.hpp
+++ b/source/modulo_core/include/modulo_core/communication/SubscriptionHandler.hpp
@@ -26,9 +26,16 @@ public:
 
   /**
    * @brief Setter of the ROS subscription.
+   * @param subscription The ROS subscription
    * @throws modulo_core::exceptions::NullPointerException if the provided subscription pointer is null
    */
   void set_subscription(const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription);
+
+  /**
+   * @brief Setter of a user callback function to be executed after the subscription callback
+   * @param user_callback The ser callback function
+   */
+  void set_user_callback(const std::function<void()>& user_callback);
 
   /**
    * @brief Get a callback function that will be associated with the ROS subscription to receive and translate messages.
@@ -36,7 +43,14 @@ public:
   std::function<void(const std::shared_ptr<MsgT>)> get_callback();
 
   /**
-   * @brief Create an SubscriptionInterface pointer through an instance of a SubscriptionHandler by providing a ROS
+   * @brief Get a callback function that will be associated with the ROS subscription to receive and translate messages.
+   * @details This variant also takes a user callback function to execute after the message is received and translated.
+   * @param user_callback Void callback function for additional logic after the message is received and translated.
+   */
+  std::function<void(const std::shared_ptr<MsgT>)> get_callback(const std::function<void()>& user_callback);
+
+  /**
+   * @brief Create a SubscriptionInterface pointer through an instance of a SubscriptionHandler by providing a ROS
    * subscription.
    * @details This throws a NullPointerException if the ROS subscription is null.
    * @see SubscriptionHandler::set_subscription
@@ -47,8 +61,14 @@ public:
   create_subscription_interface(const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription);
 
 private:
+  /**
+   * @brief Handle exceptions caught during callback evaluation.
+   */
+  void handle_callback_exceptions();
+
   std::shared_ptr<rclcpp::Subscription<MsgT>> subscription_; ///< The pointer referring to the ROS subscription
   std::shared_ptr<rclcpp::Clock> clock_; ///< ROS clock for throttling log
+  std::function<void()> user_callback_ = []{}; ///< User callback to be executed after the subscription callback
 };
 
 template<typename MsgT>
@@ -65,10 +85,37 @@ void SubscriptionHandler<MsgT>::set_subscription(const std::shared_ptr<rclcpp::S
 }
 
 template<typename MsgT>
+void SubscriptionHandler<MsgT>::set_user_callback(const std::function<void()>& user_callback) {
+  this->user_callback_ = user_callback;
+}
+
+template<typename MsgT>
+std::function<void(const std::shared_ptr<MsgT>)>
+SubscriptionHandler<MsgT>::get_callback(const std::function<void()>& user_callback) {
+  this->set_user_callback(user_callback);
+  return this->get_callback();
+}
+
+template<typename MsgT>
 std::shared_ptr<SubscriptionInterface> SubscriptionHandler<MsgT>::create_subscription_interface(
     const std::shared_ptr<rclcpp::Subscription<MsgT>>& subscription
 ) {
   this->set_subscription(subscription);
   return std::shared_ptr<SubscriptionInterface>(this->shared_from_this());
 }
+
+template<typename MsgT>
+void SubscriptionHandler<MsgT>::handle_callback_exceptions() {
+  try {
+    // re-throw the original exception
+    throw;
+  } catch (const exceptions::CoreException& ex) {
+    RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
+                                "Exception in subscription callback: " << ex.what());
+  } catch (const std::exception& ex) {
+    RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
+                                "Unhandled exception in subscription user callback: " << ex.what());
+  }
+}
+
 }// namespace modulo_core::communication

--- a/source/modulo_core/src/communication/SubscriptionHandler.cpp
+++ b/source/modulo_core/src/communication/SubscriptionHandler.cpp
@@ -35,9 +35,9 @@ SubscriptionHandler<std_msgs::msg::Bool>::get_callback() {
   return [this](const std::shared_ptr<std_msgs::msg::Bool> message) {
     try {
       this->get_message_pair()->template read<std_msgs::msg::Bool, bool>(*message);
-    } catch (const exceptions::CoreException& ex) {
-      RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
-                                  "Exception in subscription callback: " << ex.what());
+      this->user_callback_();
+    } catch (...) {
+      this->handle_callback_exceptions();
     }
   };
 }
@@ -48,9 +48,9 @@ SubscriptionHandler<std_msgs::msg::Float64>::get_callback() {
   return [this](const std::shared_ptr<std_msgs::msg::Float64> message) {
     try {
       this->get_message_pair()->template read<std_msgs::msg::Float64, double>(*message);
-    } catch (const exceptions::CoreException& ex) {
-      RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
-                                  "Exception in subscription callback: " << ex.what());
+      this->user_callback_();
+    } catch (...) {
+      this->handle_callback_exceptions();
     }
   };
 }
@@ -61,9 +61,9 @@ SubscriptionHandler<std_msgs::msg::Float64MultiArray>::get_callback() {
   return [this](const std::shared_ptr<std_msgs::msg::Float64MultiArray> message) {
     try {
       this->get_message_pair()->template read<std_msgs::msg::Float64MultiArray, std::vector<double>>(*message);
-    } catch (const exceptions::CoreException& ex) {
-      RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
-                                  "Exception in subscription callback: " << ex.what());
+      this->user_callback_();
+    } catch (...) {
+      this->handle_callback_exceptions();
     }
   };
 }
@@ -74,9 +74,9 @@ SubscriptionHandler<std_msgs::msg::Int32>::get_callback() {
   return [this](const std::shared_ptr<std_msgs::msg::Int32> message) {
     try {
       this->get_message_pair()->template read<std_msgs::msg::Int32, int>(*message);
-    } catch (const exceptions::CoreException& ex) {
-      RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
-                                  "Exception in subscription callback: " << ex.what());
+      this->user_callback_();
+    } catch (...) {
+      this->handle_callback_exceptions();
     }
   };
 }
@@ -87,9 +87,9 @@ SubscriptionHandler<std_msgs::msg::String>::get_callback() {
   return [this](const std::shared_ptr<std_msgs::msg::String> message) {
     try {
       this->get_message_pair()->template read<std_msgs::msg::String, std::string>(*message);
-    } catch (const exceptions::CoreException& ex) {
-      RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
-                                  "Exception in subscription callback: " << ex.what());
+      this->user_callback_();
+    } catch (...) {
+      this->handle_callback_exceptions();
     }
   };
 }
@@ -99,9 +99,9 @@ std::function<void(const std::shared_ptr<EncodedState>)> SubscriptionHandler<Enc
   return [this](const std::shared_ptr<EncodedState> message) {
     try {
       this->get_message_pair()->template read<EncodedState, state_representation::State>(*message);
-    } catch (const exceptions::CoreException& ex) {
-      RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger("SubscriptionHandler"), *this->clock_, 1000,
-                                  "Exception in subscription callback: " << ex.what());
+      this->user_callback_();
+    } catch (...) {
+      this->handle_callback_exceptions();
     }
   };
 }

--- a/source/modulo_core/test/cpp/include/test_modulo_core/communication_nodes.hpp
+++ b/source/modulo_core/test/cpp/include/test_modulo_core/communication_nodes.hpp
@@ -34,12 +34,9 @@ public:
       Node("minimal_subscriber") {
     this->received_future = this->received_.get_future();
     this->subscription_interface_ = std::make_shared<SubscriptionHandler<MsgT>>(message_pair);
-    auto subscription = this->create_subscription<MsgT>(
-        topic_name, 10, [this](const std::shared_ptr<MsgT> message) {
-          this->subscription_interface_->template get_handler<MsgT>()->get_callback()(message);
-          this->received_.set_value();
-        }
-    );
+    auto handler = this->subscription_interface_->template get_handler<MsgT>();
+    handler->set_user_callback([this] { this->received_.set_value(); });
+    auto subscription = this->create_subscription<MsgT>(topic_name, 10, handler->get_callback());
     this->subscription_interface_ =
         this->subscription_interface_->template get_handler<MsgT>()->create_subscription_interface(subscription);
   }


### PR DESCRIPTION
[Insert a user callback into SubscriptionHandler](https://github.com/epfl-lasa/modulo/commit/b64a7e0bee1a1ab320770dd4da38ed11a787299c)
* Add private class property and setter for user_callback_, a void function

* Invoke user callback within the subscription callback, after reading the message

* Move callback error handling to helper function to simplify implementation and reduce code duplication

* Allow setting user callback directly when getting the subscription callback with a function overload

* Update test to use user callback

* Adjust docstrings

[Implement user callback in component add_input](https://github.com/epfl-lasa/modulo/commit/c56fef8fc9deaabee1418ec7a52c046ffebe85b7)

* Resolve TODO by overloading add_input with a user_callback argument after the shared data pointer. This allows a void function to be executed after the message is read into the data (as opposed to the generic input callback which takes a raw message). The default add_input with a data pointer passes an empty user callback instead.

* Update tests

---

This was a quick little feature I wanted to implement. Basically it allows extra logic to be triggered on a subscription, but while retaining all the convenience of the standard automatic message reading when providing the data pointer. I chose to inject it into the SubscriptionHandler so that we can guarantee the callback is only triggered when the data has been read successfully. The tests pass but I haven't tested a real component with it.

TODO is the equivalent Python implementation. Maybe @domire8 would be interested to do that.